### PR TITLE
Add a configuration file to enable setting defaults for the CLI options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,16 +67,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -163,10 +192,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "config"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be"
+dependencies = [
+ "async-trait",
+ "convert_case",
+ "json5",
+ "lazy_static",
+ "nom",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "toml",
+ "yaml-rust",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "csv"
@@ -187,6 +290,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -211,10 +324,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -232,6 +370,18 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
@@ -266,6 +416,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -307,6 +467,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +500,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,10 +517,12 @@ version = "0.3.1"
 dependencies = [
  "chrono",
  "clap",
+ "config",
  "glob",
  "inline_colorization",
  "nix",
  "prettytable",
+ "serde",
  "term_size",
 ]
 
@@ -352,6 +531,12 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "nix"
@@ -363,6 +548,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -379,6 +574,67 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ed8acf08e98e744e5384c8bc63ceb0364e68a6854187221c18df61c4797690e"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "pest"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "prettytable"
@@ -424,6 +680,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64",
+ "bitflags",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,22 +715,54 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -514,10 +824,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
@@ -530,6 +901,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -694,3 +1071,21 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,7 @@ dependencies = [
  "chrono",
  "clap",
  "config",
+ "dirs-next",
  "glob",
  "inline_colorization",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,5 @@ inline_colorization = "0.1.6"
 nix = {version = "0.29.0", features = ["user"]}
 prettytable = "0.10.0"
 term_size = "0.3.2"
+config = "0.14.0"
+serde = { version = "1.0.209", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ prettytable = "0.10.0"
 term_size = "0.3.2"
 config = "0.14.0"
 serde = { version = "1.0.209", features = ["derive"] }
+dirs-next = "2.0.0"

--- a/TODO.md
+++ b/TODO.md
@@ -5,15 +5,12 @@
 is a symlink.
 - [ ] add colorization for different file types, folders and symlinks. Make it
 customizable and theme-able. Make it default but allow an option to disable it.
-(or vice-versa). Files that have a known extension should all be colored the 
+(or vice-versa). Files that have a known extension should all be colored the
 same way, and different to unknown file tipes.
-- [ ] add configuration file to set options. Use TOML format by default,
-maybe adding YAML later. Store in the correct `.config` directory depending on
-the OS.
 - [ ] for a symlink, color the name as it is, but color the target depending on
 whether it is a directory, file, or symlink.
 - [ ] colorize the short-form output same as the long-form output.
 - [ ] Add icons for partials like `TODO.*`, `LICENSE.*` and more.
 - [ ] option to  grey-out files in the `.gitignore`.
-- [ ] once the config file is implemented, allow extending the existing file and
+- [ ] using the config file, allow extending the existing file and
 folder mapping, or deleting specific maps.

--- a/config.toml
+++ b/config.toml
@@ -1,8 +1,0 @@
-[lsplus]
-long_format = true
-show_all = true 
-append_slash = true
-dirs_first = true
-human_readable = true
-fuzzy_time = true
-no_icons = false

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,8 @@
+[lsplus]
+long_format = true
+show_all = true 
+append_slash = true
+dirs_first = true
+human_readable = true
+fuzzy_time = true
+no_icons = false

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,3 +1,4 @@
+# documentation written using 'mdbook'
 [book]
 authors = ["Grant Ramsay"]
 language = "en"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,4 +4,5 @@
 
 - [Installation](./installation.md)
 - [Usage](./usage.md)
+- [Configuration File](./config.md)
 - [Future Plans](./todo.md)

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -1,0 +1,93 @@
+# Configuration File
+
+It is possible to configure `lsplus` using a configuration file. The
+configuration file is a simple **`TOML`** file that is placed in the following
+location:
+
+- Linux: `~/.config/lsplus/config.toml`
+- MacOS: `~/.config/lsplus/config.toml`
+
+The configuration file is optional and if it is not found, `lsplus` will use the
+default settings.
+
+## Available Options
+
+The following options are available in the configuration file and correspond to
+the relevant command line options:
+
+### show_all
+
+- Permitted values: `true` or `false`
+- Default value: `false`
+
+This option corresponds to the `-a` or `--all` command line option and will
+display all files and directories if set to `true`, including hidden files.
+
+### almost_all
+
+- Permitted values: `true` or `false`
+- Default value: `false`
+
+This option corresponds to the `-A` or `--almost-all` command line option and
+will display all files and directories if set to `true`, except for `.` and
+`..`.
+
+### append_slash
+
+- Permitted values: `true` or `false`
+- Default value: `false`
+
+This option corresponds to the `-p` or `--slash-dirs` command line option and
+will append a slash to directories if set to `true`.
+
+### dirs_first
+
+- Permitted values: `true` or `false`
+- Default value: `false`
+
+This option corresponds to the `--sort-dirs` command line option and will
+
+### long_format
+
+- Permitted values: `true` or `false`
+- Default value: `false`
+
+This option corresponds to the `--long` command line option and will display the
+output in long format if set to `true`.
+
+### human_readable
+
+- Permitted values: `true` or `false`
+- Default value: `false`
+
+This option corresponds to the `-h` or `--human-readable` command line option
+and will display file sizes in human readable format if set to `true`.
+
+### no_icons
+
+- Permitted values: `true` or `false`
+- Default value: `false`
+
+This option corresponds to the `--no-icons` command line option and will not
+display icons if set to `true`.
+
+### fuzzy_time
+
+- Permitted values: `true` or `false`
+- Default value: `false`
+
+This option corresponds to the `-Z` or `--fuzzy-time` command line option and
+will display the time in a 'fuzzy' format if set to `true`.
+
+## Example Configuration File
+
+The following is an example configuration file that sets several options. Any
+options that are not set will use the default values:
+
+```toml
+show_all = true
+append_slash = true
+dirs_first = true
+human_readable = true
+fuzzy_time = true
+```

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -8,15 +8,18 @@ To install the latest release of this package, you can use the following command
 cargo install lsplus
 ```
 
-This will install the `lsp` binary into your `~/.cargo/bin` directory. Make 
-sure that this directory is in your `PATH` environment variable so that you 
+This will install the `lsp` binary into your `~/.cargo/bin` directory. Make
+sure that this directory is in your `PATH` environment variable so that you
 can run the `lsp` command from anywhere.
 
 ## From Source
 
-You can also install the package from source by cloning the repository and 
+You can also install the package from source by cloning the repository and
 running the following command:
 
 ```bash
 cargo install --git https://github.com/seapagan/lsplus.git
 ```
+
+This may allow you to access the latest features and bug fixes that have not
+yet been released.

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -1,11 +1,11 @@
 # An `ls` replacement written in `Rust`
 
-This is currently a very simple (though functional) clone of the Unix 'ls' 
-command written in Rust. It is a learning project for me to learn Rust so 
+
+This is currently a very simple (though functional) clone of the Unix 'ls'
+command written in Rust. It is a learning project for me to learn Rust so
 probably contains many inefficiencies and bad practices. I'll get better 😁
 
 ![lsp output](./images/screenshot.png)
-
 
 ## Compatibility
 
@@ -14,12 +14,12 @@ MacOs, etc.). Windows support is planned to be added very soon.
 
 ## Nerd Fonts
 
-To display the folder and file icons, you need to first install a 'Nerd Font' 
+To display the folder and file icons, you need to first install a 'Nerd Font'
 for your terminal. You can find a great selection of Nerd Fonts
 [here](https://www.nerdfonts.com/)
 
 My personal favourite is `MesoLG Nerd Font`, but there are many others to choose
 from. You will also need to set up your terminal to use that font.
 
-If you **DO NOT** want to install a Nerd Font, pass the `--no-icons` switch to 
+If you **DO NOT** want to install a Nerd Font, pass the `--no-icons` switch to
 the program.

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -43,7 +43,7 @@ show the time in a human-readable format, e.g. '2 hours ago', 'yesterday', etc.
 Icons are added to folders, files, and links. There is only a limited set of
 mappings implemented at the moment, but more will be added in the future. Add
 an issue if you have a specific icon you would like to see - even better, add
-a Pull Request implementing it! :grin: 
+a Pull Request implementing it! :grin:
 
 You can disable the icons by using the `-no-icons` option.
 
@@ -67,6 +67,8 @@ alias ll='lsp -laph'
 
 This will show a long format listing with hidden files, append a '/' to
 directories, and show human readable file sizes.
+
+You can also use the configuration file to set the default options you want.
 
 ![lsp output](./images/screenshot.png)
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,28 +17,28 @@ use clap::{Arg, ArgAction, Parser};
 )]
 pub struct Flags {
     #[arg(short ='a', long = "all", action = ArgAction::SetTrue, help = "Do not ignore entries starting with .")]
-    pub show_all: bool,
+    pub show_all: Option<bool>,
 
     #[arg(short ='A', long = "almost-all", action = ArgAction::SetTrue, help = "Do not list implied . and ..")]
-    pub almost_all: bool,
+    pub almost_all: Option<bool>,
 
     #[arg(short='l', long="long", action = ArgAction::SetTrue, help = "Display detailed information")]
-    pub long: bool,
+    pub long: Option<bool>,
 
     #[arg(short='h', long="human-readable", action = ArgAction::SetTrue, help = "with -l, print sizes like 1K 234M 2G etc.")]
-    pub human_readable: bool,
+    pub human_readable: Option<bool>,
 
     #[arg(default_value = ".", help = "The path to list")]
     pub paths: Vec<String>,
 
     #[arg(short = 'p', long = "slash-dirs", action = ArgAction::SetTrue, help = "Append a slash to directories")]
-    pub slash: bool,
+    pub slash: Option<bool>,
 
     #[arg(short = 'D', long = "sort-dirs", action = ArgAction::SetTrue, help = "Sort directories first")]
-    pub dirs_first: bool,
+    pub dirs_first: Option<bool>,
 
     #[arg(long="no-icons", action = ArgAction::SetTrue, help = "Do not display file or folder icons")]
-    pub no_icons: bool,
+    pub no_icons: Option<bool>,
 
     #[arg(
         long = "version",
@@ -55,7 +55,7 @@ pub struct Flags {
         action = ArgAction::SetTrue,
         help = "Use fuzzy time format"
     )]
-    pub fuzzy_time: bool,
+    pub fuzzy_time: Option<bool>,
 }
 
 pub fn version_info() -> String {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,30 +15,47 @@ use clap::{Arg, ArgAction, Parser};
             .help("Print help information")
     )
 )]
+#[derive(Debug)]
 pub struct Flags {
-    #[arg(short ='a', long = "all", action = ArgAction::SetTrue, help = "Do not ignore entries starting with .")]
-    pub show_all: Option<bool>,
+    #[arg(
+        short = 'a',
+        long = "all",
+        help = "Do not ignore entries starting with ."
+    )]
+    pub show_all: bool,
 
-    #[arg(short ='A', long = "almost-all", action = ArgAction::SetTrue, help = "Do not list implied . and ..")]
-    pub almost_all: Option<bool>,
+    #[arg(
+        short = 'A',
+        long = "almost-all",
+        help = "Do not list implied . and .."
+    )]
+    pub almost_all: bool,
 
-    #[arg(short='l', long="long", action = ArgAction::SetTrue, help = "Display detailed information")]
-    pub long: Option<bool>,
+    #[arg(short = 'l', long = "long", help = "Display detailed information")]
+    pub long: bool,
 
-    #[arg(short='h', long="human-readable", action = ArgAction::SetTrue, help = "with -l, print sizes like 1K 234M 2G etc.")]
-    pub human_readable: Option<bool>,
+    #[arg(
+        short = 'h',
+        long = "human-readable",
+        help = "with -l, print sizes like 1K 234M 2G etc."
+    )]
+    pub human_readable: bool,
 
     #[arg(default_value = ".", help = "The path to list")]
     pub paths: Vec<String>,
 
-    #[arg(short = 'p', long = "slash-dirs", action = ArgAction::SetTrue, help = "Append a slash to directories")]
-    pub slash: Option<bool>,
+    #[arg(
+        short = 'p',
+        long = "slash-dirs",
+        help = "Append a slash to directories"
+    )]
+    pub slash: bool,
 
-    #[arg(short = 'D', long = "sort-dirs", action = ArgAction::SetTrue, help = "Sort directories first")]
-    pub dirs_first: Option<bool>,
+    #[arg(short = 'D', long = "sort-dirs", help = "Sort directories first")]
+    pub dirs_first: bool,
 
-    #[arg(long="no-icons", action = ArgAction::SetTrue, help = "Do not display file or folder icons")]
-    pub no_icons: Option<bool>,
+    #[arg(long = "no-icons", help = "Do not display file or folder icons")]
+    pub no_icons: bool,
 
     #[arg(
         long = "version",
@@ -49,13 +66,8 @@ pub struct Flags {
     )]
     pub version: bool,
 
-    #[arg(
-        long = "fuzzy-time",
-        short = 'Z',
-        action = ArgAction::SetTrue,
-        help = "Use fuzzy time format"
-    )]
-    pub fuzzy_time: Option<bool>,
+    #[arg(long = "fuzzy-time", short = 'Z', help = "Use fuzzy time format")]
+    pub fuzzy_time: bool,
 }
 
 pub fn version_info() -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,20 +11,29 @@ mod cli;
 mod structs;
 mod utils;
 use config::{Config, File, FileFormat};
+use dirs_next::home_dir;
 
 use structs::{FileInfo, Params};
 use utils::file::{check_display_name, collect_file_info};
 
-fn load_config(file_path: &str) -> Params {
+fn load_config() -> Params {
+    let mut config_path = PathBuf::new();
+
+    // Get the home directory and construct the path
+    if let Some(home_dir) = home_dir() {
+        config_path.push(home_dir);
+        config_path.push(".config/lsplus/config.toml");
+    }
+
     let settings = Config::builder()
-        .add_source(File::new(file_path, FileFormat::Toml))
+        .add_source(File::new(config_path.to_str().unwrap(), FileFormat::Toml))
         .build();
 
     match settings {
         Ok(config) => config.into(), // Convert Config into Params using the From trait
         Err(e) => {
             // If the error is related to the file not being found, return default Params
-            if e.to_string().contains("No such file or directory") {
+            if e.to_string().contains("not found") {
                 Params::default()
             } else {
                 eprintln!("Error loading config: {}", e);
@@ -42,7 +51,7 @@ fn main() {
     }
 
     // Load config values
-    let config = load_config("config.toml");
+    let config = load_config();
 
     let params = Params {
         show_all: args.show_all || config.show_all,

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,14 +45,14 @@ fn main() {
     let config = load_config("config.toml");
 
     let params = Params {
-        show_all: args.show_all.unwrap_or(config.show_all),
-        append_slash: args.slash.unwrap_or(config.append_slash),
-        dirs_first: args.dirs_first.unwrap_or(config.dirs_first),
-        almost_all: args.almost_all.unwrap_or(config.almost_all),
-        long_format: args.long.unwrap_or(config.long_format),
-        human_readable: args.human_readable.unwrap_or(config.human_readable),
-        no_icons: args.no_icons.unwrap_or(config.no_icons),
-        fuzzy_time: args.fuzzy_time.unwrap_or(config.fuzzy_time),
+        show_all: args.show_all || config.show_all,
+        append_slash: args.slash || config.append_slash,
+        dirs_first: args.dirs_first || config.dirs_first,
+        almost_all: args.almost_all || config.almost_all,
+        long_format: args.long || config.long_format,
+        human_readable: args.human_readable || config.human_readable,
+        no_icons: args.no_icons || config.no_icons,
+        fuzzy_time: args.fuzzy_time || config.fuzzy_time,
     };
 
     let patterns = if args.paths.is_empty() {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -42,22 +42,6 @@ impl Default for Params {
     }
 }
 
-// impl From<Config> for Params {
-//     fn from(settings: Config) -> Self {
-//         Params {
-//             show_all: settings.get_bool("show_all").unwrap_or(false),
-//             append_slash: settings.get_bool("append_slash").unwrap_or(false),
-//             dirs_first: settings.get_bool("dirs_first").unwrap_or(false),
-//             almost_all: settings.get_bool("almost_all").unwrap_or(false),
-//             long_format: settings.get_bool("long_format").unwrap_or(false),
-//             human_readable: settings
-//                 .get_bool("human_readable")
-//                 .unwrap_or(false),
-//             no_icons: settings.get_bool("no_icons").unwrap_or(false),
-//             fuzzy_time: settings.get_bool("fuzzy_time").unwrap_or(false),
-//         }
-//     }
-// }
 impl From<Config> for Params {
     fn from(settings: Config) -> Self {
         let mut params = Params::default();

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,7 +1,21 @@
 use super::utils::icons::Icon;
+use config::Config;
+use serde::Deserialize;
+use std::convert::From;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
+macro_rules! config_to_params {
+    ($settings:expr, $params:ident, $( $field:ident ),* ) => {
+        $(
+            if let Ok(value) = $settings.get_bool(stringify!($field)) {
+                $params.$field = value;
+            }
+        )*
+    };
+}
+
+#[derive(Debug, Deserialize)]
 pub struct Params {
     pub show_all: bool,
     pub append_slash: bool,
@@ -12,6 +26,59 @@ pub struct Params {
     pub no_icons: bool,
     pub fuzzy_time: bool,
 }
+
+impl Default for Params {
+    fn default() -> Self {
+        Params {
+            show_all: false,
+            append_slash: false,
+            dirs_first: false,
+            almost_all: false,
+            long_format: false,
+            human_readable: false,
+            no_icons: false,
+            fuzzy_time: false,
+        }
+    }
+}
+
+// impl From<Config> for Params {
+//     fn from(settings: Config) -> Self {
+//         Params {
+//             show_all: settings.get_bool("show_all").unwrap_or(false),
+//             append_slash: settings.get_bool("append_slash").unwrap_or(false),
+//             dirs_first: settings.get_bool("dirs_first").unwrap_or(false),
+//             almost_all: settings.get_bool("almost_all").unwrap_or(false),
+//             long_format: settings.get_bool("long_format").unwrap_or(false),
+//             human_readable: settings
+//                 .get_bool("human_readable")
+//                 .unwrap_or(false),
+//             no_icons: settings.get_bool("no_icons").unwrap_or(false),
+//             fuzzy_time: settings.get_bool("fuzzy_time").unwrap_or(false),
+//         }
+//     }
+// }
+impl From<Config> for Params {
+    fn from(settings: Config) -> Self {
+        let mut params = Params::default();
+
+        config_to_params!(
+            settings,
+            params,
+            show_all,
+            append_slash,
+            dirs_first,
+            almost_all,
+            long_format,
+            human_readable,
+            no_icons,
+            fuzzy_time
+        );
+
+        params
+    }
+}
+
 #[derive(Debug)]
 pub struct FileInfo {
     pub file_type: String,


### PR DESCRIPTION
Allow using a TOML configuration file.

This should be stored in the `~/.config/lsplus/config.toml` file. If it does not exist, defaults are used.