### PR TITLE
Add and Map file/folder icons, make them optional

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -10,5 +10,3 @@ derivatives will show both
 - wild-cards for the path are not supported and will cause the program to crash.
 - when sorting, dot files should come before non-dot files with the same sorting
 ie `.changelog` should come before `changelog` etc.
-- the extension handling needs looking at, files that end with (at least) are 
-getting matched for an extension even without the dot before them.

--- a/BUGS.md
+++ b/BUGS.md
@@ -10,3 +10,5 @@ derivatives will show both
 - wild-cards for the path are not supported and will cause the program to crash.
 - when sorting, dot files should come before non-dot files with the same sorting
 ie `.changelog` should come before `changelog` etc.
+- the extension handling needs looking at, files that end with (at least) are 
+getting matched for an extension even without the dot before them.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ for your terminal. You can find a great selection of Nerd Fonts
 My personal favourite is `MesoLG Nerd Font`, but there are many others to choose
 from. You will also need to set up your terminal to use that font.
 
+If you **DO NOT** want to install a Nerd Font, pass the `--no-icons` switch to 
+the program.
+
 ## Installation
 
 ### Latest Release
@@ -81,6 +84,7 @@ Curently, only a sub-set of the standard `ls` options are supported. These are:
 - `-l` / `--long` - Show long format listing
 - `-h` / `--human-readable` - Human readable file sizes
 - `-D` / `--sort-dirs` - Sort directories first
