### PR TITLE
properly list the contents of a symlink to folder

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 # TODO
 
-- [ ] add testing.
 - [ ] add colorization for different file types, folders and symlinks. Make it
       customizable and theme-able. Make it default but allow an option to
       disable it (or vice-versa). Files that have a known extension should all


### PR DESCRIPTION
when a symlink to a folder was passed to the CLI it would list the link like a file, instead of the contents of the link target.

fixes #48 