+- `-no-icons` - don't show file or folder icons
 
 Many of the remaining options are planned to be implemented in the future. 
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# LSPlus - an 'ls' clone written in Rust.
+# LSPlus - an 'ls' clone written in Rust
 
 [![Rust](https://github.com/seapagan/lsplus/actions/workflows/rust.yml/badge.svg)](https://github.com/seapagan/lsplus/actions/workflows/rust.yml)
 [![pages-build-deployment](https://github.com/seapagan/lsplus/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/seapagan/lsplus/actions/workflows/pages/pages-build-deployment)
 ![Crates.io License](https://img.shields.io/crates/l/lsplus)
 [![Crates.io Version](https://img.shields.io/crates/v/lsplus?link=https%3A%2F%2Fcrates.io%2Fcrates%2Flsplus)](https://crates.io/crates/lsplus)
 [![GitHub issues](https://img.shields.io/github/issues/seapagan/lsplus)](https://github.com/seapagan/lsplus/issues)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/73f67c2ab44548298e0660ca73308729)](https://app.codacy.com/gh/seapagan/lsplus/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 This is currently a very simple (though functional) clone of the Unix 'ls' 
 command written in Rust. It is a learning project for me to learn Rust so 
@@ -26,6 +27,7 @@ probably contains many inefficiencies and bad practices. I'll get better :grin:
 <!-- vim-markdown-toc -->
 
 ## Compatibility
+
 This project is currently only compatible with Unix-like systems (Linux,
 MacOs, etc.). Windows support is planned to be added very soon.
 
@@ -86,10 +88,15 @@ Curently, only a sub-set of the standard `ls` options are supported. These are:
 - `-D` / `--sort-dirs` - Sort directories first
 - `-no-icons` - don't show file or folder icons
 
-Many of the remaining options are planned to be implemented in the future. 
+You can combine the short options together, e.g. `-laph` will show a long format
+listing with hidden files, append a '/' to directories, and show human-readable
+file sizes.
 
-The long-format listing is colorized by default and cannot be disabled, but 
-there will be an option to disable colors in the future.
+Use the `--help` option to see the full list of options.
+
+The long-format listing is currently colorized by default and cannot be
+disabled. This will be made configurable in the future along with adding more
+of the original `ls` options.
 
 Icons are added to folders, files, and links. There is only a limited set of
 mappings implemented at the moment, but more will be added in the future. Add

--- a/README.md
+++ b/README.md
@@ -10,37 +10,56 @@ This is currently a very simple (though functional) clone of the Unix 'ls'
 command written in Rust. It is a learning project for me to learn Rust so 
 probably contains many inefficiencies and bad practices. I'll get better :grin:
 
-> [!IMPORTANT]
-> This project is currently only compatible with Unix-like systems (Linux, 
+![lsp output](./docs/src/images/screenshot.png)
+
+<!-- vim-markdown-toc GFM -->
+
+- [Compatibility](#compatibility)
+- [Nerd Fonts](#nerd-fonts)
+- [Installation](#installation)
+  - [Latest Release](#latest-release)
+  - [From Source](#from-source)
+- [Usage](#usage)
+  - [Aliases](#aliases)
+- [Future Plans](#future-plans)
+
+<!-- vim-markdown-toc -->
+
+## Compatibility
+This project is currently only compatible with Unix-like systems (Linux,
 MacOs, etc.). Windows support is planned to be added very soon.
 
-![lsp output](./docs/src/images/screenshot.png)
+## Nerd Fonts
+
+To display the folder and file icons, you need to first install a 'Nerd Font' 
+for your terminal. You can find a great selection of Nerd Fonts
+[here](https://www.nerdfonts.com/)
+
+My personal favourite is `MesoLG Nerd Font`, but there are many others to choose
+from. You will also need to set up your terminal to use that font.
 
 ## Installation
 
-To install the latest release of this package, you can use the following command:
-
 ### Latest Release
+
+To install the latest release of this package, you can use the following command:
 
 ```bash
 cargo install lsplus
-``` 
+```
 
 This will install the `lsp` binary into your `~/.cargo/bin` directory. Make 
 sure that this directory is in your `PATH` environment variable so that you 
 can run the `lsp` command from anywhere.
 
-## From Source
+### From Source
 
-You can also install the package from source by cloning the repository and 
-running the following command:
+You can also install the package from the GitHub repository by running the 
+following command:
 
 ```bash
-git clone https://github.com/seapagan/lsplus.git
-cd lsplus
-cargo install --path .
+cargo install --git https://github.com/seapagan/lsplus.git
 ```
-
 
 ## Usage
 
@@ -68,8 +87,10 @@ Many of the remaining options are planned to be implemented in the future.
 The long-format listing is colorized by default and cannot be disabled, but 
 there will be an option to disable colors in the future.
 
-Icons are added to folders and links, this will be improved to show relevant
-icons for other file types in the future.
+Icons are added to folders, files, and links. There is only a limited set of
+mappings implemented at the moment, but more will be added in the future. Add
+an issue if you have a specific icon you would like to see - even better, add
+a Pull Request implementing it! :grin: 
 
 ### Aliases
 
@@ -92,3 +113,7 @@ alias ls='lsp -laph'
 This will show a long format listing with hidden files, append a '/' to
 directories, and show human readable file sizes, as in the image above.
 
+## Future Plans
+
+I am planning to add many more features to this project in the future. Check out
+the [TODO](./TODO.md) file for a list of planned features and improvements.

--- a/TODO.md
+++ b/TODO.md
@@ -2,8 +2,6 @@
 
 - [ ] in short mode when `-p` is specified, show a '*' or something if the file
 is a symlink.
-- [ ] add more icons for different file types. Implement a module that simply
-maps icons to file-types, and file file-types to extensions.
 - [ ] add colorization for different file types, folders and symlinks. Make it
 customizable and theme-able. Make it default but allow an option to disable it.
 (or vice-versa). Files that have a known extension should all be colored the same
@@ -17,3 +15,5 @@ whether it is a directory, file, or symlink.
 - [ ] add option for 'fuzzy' dates, e.g. 'yesterday', 'last week', 'last month',
 'last year', '2 years ago', etc.
 - [ ] colorize the short-form output same as the long-form output.
+- [ ] make file/folder icons optional and default to off.
+- [ ] note in README that a `Nerd Font` is required for the icons to display

--- a/TODO.md
+++ b/TODO.md
@@ -15,4 +15,6 @@ whether it is a directory, file, or symlink.
 - [ ] add option for 'fuzzy' dates, e.g. 'yesterday', 'last week', 'last month',
 'last year', '2 years ago', etc.
 - [ ] colorize the short-form output same as the long-form output.
-- [ ] make file/folder icons optional and default to off.
+- [ ] add icon to specific file NAMES (not just extensions) - e.g. `Cargo.toml`,
+`Makefile`, `Dockerfile`, `swapfile` etc. Also partials like `TODO.*`, 
+`LICENSE.*` and more.

--- a/TODO.md
+++ b/TODO.md
@@ -18,3 +18,4 @@ whether it is a directory, file, or symlink.
 - [ ] add icon to specific file NAMES (not just extensions) - e.g. `Cargo.toml`,
 `Makefile`, `Dockerfile`, `swapfile` etc. Also partials like `TODO.*`, 
 `LICENSE.*` and more.
+- [ ] option to color files in the `.gitignore` as grayed out

--- a/TODO.md
+++ b/TODO.md
@@ -18,4 +18,6 @@ whether it is a directory, file, or symlink.
 - [ ] add icon to specific file NAMES (not just extensions) - e.g. `Cargo.toml`,
 `Makefile`, `Dockerfile`, `swapfile` etc. Also partials like `TODO.*`, 
 `LICENSE.*` and more.
-- [ ] option to color files in the `.gitignore` as grayed out
+- [ ] option to  grey-out files in the `.gitignore`.
+- [ ] once the config file is implemented, allow extending the existing file and
+folder mapping, or deleting specific maps.

--- a/TODO.md
+++ b/TODO.md
@@ -16,4 +16,3 @@ whether it is a directory, file, or symlink.
 'last year', '2 years ago', etc.
 - [ ] colorize the short-form output same as the long-form output.
 - [ ] make file/folder icons optional and default to off.
-- [ ] note in README that a `Nerd Font` is required for the icons to display

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,6 +37,9 @@ pub struct Flags {
     #[arg(short = 'D', long = "sort-dirs", action = ArgAction::SetTrue, help = "Sort directories first")]
     pub dirs_first: bool,
 
+    #[arg(long="no-icons", action = ArgAction::SetTrue, help = "Do not display file or folder icons")]
+    pub no_icons: bool,
+
     #[arg(
         long = "version",
         short = 'V',

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ fn main() -> io::Result<()> {
             ];
 
             if !units.is_empty() {
-                row_cells.insert(5, Cell::new(units)); //.style_spec("l"));
+                row_cells.insert(5, Cell::new(units));
             }
             table.add_row(Row::new(row_cells));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ struct Params {
     almost_all: bool,
     long_format: bool,
     human_readable: bool,
+    no_icons: bool,
 }
 
 fn main() -> io::Result<()> {
@@ -33,6 +34,7 @@ fn main() -> io::Result<()> {
         almost_all: args.almost_all,
         long_format: args.long,
         human_readable: args.human_readable,
+        no_icons: args.no_icons,
     };
     let path = args.path;
 
@@ -94,20 +96,26 @@ fn main() -> io::Result<()> {
             let (display_size, units) =
                 utils::format::show_size(size, params.human_readable);
 
-            let mut row_cells = vec![
-                Cell::new(&format!("{}{} ", file_type, mode)),
-                Cell::new(&nlink.to_string()),
-                Cell::new(&format!(" {color_cyan}{}", user)),
-                Cell::new(&format!("{color_green}{} ", group)),
-                Cell::new(&display_size).style_spec("r"),
-                Cell::new(&format!(" {color_yellow}{} ", mtime)),
-                Cell::new(&format!("{}", item_icon)),
-                Cell::new(&format!(" {}", display_name)),
-            ];
+            let mut row_cells = Vec::with_capacity(9);
+
+            row_cells.push(Cell::new(&format!("{}{} ", file_type, mode)));
+            row_cells.push(Cell::new(&nlink.to_string()));
+            row_cells.push(Cell::new(&format!(" {color_cyan}{}", user)));
+            row_cells.push(Cell::new(&format!("{color_green}{} ", group)));
+            row_cells.push(Cell::new(&display_size).style_spec("r"));
 
             if !units.is_empty() {
-                row_cells.insert(5, Cell::new(units));
+                row_cells.push(Cell::new(units));
             }
+
+            row_cells.push(Cell::new(&format!(" {color_yellow}{} ", mtime)));
+
+            if !params.no_icons {
+                row_cells.push(Cell::new(&format!("{} ", item_icon)));
+            }
+
+            row_cells.push(Cell::new(&display_name.to_string()));
+
             table.add_row(Row::new(row_cells));
         }
         table.printstd();

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,10 @@ fn main() -> io::Result<()> {
                 PathBuf::from(file_name.clone())
             };
             let metadata = fs::symlink_metadata(&full_path)?;
-            let item_icon = utils::icons::get_item_icon(&metadata);
+            let item_icon = utils::icons::get_item_icon(
+                &metadata,
+                &full_path.to_string_lossy(),
+            );
             let (file_type, mode, nlink, size, mtime, user, group) =
                 utils::file::get_file_details(&metadata);
 
@@ -98,7 +101,7 @@ fn main() -> io::Result<()> {
                 Cell::new(&format!("{color_green}{} ", group)),
                 Cell::new(&display_size).style_spec("r"),
                 Cell::new(&format!(" {color_yellow}{} ", mtime)),
-                Cell::new(&item_icon),
+                Cell::new(&format!("{}", item_icon)),
                 Cell::new(&format!(" {}", display_name)),
             ];
 

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -49,15 +49,8 @@ pub enum Icon {
     XmlFile = '\u{e619}' as isize,
     ZipFile = '\u{f1c6}' as isize,
 }
-#[allow(non_upper_case_globals)] // needed to keep constant names consistent
-#[allow(dead_code)] // This is a temporary solution to avoid warnings
-impl Icon {
-    // these constants are used to make it easier to reference the icons
-    // by multiple names without Enum errors. We need this to use the same icon
-    // for a folder and a file, for example.
-    pub const GitFolder: Icon = Icon::GitFile;
-    pub const ConfigFolder: Icon = Icon::ConfigFile;
 
+impl Icon {
     fn as_char(self) -> char {
         char::from_u32(self as u32).unwrap()
     }
@@ -81,10 +74,10 @@ fn folder_icons() -> &'static HashMap<&'static str, Icon> {
 
     FOLDER_ICONS.get_or_init(|| {
         let mut m = HashMap::new();
-        m.insert(".config", Icon::ConfigFolder);
+        m.insert(".config", Icon::ConfigFile);
         m.insert(".github", Icon::GitHubFolder);
         m.insert(".ssh", Icon::SshFolder);
-        m.insert(".git", Icon::GitFolder);
+        m.insert(".git", Icon::GitFile);
         m.insert(".vscode", Icon::VsCodeFolder);
         m.insert("node_modules", Icon::NodeModulesFolder);
         m.insert("Trash", Icon::TrashFolder);

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -1,10 +1,9 @@
-use std::fs;
-
-use std::fmt;
+use std::collections::HashMap;
+use std::{fmt, fs};
 
 #[allow(dead_code)] // This is a temporary solution to avoid warnings
 #[derive(Debug, Clone, Copy)]
-enum UnicodeChar {
+pub enum UnicodeChar {
     // we define all the possible icons we can use. This will be a growing
     // list as we decode more file types.
     Folder = '\u{f07c}' as isize,
@@ -25,11 +24,12 @@ enum UnicodeChar {
     CssFile = '\u{e749}' as isize,
     HtmlFile = '\u{e736}' as isize,
     JavaScriptFile = '\u{e74e}' as isize,
-    JsonFile = '\u{e626}' as isize,
-    LogFile = '\u{f4ed}' as isize,
+    JsonFile = '\u{e60b}' as isize,
+    LogFile = '\u{f18d}' as isize,
+    LuaFile = '\u{e620}' as isize,
     MarkdownFile = '\u{e73e}' as isize,
     PictureFile = '\u{f03e}' as isize,
-    PythonFile = '\u{ed1b}' as isize,
+    PythonFile = '\u{e606}' as isize,
     ReactFile = '\u{e7ba}' as isize,
     RubyFile = '\u{e23e}' as isize,
     RustFile = '\u{e7a8}' as isize,
@@ -41,23 +41,70 @@ enum UnicodeChar {
 
 impl UnicodeChar {
     fn as_char(self) -> char {
-        // This is safe because we know all our values are valid Unicode code points
         char::from_u32(self as u32).unwrap()
+    }
+
+    fn as_string(self) -> String {
+        self.as_char().to_string()
     }
 }
 
 impl fmt::Display for UnicodeChar {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_char())
+        write!(f, "{}", self.as_string())
     }
 }
 
-pub fn get_item_icon(metadata: &fs::Metadata) -> String {
+// Define a function that maps file names to icons
+fn get_file_icon(file_name: &str) -> UnicodeChar {
+    let mut map = HashMap::new();
+    map.insert("conf", UnicodeChar::ConfigFile);
+    map.insert("log", UnicodeChar::LogFile);
+
+    //formatted text files
+    map.insert("json", UnicodeChar::JsonFile);
+    map.insert("md", UnicodeChar::MarkdownFile);
+    map.insert("toml", UnicodeChar::TomlFile);
+    map.insert("xml", UnicodeChar::XmlFile);
+
+    // coding related files
+    map.insert("py", UnicodeChar::PythonFile);
+    map.insert("jsx", UnicodeChar::ReactFile);
+    map.insert("tsx", UnicodeChar::ReactFile);
+    map.insert("rb", UnicodeChar::RubyFile);
+    map.insert("rs", UnicodeChar::RustFile);
+    map.insert("ts", UnicodeChar::TypeScriptFile);
+    map.insert("lua", UnicodeChar::LuaFile);
+
+    // we-dev related files
+    map.insert("css", UnicodeChar::CssFile);
+    map.insert("html", UnicodeChar::HtmlFile);
+    map.insert("htm", UnicodeChar::HtmlFile);
+    map.insert("js", UnicodeChar::JavaScriptFile);
+
+    // picture files
+    map.insert("jpg", UnicodeChar::PictureFile);
+    map.insert("png", UnicodeChar::PictureFile);
+    map.insert("svg", UnicodeChar::PictureFile);
+
+    // shell-related files
+    map.insert("sh", UnicodeChar::TerminalFile);
+    map.insert("bash", UnicodeChar::TerminalFile);
+    map.insert("zsh", UnicodeChar::TerminalFile);
+    map.insert("fish", UnicodeChar::TerminalFile);
+    map.insert("profile", UnicodeChar::TerminalFile);
+
+    let extension = file_name.split('.').last().unwrap_or("");
+    // Return the icon or default to GenericFile if not found
+    *map.get(extension).unwrap_or(&UnicodeChar::GenericFile)
+}
+pub fn get_item_icon(metadata: &fs::Metadata, file_name: &str) -> UnicodeChar {
     if metadata.is_dir() {
-        UnicodeChar::Folder.to_string()
+        UnicodeChar::Folder
     } else if metadata.is_symlink() {
-        UnicodeChar::Symlink.to_string()
+        UnicodeChar::Symlink
     } else {
-        UnicodeChar::GenericFile.to_string()
+        // UnicodeChar::GenericFile
+        get_file_icon(file_name)
     }
 }

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -1,11 +1,34 @@
 use std::fs;
 
+use std::fmt;
+
+#[derive(Debug, Clone, Copy)]
+enum UnicodeChar {
+    Folder = '\u{f07c}' as isize,
+    Symlink = '\u{f1177}' as isize,
+
+    GenericFile = '\u{f15b}' as isize,
+}
+
+impl UnicodeChar {
+    fn as_char(self) -> char {
+        // This is safe because we know all our values are valid Unicode code points
+        char::from_u32(self as u32).unwrap()
+    }
+}
+
+impl fmt::Display for UnicodeChar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_char())
+    }
+}
+
 pub fn get_item_icon(metadata: &fs::Metadata) -> String {
     if metadata.is_dir() {
-        "\u{f07c}".to_string()
+        UnicodeChar::Folder.to_string()
     } else if metadata.is_symlink() {
-        "\u{f1177}".to_string()
+        UnicodeChar::Symlink.to_string()
     } else {
-        "".to_string()
+        UnicodeChar::GenericFile.to_string()
     }
 }

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -2,12 +2,41 @@ use std::fs;
 
 use std::fmt;
 
+#[allow(dead_code)] // This is a temporary solution to avoid warnings
 #[derive(Debug, Clone, Copy)]
 enum UnicodeChar {
+    // we define all the possible icons we can use. This will be a growing
+    // list as we decode more file types.
     Folder = '\u{f07c}' as isize,
     Symlink = '\u{f1177}' as isize,
-
     GenericFile = '\u{f15b}' as isize,
+
+    // specific folder types
+    ConfigFolder = '\u{e5fc}' as isize,
+    GitFolder = '\u{f1d3}' as isize,
+    GitHubFolder = '\u{f408}' as isize,
+    HomeFolder = '\u{f015}' as isize,
+    NodeModulesFolder = '\u{ed0d}' as isize,
+    TrashFolder = '\u{ea81}' as isize,
+    VsCodeFolder = '\u{f0a1e}' as isize,
+
+    // specific file types
+    ConfigFile = '\u{f013}' as isize,
+    CssFile = '\u{e749}' as isize,
+    HtmlFile = '\u{e736}' as isize,
+    JavaScriptFile = '\u{e74e}' as isize,
+    JsonFile = '\u{e626}' as isize,
+    LogFile = '\u{f4ed}' as isize,
+    MarkdownFile = '\u{e73e}' as isize,
+    PictureFile = '\u{f03e}' as isize,
+    PythonFile = '\u{ed1b}' as isize,
+    ReactFile = '\u{e7ba}' as isize,
+    RubyFile = '\u{e23e}' as isize,
+    RustFile = '\u{e7a8}' as isize,
+    TerminalFile = '\u{ea85}' as isize,
+    TomlFile = '\u{e6b2}' as isize,
+    TypeScriptFile = '\u{e628}' as isize,
+    XmlFile = '\u{e619}' as isize,
 }
 
 impl UnicodeChar {

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -16,18 +16,18 @@ pub enum Icon {
     CacheFolder = '\u{f163f}' as isize,
     GitHubFolder = '\u{f408}' as isize,
     HomeFolder = '\u{f015}' as isize,
-    NodeModulesFolder = '\u{ed0d}' as isize,
+    NodeModulesFolder = '\u{f0399}' as isize,
     SecurityFolder = '\u{f084}' as isize,
     TrashFolder = '\u{ea81}' as isize,
     VsCodeFolder = '\u{f0a1e}' as isize,
 
     // specific file types
+    CompactDiscFile = '\u{e271}' as isize,
     ConfigFile = '\u{f013}' as isize,
     CssFile = '\u{e749}' as isize,
     DatabaseFile = '\u{e706}' as isize,
     DebianFile = '\u{f306}' as isize,
     DockerFile = '\u{f21f}' as isize,
-    // FontFile = '\u{f031}' as isize,
     FontFile = '\u{e659}' as isize,
     GitFile = '\u{f1d3}' as isize,
     HistoryFile = '\u{f1da}' as isize,
@@ -44,6 +44,7 @@ pub enum Icon {
     ReactFile = '\u{e7ba}' as isize,
     RubyFile = '\u{e23e}' as isize,
     RustFile = '\u{e7a8}' as isize,
+    SassFile = '\u{e603}' as isize,
     SwapFile = '\u{f0fb4}' as isize,
     TerminalFile = '\u{ea85}' as isize,
     TextFile = '\u{f15c}' as isize,
@@ -92,6 +93,7 @@ fn folder_icons() -> &'static HashMap<&'static str, Icon> {
         m.insert(".pyenv", Icon::PythonFile);
         m.insert(".rbenv", Icon::RubyFile);
         m.insert(".npm", Icon::NodeModulesFolder);
+        m.insert(".yarn", Icon::NodeModulesFolder);
         m.insert(".cargo", Icon::RustFile);
         m.insert(".rustup", Icon::RustFile);
         m.insert(".gnupg", Icon::SecurityFolder);
@@ -115,6 +117,9 @@ fn file_name_icons() -> &'static HashMap<&'static str, Icon> {
         m.insert("swapfile", Icon::SwapFile);
         m.insert("docker-compose.yml", Icon::DockerFile);
         m.insert("Dockerfile", Icon::DockerFile);
+        m.insert("LICENSE", Icon::TextFile);
+        m.insert("Rakefile", Icon::RubyFile);
+        m.insert("Gemfile", Icon::RubyFile);
 
         m
     })
@@ -134,23 +139,27 @@ fn file_type_icons() -> &'static HashMap<&'static str, Icon> {
                 &["conf", "cfg", "ini", "pylintrc", "yaml", "yml", "yarnrc"],
                 Icon::ConfigFile,
             ),
-            (&["gitignore", "gitconfig", "gitattributes"], Icon::GitFile),
+            (
+                &["gitignore", "gitconfig", "gitattributes", "gitmodules"],
+                Icon::GitFile,
+            ),
             (&["env"], Icon::WrenchFile),
             (&["json"], Icon::JsonFile),
             (&["md"], Icon::MarkdownFile),
             (&["toml"], Icon::TomlFile),
             (&["xml"], Icon::XmlFile),
             (&["db", "sqlite", "sql"], Icon::DatabaseFile),
-            (&["py"], Icon::PythonFile),
+            (&["py", "whl"], Icon::PythonFile),
             (&["jsx", "tsx"], Icon::ReactFile),
-            (&["rb", "gemrc"], Icon::RubyFile),
+            (&["rb", "gemrc", "rspec"], Icon::RubyFile),
             (&["rs"], Icon::RustFile),
             (&["ts"], Icon::TypeScriptFile),
             (&["lua"], Icon::LuaFile),
             (&["pl"], Icon::PerlFile),
             (&["css"], Icon::CssFile),
+            (&["scss", "sass"], Icon::SassFile),
             (&["html", "htm"], Icon::HtmlFile),
-            (&["js"], Icon::JavaScriptFile),
+            (&["js", "cjs"], Icon::JavaScriptFile),
             (&["jpg", "png", "svg"], Icon::PictureFile),
             (
                 &[
@@ -164,7 +173,17 @@ fn file_type_icons() -> &'static HashMap<&'static str, Icon> {
                 Icon::HistoryFile,
             ),
             (&["deb"], Icon::DebianFile),
-            (&["tar.gz", "tgz", "gz", "zip", "rar"], Icon::ZipFile),
+            (
+                &[
+                    "gz", "tgz", "zip", "rar", "xz", "tar", "7z", "bz2",
+                    "bz2", "z", "Z", "arj", "lzh", "cab",
+                ],
+                Icon::ZipFile,
+            ),
+            (
+                &["iso", "bin", "dmg", "img", "qcow", "vdi", "vmdk"],
+                Icon::CompactDiscFile,
+            ),
             (&["lock"], Icon::LockFile),
             (
                 &[

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 use std::sync::OnceLock;
 use std::{fmt, fs};
 
-#[allow(dead_code)] // This is a temporary solution to avoid warnings
 #[derive(Debug, Clone, Copy)]
 pub enum Icon {
     // we define all the possible icons we can use. This will be a growing
@@ -14,10 +13,10 @@ pub enum Icon {
     GenericFile = '\u{f15b}' as isize,
 
     // specific folder types
-    SshFolder = '\u{f084}' as isize,
     GitHubFolder = '\u{f408}' as isize,
     HomeFolder = '\u{f015}' as isize,
     NodeModulesFolder = '\u{ed0d}' as isize,
+    SecurityFolder = '\u{f084}' as isize,
     TrashFolder = '\u{ea81}' as isize,
     VsCodeFolder = '\u{f0a1e}' as isize,
 
@@ -26,6 +25,9 @@ pub enum Icon {
     CssFile = '\u{e749}' as isize,
     DatabaseFile = '\u{e706}' as isize,
     DebianFile = '\u{f306}' as isize,
+    DockerFile = '\u{f21f}' as isize,
+    // FontFile = '\u{f031}' as isize,
+    FontFile = '\u{e659}' as isize,
     GitFile = '\u{f1d3}' as isize,
     HistoryFile = '\u{f1da}' as isize,
     HtmlFile = '\u{e736}' as isize,
@@ -46,6 +48,7 @@ pub enum Icon {
     TextFile = '\u{f15c}' as isize,
     TomlFile = '\u{e6b2}' as isize,
     TypeScriptFile = '\u{e628}' as isize,
+    WrenchFile = '\u{f0ad}' as isize,
     XmlFile = '\u{e619}' as isize,
     ZipFile = '\u{f1c6}' as isize,
 }
@@ -76,91 +79,106 @@ fn folder_icons() -> &'static HashMap<&'static str, Icon> {
         let mut m = HashMap::new();
         m.insert(".config", Icon::ConfigFile);
         m.insert(".github", Icon::GitHubFolder);
-        m.insert(".ssh", Icon::SshFolder);
+        m.insert(".ssh", Icon::SecurityFolder);
         m.insert(".git", Icon::GitFile);
         m.insert(".vscode", Icon::VsCodeFolder);
         m.insert("node_modules", Icon::NodeModulesFolder);
         m.insert("Trash", Icon::TrashFolder);
         m.insert("home", Icon::HomeFolder);
+        m.insert("root", Icon::SecurityFolder);
+        m.insert("venv", Icon::PythonFile);
+        m.insert(".venv", Icon::PythonFile);
+        m.insert(".pyenv", Icon::PythonFile);
+        m.insert(".rbenv", Icon::RubyFile);
+        m.insert(".npm", Icon::NodeModulesFolder);
+        m.insert(".cargo", Icon::RustFile);
+        m.insert(".rustup", Icon::RustFile);
+        m.insert(".gnupg", Icon::SecurityFolder);
+        m.insert(".docker", Icon::DockerFile);
+        m.insert(".cpan", Icon::PerlFile);
+        m.insert(".cpanm", Icon::PerlFile);
 
         m
     })
 }
 
-// map file extensions to icons
-fn file_icons() -> &'static HashMap<&'static str, Icon> {
+// map file NAME extensions to icons
+fn file_name_icons() -> &'static HashMap<&'static str, Icon> {
+    // these are specifc exact file names that we want to map to icons.
+    static FILE_NAME_ICONS: OnceLock<HashMap<&'static str, Icon>> =
+        OnceLock::new();
+
+    FILE_NAME_ICONS.get_or_init(|| {
+        let mut m = HashMap::new();
+        m.insert("swapfile", Icon::SwapFile);
+        m.insert("docker-compose.yml", Icon::DockerFile);
+        m.insert("Dockerfile", Icon::DockerFile);
+
+        m
+    })
+}
+
+// map file EXTENSIONS to icons
+fn file_type_icons() -> &'static HashMap<&'static str, Icon> {
     static FILE_ICONS: OnceLock<HashMap<&'static str, Icon>> = OnceLock::new();
 
+    // this one is done a bit differently since there may be many extensions
+    // sharing the same icon
     FILE_ICONS.get_or_init(|| {
+        let icon_groups: Vec<(&[&str], Icon)> = vec![
+            (&["txt"], Icon::LogFile),
+            (&["log"], Icon::TextFile),
+            (
+                &["conf", "cfg", "ini", "yaml", "yml", "yarnrc"],
+                Icon::ConfigFile,
+            ),
+            (&["gitignore", "gitconfig", "gitattributes"], Icon::GitFile),
+            (&["env"], Icon::WrenchFile),
+            (&["json"], Icon::JsonFile),
+            (&["md"], Icon::MarkdownFile),
+            (&["toml"], Icon::TomlFile),
+            (&["xml"], Icon::XmlFile),
+            (&["db", "sqlite", "sql"], Icon::DatabaseFile),
+            (&["py"], Icon::PythonFile),
+            (&["jsx", "tsx"], Icon::ReactFile),
+            (&["rb", "gemrc"], Icon::RubyFile),
+            (&["rs"], Icon::RustFile),
+            (&["ts"], Icon::TypeScriptFile),
+            (&["lua"], Icon::LuaFile),
+            (&["pl"], Icon::PerlFile),
+            (&["css"], Icon::CssFile),
+            (&["html", "htm"], Icon::HtmlFile),
+            (&["js"], Icon::JavaScriptFile),
+            (&["jpg", "png", "svg"], Icon::PictureFile),
+            (
+                &[
+                    "sh", "bash", "bashrc", "zsh", "zshrc", "fish", "profile",
+                    "zprofile",
+                ],
+                Icon::TerminalFile,
+            ),
+            (
+                &["bash_history", "zsh_history", "psql_history"],
+                Icon::HistoryFile,
+            ),
+            (&["deb"], Icon::DebianFile),
+            (&["tar.gz", "tgz"], Icon::ZipFile),
+            (&["lock"], Icon::LockFile),
+            (
+                &[
+                    "ttf", "otf", "woff", "woff2", "eot", "pfb", "pfm", "fon",
+                    "dfont", "pfa", "pcf", "bdf", "snf",
+                ],
+                Icon::FontFile,
+            ),
+        ];
+
         let mut m = HashMap::new();
-        m.insert("log", Icon::LogFile);
-        m.insert("txt", Icon::TextFile);
-
-        // config files
-        m.insert("conf", Icon::ConfigFile);
-        m.insert("cfg", Icon::ConfigFile);
-        m.insert("ini", Icon::ConfigFile);
-        m.insert("gitignore", Icon::GitFile);
-        m.insert("gitconfig", Icon::GitFile);
-
-        // formatted text files
-        m.insert("json", Icon::JsonFile);
-        m.insert("md", Icon::MarkdownFile);
-        m.insert("toml", Icon::TomlFile);
-        m.insert("xml", Icon::XmlFile);
-        m.insert("yaml", Icon::ConfigFile);
-        m.insert("yml", Icon::ConfigFile);
-
-        // database files
-        m.insert("db", Icon::DatabaseFile);
-        m.insert("sqlite", Icon::DatabaseFile);
-        m.insert("sql", Icon::DatabaseFile);
-
-        // coding related files
-        m.insert("py", Icon::PythonFile);
-        m.insert("jsx", Icon::ReactFile);
-        m.insert("tsx", Icon::ReactFile);
-        m.insert("rb", Icon::RubyFile);
-        m.insert("gemrc", Icon::RubyFile);
-        m.insert("rs", Icon::RustFile);
-        m.insert("ts", Icon::TypeScriptFile);
-        m.insert("lua", Icon::LuaFile);
-        m.insert("pl", Icon::PerlFile);
-
-        // web-dev related files
-        m.insert("css", Icon::CssFile);
-        m.insert("html", Icon::HtmlFile);
-        m.insert("htm", Icon::HtmlFile);
-        m.insert("js", Icon::JavaScriptFile);
-
-        // picture files
-        m.insert("jpg", Icon::PictureFile);
-        m.insert("png", Icon::PictureFile);
-        m.insert("svg", Icon::PictureFile);
-
-        // shell-related files
-        m.insert("sh", Icon::TerminalFile);
-        m.insert("bash", Icon::TerminalFile);
-        m.insert("bashrc", Icon::TerminalFile);
-        m.insert("zsh", Icon::TerminalFile);
-        m.insert("zshrc", Icon::TerminalFile);
-        m.insert("fish", Icon::TerminalFile);
-        m.insert("profile", Icon::TerminalFile);
-        m.insert("zprofile", Icon::TerminalFile);
-
-        // history files
-        m.insert("bash_history", Icon::HistoryFile);
-        m.insert("zsh_history", Icon::HistoryFile);
-        m.insert("psql_history", Icon::HistoryFile);
-
-        // archive or simiar
-        m.insert("deb", Icon::DebianFile);
-        m.insert("tar.gz", Icon::ZipFile);
-        m.insert("tgz", Icon::ZipFile);
-
-        // lock files
-        m.insert("lock", Icon::LockFile);
-
+        for (extensions, icon) in icon_groups {
+            for &ext in extensions {
+                m.insert(ext, icon);
+            }
+        }
         m
     })
 }
@@ -169,22 +187,12 @@ fn known_extensions() -> &'static HashSet<&'static str> {
     // Return a set of all known extensions, from the keys of the file_icons
     // hashmap
     static KNOWN_EXTENSIONS: OnceLock<HashSet<&'static str>> = OnceLock::new();
-    KNOWN_EXTENSIONS.get_or_init(|| file_icons().keys().cloned().collect())
+    KNOWN_EXTENSIONS
+        .get_or_init(|| file_type_icons().keys().cloned().collect())
 }
 
 fn get_folder_icon(folder_name: &str) -> Icon {
-    // Use Path to get the folder name
-    let path = Path::new(folder_name);
-    let folder_name_trimmed = path
-        .file_name()
-        .unwrap_or(path.as_os_str())
-        .to_str()
-        .unwrap_or(folder_name);
-
-    // Return the icon for the folder based on its trimmed name
-    *folder_icons()
-        .get(folder_name_trimmed)
-        .unwrap_or(&Icon::Folder)
+    *folder_icons().get(folder_name).unwrap_or(&Icon::Folder)
 }
 
 fn get_file_icon(file_name: &str) -> Icon {
@@ -196,10 +204,23 @@ fn get_file_icon(file_name: &str) -> Icon {
         .max_by_key(|ext| ext.len())
         .unwrap_or(&"");
 
-    *file_icons().get(*extension).unwrap_or(&Icon::GenericFile)
+    *file_type_icons()
+        .get(*extension)
+        .unwrap_or(&Icon::GenericFile)
 }
 
-pub fn get_item_icon(metadata: &fs::Metadata, file_name: &str) -> Icon {
+fn get_filename_icon(file_name: &str) -> Option<Icon> {
+    // Return the icon for the filename based on its name if found
+    file_name_icons().get(file_name).cloned()
+}
+
+pub fn get_item_icon(metadata: &fs::Metadata, file_path: &str) -> Icon {
+    // Extract just the file name without the path
+    let file_name = Path::new(file_path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+
     // Return the icon for the item based on its metadata and name
     if metadata.is_dir() {
         // Icon::Folder
@@ -207,7 +228,7 @@ pub fn get_item_icon(metadata: &fs::Metadata, file_name: &str) -> Icon {
     } else if metadata.is_symlink() {
         Icon::Symlink
     } else {
-        // UnicodeChar::GenericFile
-        get_file_icon(file_name)
+        get_filename_icon(file_name)
+            .unwrap_or_else(|| get_file_icon(file_name))
     }
 }

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -70,7 +70,7 @@ impl fmt::Display for UnicodeChar {
     }
 }
 
-// map extensions to icons
+// map file extensions to icons
 fn file_icons() -> &'static HashMap<&'static str, UnicodeChar> {
     static FILE_ICONS: OnceLock<HashMap<&'static str, UnicodeChar>> =
         OnceLock::new();

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -13,6 +13,7 @@ pub enum Icon {
     GenericFile = '\u{f15b}' as isize,
 
     // specific folder types
+    CacheFolder = '\u{f163f}' as isize,
     GitHubFolder = '\u{f408}' as isize,
     HomeFolder = '\u{f015}' as isize,
     NodeModulesFolder = '\u{ed0d}' as isize,
@@ -97,6 +98,7 @@ fn folder_icons() -> &'static HashMap<&'static str, Icon> {
         m.insert(".docker", Icon::DockerFile);
         m.insert(".cpan", Icon::PerlFile);
         m.insert(".cpanm", Icon::PerlFile);
+        m.insert(".cache", Icon::CacheFolder);
 
         m
     })
@@ -129,7 +131,7 @@ fn file_type_icons() -> &'static HashMap<&'static str, Icon> {
             (&["txt"], Icon::LogFile),
             (&["log"], Icon::TextFile),
             (
-                &["conf", "cfg", "ini", "yaml", "yml", "yarnrc"],
+                &["conf", "cfg", "ini", "pylintrc", "yaml", "yml", "yarnrc"],
                 Icon::ConfigFile,
             ),
             (&["gitignore", "gitconfig", "gitattributes"], Icon::GitFile),
@@ -162,7 +164,7 @@ fn file_type_icons() -> &'static HashMap<&'static str, Icon> {
                 Icon::HistoryFile,
             ),
             (&["deb"], Icon::DebianFile),
-            (&["tar.gz", "tgz"], Icon::ZipFile),
+            (&["tar.gz", "tgz", "gz", "zip", "rar"], Icon::ZipFile),
             (&["lock"], Icon::LockFile),
             (
                 &[
@@ -198,9 +200,16 @@ fn get_folder_icon(folder_name: &str) -> Icon {
 fn get_file_icon(file_name: &str) -> Icon {
     // Find the longest known extension from the end of the filename and return
     // the icon for that extension
+
+    // Helper function to check if a file name ends with an extension
+    fn has_extension(file_name: &str, ext: &str) -> bool {
+        file_name.ends_with(ext)
+            && file_name[file_name.len() - ext.len() - 1..].starts_with('.')
+    }
+
     let extension = known_extensions()
         .iter()
-        .filter(|&ext| file_name.ends_with(ext))
+        .filter(|&&ext| has_extension(file_name, ext))
         .max_by_key(|ext| ext.len())
         .unwrap_or(&"");
 

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -12,7 +12,6 @@ pub enum UnicodeChar {
 
     // specific folder types
     ConfigFolder = '\u{e5fc}' as isize,
-    GitFolder = '\u{f1d3}' as isize,
     GitHubFolder = '\u{f408}' as isize,
     HomeFolder = '\u{f015}' as isize,
     NodeModulesFolder = '\u{ed0d}' as isize,
@@ -22,6 +21,9 @@ pub enum UnicodeChar {
     // specific file types
     ConfigFile = '\u{f013}' as isize,
     CssFile = '\u{e749}' as isize,
+    DatabaseFile = '\u{e706}' as isize,
+    GitFile = '\u{f1d3}' as isize,
+    HistoryFile = '\u{f1da}' as isize,
     HtmlFile = '\u{e736}' as isize,
     JavaScriptFile = '\u{e74e}' as isize,
     JsonFile = '\u{e60b}' as isize,
@@ -34,12 +36,19 @@ pub enum UnicodeChar {
     RubyFile = '\u{e23e}' as isize,
     RustFile = '\u{e7a8}' as isize,
     TerminalFile = '\u{ea85}' as isize,
+    TextFile = '\u{f15c}' as isize,
     TomlFile = '\u{e6b2}' as isize,
     TypeScriptFile = '\u{e628}' as isize,
     XmlFile = '\u{e619}' as isize,
 }
-
+#[allow(non_upper_case_globals)] // needed to keep constant names consistent
+#[allow(dead_code)] // This is a temporary solution to avoid warnings
 impl UnicodeChar {
+    // these constants are used to make it easier to reference the icons
+    // by multiple names without Enum errors. We need this to use the same icon
+    // for a folder and a file, for example.
+    pub const GitFolder: UnicodeChar = UnicodeChar::GitFile;
+
     fn as_char(self) -> char {
         char::from_u32(self as u32).unwrap()
     }
@@ -50,6 +59,7 @@ impl UnicodeChar {
 }
 
 impl fmt::Display for UnicodeChar {
+    // implement the Display trait so we can print the icons as strings easily
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.as_string())
     }
@@ -58,20 +68,35 @@ impl fmt::Display for UnicodeChar {
 // Define a function that maps file names to icons
 fn get_file_icon(file_name: &str) -> UnicodeChar {
     let mut map = HashMap::new();
-    map.insert("conf", UnicodeChar::ConfigFile);
     map.insert("log", UnicodeChar::LogFile);
+    map.insert("txt", UnicodeChar::TextFile);
+
+    // config files
+    map.insert("conf", UnicodeChar::ConfigFile);
+    map.insert("cfg", UnicodeChar::ConfigFile);
+    map.insert("ini", UnicodeChar::ConfigFile);
+    map.insert("gitignore", UnicodeChar::GitFile);
+    map.insert("gitconfig", UnicodeChar::GitFile);
 
     //formatted text files
     map.insert("json", UnicodeChar::JsonFile);
     map.insert("md", UnicodeChar::MarkdownFile);
     map.insert("toml", UnicodeChar::TomlFile);
     map.insert("xml", UnicodeChar::XmlFile);
+    map.insert("yaml", UnicodeChar::ConfigFile);
+    map.insert("yml", UnicodeChar::ConfigFile);
+
+    // database files
+    map.insert("db", UnicodeChar::DatabaseFile);
+    map.insert("sqlite", UnicodeChar::DatabaseFile);
+    map.insert("sql", UnicodeChar::DatabaseFile);
 
     // coding related files
     map.insert("py", UnicodeChar::PythonFile);
     map.insert("jsx", UnicodeChar::ReactFile);
     map.insert("tsx", UnicodeChar::ReactFile);
     map.insert("rb", UnicodeChar::RubyFile);
+    map.insert("gemrc", UnicodeChar::RubyFile);
     map.insert("rs", UnicodeChar::RustFile);
     map.insert("ts", UnicodeChar::TypeScriptFile);
     map.insert("lua", UnicodeChar::LuaFile);
@@ -90,9 +115,16 @@ fn get_file_icon(file_name: &str) -> UnicodeChar {
     // shell-related files
     map.insert("sh", UnicodeChar::TerminalFile);
     map.insert("bash", UnicodeChar::TerminalFile);
+    map.insert("bashrc", UnicodeChar::TerminalFile);
     map.insert("zsh", UnicodeChar::TerminalFile);
+    map.insert("zshrc", UnicodeChar::TerminalFile);
     map.insert("fish", UnicodeChar::TerminalFile);
     map.insert("profile", UnicodeChar::TerminalFile);
+    map.insert("zprofile", UnicodeChar::TerminalFile);
+
+    // history files
+    map.insert("bash_history", UnicodeChar::HistoryFile);
+    map.insert("zsh_history", UnicodeChar::HistoryFile);
 
     let extension = file_name.split('.').last().unwrap_or("");
     // Return the icon or default to GenericFile if not found

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -5,7 +5,7 @@ use std::{fmt, fs};
 
 #[allow(dead_code)] // This is a temporary solution to avoid warnings
 #[derive(Debug, Clone, Copy)]
-pub enum UnicodeChar {
+pub enum Icon {
     // we define all the possible icons we can use. This will be a growing
     // list as we decode more file types.
     Folder = '\u{f07c}' as isize,
@@ -48,11 +48,11 @@ pub enum UnicodeChar {
 }
 #[allow(non_upper_case_globals)] // needed to keep constant names consistent
 #[allow(dead_code)] // This is a temporary solution to avoid warnings
-impl UnicodeChar {
+impl Icon {
     // these constants are used to make it easier to reference the icons
     // by multiple names without Enum errors. We need this to use the same icon
     // for a folder and a file, for example.
-    pub const GitFolder: UnicodeChar = UnicodeChar::GitFile;
+    pub const GitFolder: Icon = Icon::GitFile;
 
     fn as_char(self) -> char {
         char::from_u32(self as u32).unwrap()
@@ -63,7 +63,7 @@ impl UnicodeChar {
     }
 }
 
-impl fmt::Display for UnicodeChar {
+impl fmt::Display for Icon {
     // implement the Display trait so we can print the icons as strings easily
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.as_string())
@@ -71,78 +71,77 @@ impl fmt::Display for UnicodeChar {
 }
 
 // map file extensions to icons
-fn file_icons() -> &'static HashMap<&'static str, UnicodeChar> {
-    static FILE_ICONS: OnceLock<HashMap<&'static str, UnicodeChar>> =
-        OnceLock::new();
+fn file_icons() -> &'static HashMap<&'static str, Icon> {
+    static FILE_ICONS: OnceLock<HashMap<&'static str, Icon>> = OnceLock::new();
 
     FILE_ICONS.get_or_init(|| {
         let mut m = HashMap::new();
-        m.insert("log", UnicodeChar::LogFile);
-        m.insert("txt", UnicodeChar::TextFile);
+        m.insert("log", Icon::LogFile);
+        m.insert("txt", Icon::TextFile);
 
         // config files
-        m.insert("conf", UnicodeChar::ConfigFile);
-        m.insert("cfg", UnicodeChar::ConfigFile);
-        m.insert("ini", UnicodeChar::ConfigFile);
-        m.insert("gitignore", UnicodeChar::GitFile);
-        m.insert("gitconfig", UnicodeChar::GitFile);
+        m.insert("conf", Icon::ConfigFile);
+        m.insert("cfg", Icon::ConfigFile);
+        m.insert("ini", Icon::ConfigFile);
+        m.insert("gitignore", Icon::GitFile);
+        m.insert("gitconfig", Icon::GitFile);
 
         // formatted text files
-        m.insert("json", UnicodeChar::JsonFile);
-        m.insert("md", UnicodeChar::MarkdownFile);
-        m.insert("toml", UnicodeChar::TomlFile);
-        m.insert("xml", UnicodeChar::XmlFile);
-        m.insert("yaml", UnicodeChar::ConfigFile);
-        m.insert("yml", UnicodeChar::ConfigFile);
+        m.insert("json", Icon::JsonFile);
+        m.insert("md", Icon::MarkdownFile);
+        m.insert("toml", Icon::TomlFile);
+        m.insert("xml", Icon::XmlFile);
+        m.insert("yaml", Icon::ConfigFile);
+        m.insert("yml", Icon::ConfigFile);
 
         // database files
-        m.insert("db", UnicodeChar::DatabaseFile);
-        m.insert("sqlite", UnicodeChar::DatabaseFile);
-        m.insert("sql", UnicodeChar::DatabaseFile);
+        m.insert("db", Icon::DatabaseFile);
+        m.insert("sqlite", Icon::DatabaseFile);
+        m.insert("sql", Icon::DatabaseFile);
 
         // coding related files
-        m.insert("py", UnicodeChar::PythonFile);
-        m.insert("jsx", UnicodeChar::ReactFile);
-        m.insert("tsx", UnicodeChar::ReactFile);
-        m.insert("rb", UnicodeChar::RubyFile);
-        m.insert("gemrc", UnicodeChar::RubyFile);
-        m.insert("rs", UnicodeChar::RustFile);
-        m.insert("ts", UnicodeChar::TypeScriptFile);
-        m.insert("lua", UnicodeChar::LuaFile);
+        m.insert("py", Icon::PythonFile);
+        m.insert("jsx", Icon::ReactFile);
+        m.insert("tsx", Icon::ReactFile);
+        m.insert("rb", Icon::RubyFile);
+        m.insert("gemrc", Icon::RubyFile);
+        m.insert("rs", Icon::RustFile);
+        m.insert("ts", Icon::TypeScriptFile);
+        m.insert("lua", Icon::LuaFile);
 
         // web-dev related files
-        m.insert("css", UnicodeChar::CssFile);
-        m.insert("html", UnicodeChar::HtmlFile);
-        m.insert("htm", UnicodeChar::HtmlFile);
-        m.insert("js", UnicodeChar::JavaScriptFile);
+        m.insert("css", Icon::CssFile);
+        m.insert("html", Icon::HtmlFile);
+        m.insert("htm", Icon::HtmlFile);
+        m.insert("js", Icon::JavaScriptFile);
 
         // picture files
-        m.insert("jpg", UnicodeChar::PictureFile);
-        m.insert("png", UnicodeChar::PictureFile);
-        m.insert("svg", UnicodeChar::PictureFile);
+        m.insert("jpg", Icon::PictureFile);
+        m.insert("png", Icon::PictureFile);
+        m.insert("svg", Icon::PictureFile);
 
         // shell-related files
-        m.insert("sh", UnicodeChar::TerminalFile);
-        m.insert("bash", UnicodeChar::TerminalFile);
-        m.insert("bashrc", UnicodeChar::TerminalFile);
-        m.insert("zsh", UnicodeChar::TerminalFile);
-        m.insert("zshrc", UnicodeChar::TerminalFile);
-        m.insert("fish", UnicodeChar::TerminalFile);
-        m.insert("profile", UnicodeChar::TerminalFile);
-        m.insert("zprofile", UnicodeChar::TerminalFile);
+        m.insert("sh", Icon::TerminalFile);
+        m.insert("bash", Icon::TerminalFile);
+        m.insert("bashrc", Icon::TerminalFile);
+        m.insert("zsh", Icon::TerminalFile);
+        m.insert("zshrc", Icon::TerminalFile);
+        m.insert("fish", Icon::TerminalFile);
+        m.insert("profile", Icon::TerminalFile);
+        m.insert("zprofile", Icon::TerminalFile);
 
         // history files
-        m.insert("bash_history", UnicodeChar::HistoryFile);
-        m.insert("zsh_history", UnicodeChar::HistoryFile);
-        m.insert("psql_history", UnicodeChar::HistoryFile);
+        m.insert("bash_history", Icon::HistoryFile);
+        m.insert("zsh_history", Icon::HistoryFile);
+        m.insert("psql_history", Icon::HistoryFile);
 
         // archive or simiar
-        m.insert("deb", UnicodeChar::DebianFile);
-        m.insert("tar.gz", UnicodeChar::ZipFile);
-        m.insert("tgz", UnicodeChar::ZipFile);
+        m.insert("deb", Icon::DebianFile);
+        m.insert("tar.gz", Icon::ZipFile);
+        m.insert("tgz", Icon::ZipFile);
 
         // lock files
-        m.insert("lock", UnicodeChar::LockFile);
+        m.insert("lock", Icon::LockFile);
 
         m
     })
@@ -155,7 +154,7 @@ fn known_extensions() -> &'static HashSet<&'static str> {
     KNOWN_EXTENSIONS.get_or_init(|| file_icons().keys().cloned().collect())
 }
 
-fn get_file_icon(file_name: &str) -> UnicodeChar {
+fn get_file_icon(file_name: &str) -> Icon {
     // Find the longest known extension from the end of the filename and return
     // the icon for that extension
     let extension = known_extensions()
@@ -164,17 +163,15 @@ fn get_file_icon(file_name: &str) -> UnicodeChar {
         .max_by_key(|ext| ext.len())
         .unwrap_or(&"");
 
-    *file_icons()
-        .get(*extension)
-        .unwrap_or(&UnicodeChar::GenericFile)
+    *file_icons().get(*extension).unwrap_or(&Icon::GenericFile)
 }
 
-pub fn get_item_icon(metadata: &fs::Metadata, file_name: &str) -> UnicodeChar {
+pub fn get_item_icon(metadata: &fs::Metadata, file_name: &str) -> Icon {
     // Return the icon for the item based on its metadata and name
     if metadata.is_dir() {
-        UnicodeChar::Folder
+        Icon::Folder
     } else if metadata.is_symlink() {
-        UnicodeChar::Symlink
+        Icon::Symlink
     } else {
         // UnicodeChar::GenericFile
         get_file_icon(file_name)

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::OnceLock;
 use std::{fmt, fs};
 
 #[allow(dead_code)] // This is a temporary solution to avoid warnings
@@ -22,6 +24,7 @@ pub enum UnicodeChar {
     ConfigFile = '\u{f013}' as isize,
     CssFile = '\u{e749}' as isize,
     DatabaseFile = '\u{e706}' as isize,
+    DebianFile = '\u{f306}' as isize,
     GitFile = '\u{f1d3}' as isize,
     HistoryFile = '\u{f1da}' as isize,
     HtmlFile = '\u{e736}' as isize,
@@ -40,6 +43,7 @@ pub enum UnicodeChar {
     TomlFile = '\u{e6b2}' as isize,
     TypeScriptFile = '\u{e628}' as isize,
     XmlFile = '\u{e619}' as isize,
+    ZipFile = '\u{f1c6}' as isize,
 }
 #[allow(non_upper_case_globals)] // needed to keep constant names consistent
 #[allow(dead_code)] // This is a temporary solution to avoid warnings
@@ -65,71 +69,112 @@ impl fmt::Display for UnicodeChar {
     }
 }
 
-// Define a function that maps file names to icons
-fn get_file_icon(file_name: &str) -> UnicodeChar {
-    let mut map = HashMap::new();
-    map.insert("log", UnicodeChar::LogFile);
-    map.insert("txt", UnicodeChar::TextFile);
+// map extensions to icons
+fn file_icons() -> &'static HashMap<&'static str, UnicodeChar> {
+    static FILE_ICONS: OnceLock<HashMap<&'static str, UnicodeChar>> =
+        OnceLock::new();
 
-    // config files
-    map.insert("conf", UnicodeChar::ConfigFile);
-    map.insert("cfg", UnicodeChar::ConfigFile);
-    map.insert("ini", UnicodeChar::ConfigFile);
-    map.insert("gitignore", UnicodeChar::GitFile);
-    map.insert("gitconfig", UnicodeChar::GitFile);
+    FILE_ICONS.get_or_init(|| {
+        let mut m = HashMap::new();
+        m.insert("log", UnicodeChar::LogFile);
+        m.insert("txt", UnicodeChar::TextFile);
 
-    //formatted text files
-    map.insert("json", UnicodeChar::JsonFile);
-    map.insert("md", UnicodeChar::MarkdownFile);
-    map.insert("toml", UnicodeChar::TomlFile);
-    map.insert("xml", UnicodeChar::XmlFile);
-    map.insert("yaml", UnicodeChar::ConfigFile);
-    map.insert("yml", UnicodeChar::ConfigFile);
+        // config files
+        m.insert("conf", UnicodeChar::ConfigFile);
+        m.insert("cfg", UnicodeChar::ConfigFile);
+        m.insert("ini", UnicodeChar::ConfigFile);
+        m.insert("gitignore", UnicodeChar::GitFile);
+        m.insert("gitconfig", UnicodeChar::GitFile);
 
-    // database files
-    map.insert("db", UnicodeChar::DatabaseFile);
-    map.insert("sqlite", UnicodeChar::DatabaseFile);
-    map.insert("sql", UnicodeChar::DatabaseFile);
+        // formatted text files
+        m.insert("json", UnicodeChar::JsonFile);
+        m.insert("md", UnicodeChar::MarkdownFile);
+        m.insert("toml", UnicodeChar::TomlFile);
+        m.insert("xml", UnicodeChar::XmlFile);
+        m.insert("yaml", UnicodeChar::ConfigFile);
+        m.insert("yml", UnicodeChar::ConfigFile);
 
-    // coding related files
-    map.insert("py", UnicodeChar::PythonFile);
-    map.insert("jsx", UnicodeChar::ReactFile);
-    map.insert("tsx", UnicodeChar::ReactFile);
-    map.insert("rb", UnicodeChar::RubyFile);
-    map.insert("gemrc", UnicodeChar::RubyFile);
-    map.insert("rs", UnicodeChar::RustFile);
-    map.insert("ts", UnicodeChar::TypeScriptFile);
-    map.insert("lua", UnicodeChar::LuaFile);
+        // database files
+        m.insert("db", UnicodeChar::DatabaseFile);
+        m.insert("sqlite", UnicodeChar::DatabaseFile);
+        m.insert("sql", UnicodeChar::DatabaseFile);
 
-    // we-dev related files
-    map.insert("css", UnicodeChar::CssFile);
-    map.insert("html", UnicodeChar::HtmlFile);
-    map.insert("htm", UnicodeChar::HtmlFile);
-    map.insert("js", UnicodeChar::JavaScriptFile);
+        // coding related files
+        m.insert("py", UnicodeChar::PythonFile);
+        m.insert("jsx", UnicodeChar::ReactFile);
+        m.insert("tsx", UnicodeChar::ReactFile);
+        m.insert("rb", UnicodeChar::RubyFile);
+        m.insert("gemrc", UnicodeChar::RubyFile);
+        m.insert("rs", UnicodeChar::RustFile);
+        m.insert("ts", UnicodeChar::TypeScriptFile);
+        m.insert("lua", UnicodeChar::LuaFile);
 
-    // picture files
-    map.insert("jpg", UnicodeChar::PictureFile);
-    map.insert("png", UnicodeChar::PictureFile);
-    map.insert("svg", UnicodeChar::PictureFile);
+        // web-dev related files
+        m.insert("css", UnicodeChar::CssFile);
+        m.insert("html", UnicodeChar::HtmlFile);
+        m.insert("htm", UnicodeChar::HtmlFile);
+        m.insert("js", UnicodeChar::JavaScriptFile);
 
-    // shell-related files
-    map.insert("sh", UnicodeChar::TerminalFile);
-    map.insert("bash", UnicodeChar::TerminalFile);
-    map.insert("bashrc", UnicodeChar::TerminalFile);
-    map.insert("zsh", UnicodeChar::TerminalFile);
-    map.insert("zshrc", UnicodeChar::TerminalFile);
-    map.insert("fish", UnicodeChar::TerminalFile);
-    map.insert("profile", UnicodeChar::TerminalFile);
-    map.insert("zprofile", UnicodeChar::TerminalFile);
+        // picture files
+        m.insert("jpg", UnicodeChar::PictureFile);
+        m.insert("png", UnicodeChar::PictureFile);
+        m.insert("svg", UnicodeChar::PictureFile);
 
-    // history files
-    map.insert("bash_history", UnicodeChar::HistoryFile);
-    map.insert("zsh_history", UnicodeChar::HistoryFile);
+        // shell-related files
+        m.insert("sh", UnicodeChar::TerminalFile);
+        m.insert("bash", UnicodeChar::TerminalFile);
+        m.insert("bashrc", UnicodeChar::TerminalFile);
+        m.insert("zsh", UnicodeChar::TerminalFile);
+        m.insert("zshrc", UnicodeChar::TerminalFile);
+        m.insert("fish", UnicodeChar::TerminalFile);
+        m.insert("profile", UnicodeChar::TerminalFile);
+        m.insert("zprofile", UnicodeChar::TerminalFile);
 
-    let extension = file_name.split('.').last().unwrap_or("");
-    // Return the icon or default to GenericFile if not found
-    *map.get(extension).unwrap_or(&UnicodeChar::GenericFile)
+        // history files
+        m.insert("bash_history", UnicodeChar::HistoryFile);
+        m.insert("zsh_history", UnicodeChar::HistoryFile);
+        m.insert("psql_history", UnicodeChar::HistoryFile);
+
+        // archive or simiar
+        m.insert("deb", UnicodeChar::DebianFile);
+        m.insert("tar.gz", UnicodeChar::ZipFile);
+
+        m
+    })
 }
+
+fn get_file_icon(file_name: &str) -> UnicodeChar {
+    // Get the known extensions from the file_icons HashMap
+    let known_extensions: HashSet<&str> =
+        file_icons().keys().cloned().collect();
+
+    // Find the longest known extension from the end of the filename
+    let extension = known_extensions
+        .iter()
+        .filter(|&ext| file_name.ends_with(ext))
+        .max_by_key(|ext| ext.len())
+        .unwrap_or(&"");
+
+    *file_icons()
+        .get(*extension)
+        .unwrap_or(&UnicodeChar::GenericFile)
+}
+
+// fn get_file_icon(file_name: &str) -> UnicodeChar {
+//     let extension = file_name.split('.').last().unwrap_or("");
+//     *file_icons()
+//         .get(extension)
+//         .unwrap_or(&UnicodeChar::GenericFile)
+// }
+
+// fn get_file_icon(file_name: &str) -> UnicodeChar {
+//     let extension =
+//         file_name.split_once('.').map(|(_, ext)| ext).unwrap_or("");
+//     *file_icons()
+//         .get(extension)
+//         .unwrap_or(&UnicodeChar::GenericFile)
+// }
+
 pub fn get_item_icon(metadata: &fs::Metadata, file_name: &str) -> UnicodeChar {
     if metadata.is_dir() {
         UnicodeChar::Folder


### PR DESCRIPTION
- Refactor the Icon functionality and add a list of standard icons with their mappings to file extensions and folders
- Add a option `--no-icons` which will not display file/folder icons
- also add icons for specific filenames.

In future (once the config file is implemented) this should be made extendable.