### PR TITLE
Perform some minor refactoring

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,8 @@
+[tasks.test]
+# this needs the crates 'nextest' and 'cargo-llvm-cov' installed locally
+command = "cargo"
+args = ["llvm-cov", "nextest"]
+
+[tasks.test-html]
+command = "cargo"
+args = ["llvm-cov", "nextest", "--html"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -117,7 +117,10 @@ mod tests {
     #[test]
     fn test_multiple_paths() {
         let args = Flags::parse_from(["lsplus", "path1", "path2"]);
-        assert_eq!(args.paths, vec![String::from("path1"), String::from("path2")]);
+        assert_eq!(
+            args.paths,
+            vec![String::from("path1"), String::from("path2")]
+        );
     }
 
     #[test]
@@ -173,15 +176,23 @@ mod tests {
         let info = version_info();
         assert!(info.contains("lsplus v"));
         assert!(info.contains("Released under the MIT license by"));
-        
+
         // Verify the format is correct even if env vars were empty
         let formatted = format!(
             "lsplus v{}\n\
             \n{}\n\
             \nReleased under the MIT license by {}\n",
             env!("CARGO_PKG_VERSION"),
-            if env!("CARGO_PKG_DESCRIPTION").is_empty() { "No description provided" } else { env!("CARGO_PKG_DESCRIPTION") },
-            if env!("CARGO_PKG_AUTHORS").is_empty() { "Unknown" } else { env!("CARGO_PKG_AUTHORS") }
+            if env!("CARGO_PKG_DESCRIPTION").is_empty() {
+                "No description provided"
+            } else {
+                env!("CARGO_PKG_DESCRIPTION")
+            },
+            if env!("CARGO_PKG_AUTHORS").is_empty() {
+                "Unknown"
+            } else {
+                env!("CARGO_PKG_AUTHORS")
+            }
         );
         assert_eq!(info, formatted);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,15 +226,15 @@ mod tests {
     #[test]
     fn test_run_multi() -> io::Result<()> {
         let temp_dir = tempdir()?;
-        
+
         // Create some test files
         File::create(temp_dir.path().join("test1.txt"))?;
         File::create(temp_dir.path().join("test2.txt"))?;
         std::fs::create_dir(temp_dir.path().join("testdir"))?;
-        
+
         let params = Params::default();
         let patterns = vec![temp_dir.path().to_string_lossy().to_string()];
-        
+
         assert!(run_multi(&patterns, &params).is_ok());
         Ok(())
     }
@@ -243,7 +243,7 @@ mod tests {
     fn test_run_multi_nonexistent() {
         let params = Params::default();
         let patterns = vec![String::from("/nonexistent/path")];
-        
+
         let result = run_multi(&patterns, &params);
         assert!(result.is_ok()); // The function handles errors internally
     }
@@ -251,16 +251,16 @@ mod tests {
     #[test]
     fn test_run_multi_with_glob() -> io::Result<()> {
         let temp_dir = tempdir()?;
-        
+
         // Create test files with different extensions
         File::create(temp_dir.path().join("test1.txt"))?;
         File::create(temp_dir.path().join("test2.txt"))?;
         File::create(temp_dir.path().join("test.rs"))?;
-        
+
         let params = Params::default();
         let pattern = format!("{}/*.txt", temp_dir.path().to_string_lossy());
         let patterns = vec![pattern];
-        
+
         assert!(run_multi(&patterns, &params).is_ok());
         Ok(())
     }
@@ -339,7 +339,10 @@ mod tests {
         }
 
         let settings = Config::builder()
-            .add_source(config::File::new(config_path.to_str().unwrap(), FileFormat::Toml))
+            .add_source(config::File::new(
+                config_path.to_str().unwrap(),
+                FileFormat::Toml,
+            ))
             .build();
 
         match settings {
@@ -358,7 +361,7 @@ mod tests {
     fn test_run_multi_glob_error() {
         let params = Params::default();
         let invalid_pattern = vec![String::from("[invalid-glob-pattern")];
-        
+
         // This should print an error message but not panic
         run_multi(&invalid_pattern, &params).unwrap();
     }
@@ -372,7 +375,10 @@ mod tests {
         std::fs::write(&config_path, "invalid = toml [ content").unwrap();
 
         let settings = Config::builder()
-            .add_source(config::File::new(config_path.to_str().unwrap(), FileFormat::Toml))
+            .add_source(config::File::new(
+                config_path.to_str().unwrap(),
+                FileFormat::Toml,
+            ))
             .build();
 
         match settings {
@@ -389,8 +395,9 @@ mod tests {
     fn test_main_error_handling() {
         // Test with a pattern that will cause an error
         let params = Params::default();
-        let invalid_pattern = vec![String::from("/nonexistent/path/that/should/not/exist")];
-        
+        let invalid_pattern =
+            vec![String::from("/nonexistent/path/that/should/not/exist")];
+
         let result = run_multi(&invalid_pattern, &params);
         assert!(result.is_ok()); // The function handles errors internally
     }
@@ -450,24 +457,32 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let test_file = temp_dir.path().join("no_read.txt");
         std::fs::write(&test_file, "test").unwrap();
-        std::fs::set_permissions(&test_file, std::fs::Permissions::from_mode(0o000)).unwrap();
+        std::fs::set_permissions(
+            &test_file,
+            std::fs::Permissions::from_mode(0o000),
+        )
+        .unwrap();
 
         let params = Params::default();
         let pattern = vec![test_file.to_string_lossy().to_string()];
-        
+
         // This should print an error message but not panic
         let result = run_multi(&pattern, &params);
         assert!(result.is_ok()); // The function handles errors internally
 
         // Clean up by restoring permissions so the file can be deleted
-        std::fs::set_permissions(&test_file, std::fs::Permissions::from_mode(0o644)).unwrap();
+        std::fs::set_permissions(
+            &test_file,
+            std::fs::Permissions::from_mode(0o644),
+        )
+        .unwrap();
     }
 
     #[test]
     fn test_run_multi_empty_pattern() {
         let params = Params::default();
         let pattern = vec![String::from("**/nonexistent_pattern_*.xyz")];
-        
+
         // This should handle empty glob results
         let result = run_multi(&pattern, &params);
         assert!(result.is_ok());

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -15,7 +15,7 @@ macro_rules! config_to_params {
     };
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Default)]
 pub struct Params {
     pub show_all: bool,
     pub append_slash: bool,
@@ -25,21 +25,6 @@ pub struct Params {
     pub human_readable: bool,
     pub no_icons: bool,
     pub fuzzy_time: bool,
-}
-
-impl Default for Params {
-    fn default() -> Self {
-        Params {
-            show_all: false,
-            append_slash: false,
-            dirs_first: false,
-            almost_all: false,
-            long_format: false,
-            human_readable: false,
-            no_icons: false,
-            fuzzy_time: false,
-        }
-    }
 }
 
 impl From<Config> for Params {

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -57,19 +57,19 @@ mod tests {
     fn test_format_size() {
         let (size, unit) = human_readable_format(0);
         assert_eq!(format!("{:.1} {}", size, unit), "0.0 B");
-        
+
         let (size, unit) = human_readable_format(1023);
         assert_eq!(format!("{:.1} {}", size, unit), "1023.0 B");
-        
+
         let (size, unit) = human_readable_format(1024);
         assert_eq!(format!("{:.1} {}", size, unit), "1.0 KB");
-        
+
         let (size, unit) = human_readable_format(1024 * 1024);
         assert_eq!(format!("{:.1} {}", size, unit), "1.0 MB");
-        
+
         let (size, unit) = human_readable_format(1024 * 1024 * 1024);
         assert_eq!(format!("{:.1} {}", size, unit), "1.0 GB");
-        
+
         let (size, unit) = human_readable_format(1024 * 1024 * 1024 * 1024);
         assert_eq!(format!("{:.1} {}", size, unit), "1.0 TB");
     }
@@ -78,10 +78,10 @@ mod tests {
     fn test_format_size_partial() {
         let (size, unit) = human_readable_format(1536);
         assert_eq!(format!("{:.1} {}", size, unit), "1.5 KB");
-        
+
         let (size, unit) = human_readable_format(1024 * 1024 * 3 / 2);
         assert_eq!(format!("{:.1} {}", size, unit), "1.5 MB");
-        
+
         let (size, unit) = human_readable_format(1024 * 1024 * 1024 * 5 / 2);
         assert_eq!(format!("{:.1} {}", size, unit), "2.5 GB");
 
@@ -105,21 +105,22 @@ mod tests {
         // Test extremely large sizes
         let (size, unit) = human_readable_format(1024 * 1024 * 1024 * 1024);
         assert_eq!(format!("{:.1} {}", size, unit), "1.0 TB");
-        
-        let (size, unit) = human_readable_format(1024 * 1024 * 1024 * 1024 * 1024);
+
+        let (size, unit) =
+            human_readable_format(1024 * 1024 * 1024 * 1024 * 1024);
         assert_eq!(format!("{:.1} {}", size, unit), "1.0 PB");
-        
+
         // Test exact boundary cases
         let (size, unit) = human_readable_format(1024);
         assert_eq!(format!("{:.1} {}", size, unit), "1.0 KB");
-        
+
         let (size, unit) = human_readable_format(1024 * 1024);
         assert_eq!(format!("{:.1} {}", size, unit), "1.0 MB");
-        
+
         // Test just under boundary cases
         let (size, unit) = human_readable_format(1023);
         assert_eq!(format!("{:.1} {}", size, unit), "1023.0 B");
-        
+
         let (size, unit) = human_readable_format(1024 * 1024 - 1);
         assert_eq!(format!("{:.1} {}", size, unit), "1024.0 KB");
     }
@@ -145,13 +146,13 @@ mod tests {
     fn test_mode_to_rwx_edge_cases() {
         // Test no permissions
         assert_eq!(mode_to_rwx(0o0000), "---------");
-        
+
         // Test all permissions
         assert_eq!(mode_to_rwx(0o0777), "rwxrwxrwx");
-        
+
         // Test write-only (unusual case)
         assert_eq!(mode_to_rwx(0o0222), "-w--w--w-");
-        
+
         // Test execute-only (unusual case)
         assert_eq!(mode_to_rwx(0o0111), "--x--x--x");
     }

--- a/src/utils/fuzzy_time.rs
+++ b/src/utils/fuzzy_time.rs
@@ -158,79 +158,99 @@ mod tests {
     #[test]
     fn test_fuzzy_time_boundary_cases() {
         let now = SystemTime::now();
-        
+
         // Test exactly 59 seconds
         let time = now.checked_sub(Duration::from_secs(59)).unwrap();
         assert_eq!(fuzzy_time(time), "59 seconds ago");
-        
+
         // Test exactly 60 seconds (should show as 1 minute)
         let time = now.checked_sub(Duration::from_secs(60)).unwrap();
         assert_eq!(fuzzy_time(time), "1 minute ago");
-        
+
         // Test 1 minute and 59 seconds (should show as 1 minute)
         let time = now.checked_sub(Duration::from_secs(119)).unwrap();
         assert_eq!(fuzzy_time(time), "1 minute ago");
-        
+
         // Test exactly 2 minutes
         let time = now.checked_sub(Duration::from_secs(120)).unwrap();
         assert_eq!(fuzzy_time(time), "2 minutes ago");
-        
+
         // Test exactly 23 hours
         let time = now.checked_sub(Duration::from_secs(23 * 60 * 60)).unwrap();
         assert_eq!(fuzzy_time(time), "23 hours ago");
-        
+
         // Test exactly 24 hours (should show as "yesterday")
         let time = now.checked_sub(Duration::from_secs(24 * 60 * 60)).unwrap();
         assert_eq!(fuzzy_time(time), "yesterday");
-        
+
         // Test 6 days
-        let time = now.checked_sub(Duration::from_secs(6 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(6 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "6 days ago");
-        
+
         // Test 7 days (should show as "last week")
-        let time = now.checked_sub(Duration::from_secs(7 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(7 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "last week");
     }
 
     #[test]
     fn test_fuzzy_time_month_boundaries() {
         let now = SystemTime::now();
-        
+
         // Test 29 days (should still show weeks)
-        let time = now.checked_sub(Duration::from_secs(29 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(29 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "4 weeks ago");
-        
+
         // Test 30 days (should show "last month")
-        let time = now.checked_sub(Duration::from_secs(30 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(30 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "last month");
-        
+
         // Test 45 days (should show "last month")
-        let time = now.checked_sub(Duration::from_secs(45 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(45 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "last month");
-        
+
         // Test 60 days (should show "2 months ago")
-        let time = now.checked_sub(Duration::from_secs(60 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(60 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "2 months ago");
     }
 
     #[test]
     fn test_fuzzy_time_year_boundaries() {
         let now = SystemTime::now();
-        
+
         // Test 364 days (should show months)
-        let time = now.checked_sub(Duration::from_secs(364 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(364 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "12 months ago");
-        
+
         // Test 365 days (should show "last year")
-        let time = now.checked_sub(Duration::from_secs(365 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(365 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "last year");
-        
+
         // Test 729 days (should still show "last year")
-        let time = now.checked_sub(Duration::from_secs(729 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(729 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "last year");
-        
+
         // Test 730 days (should show "2 years ago")
-        let time = now.checked_sub(Duration::from_secs(730 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(730 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "2 years ago");
     }
 
@@ -243,86 +263,112 @@ mod tests {
     #[test]
     fn test_fuzzy_time_week_boundaries() {
         let now = SystemTime::now();
-        
+
         // Test 13 days (should still show "last week")
-        let time = now.checked_sub(Duration::from_secs(13 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(13 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "last week");
-        
+
         // Test 14 days (should show "2 weeks ago")
-        let time = now.checked_sub(Duration::from_secs(14 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(14 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "2 weeks ago");
-        
+
         // Test 20 days (should show "2 weeks ago")
-        let time = now.checked_sub(Duration::from_secs(20 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(20 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "2 weeks ago");
-        
+
         // Test 21 days (should show "3 weeks ago")
-        let time = now.checked_sub(Duration::from_secs(21 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(21 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "3 weeks ago");
     }
 
     #[test]
     fn test_fuzzy_time_month_edge_cases() {
         let now = SystemTime::now();
-        
+
         // Test 59 days (should still show "last month")
-        let time = now.checked_sub(Duration::from_secs(59 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(59 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "last month");
-        
+
         // Test 61 days (should show "2 months ago")
-        let time = now.checked_sub(Duration::from_secs(61 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(61 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "2 months ago");
-        
+
         // Test 89 days (should show "2 months ago")
-        let time = now.checked_sub(Duration::from_secs(89 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(89 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "2 months ago");
-        
+
         // Test 90 days (should show "3 months ago")
-        let time = now.checked_sub(Duration::from_secs(90 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(90 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "3 months ago");
     }
 
     #[test]
     fn test_fuzzy_time_very_old_files() {
         let now = SystemTime::now();
-        
+
         // Test 2 years exactly
-        let time = now.checked_sub(Duration::from_secs(2 * 365 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(2 * 365 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "2 years ago");
-        
+
         // Test 5 years
-        let time = now.checked_sub(Duration::from_secs(5 * 365 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(5 * 365 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "5 years ago");
-        
+
         // Test 10 years
-        let time = now.checked_sub(Duration::from_secs(10 * 365 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(10 * 365 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "10 years ago");
-        
+
         // Test 20 years
-        let time = now.checked_sub(Duration::from_secs(20 * 365 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(20 * 365 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "20 years ago");
-        
+
         // Test 50 years (like old Unix timestamps)
-        let time = now.checked_sub(Duration::from_secs(50 * 365 * 24 * 60 * 60)).unwrap();
+        let time = now
+            .checked_sub(Duration::from_secs(50 * 365 * 24 * 60 * 60))
+            .unwrap();
         assert_eq!(fuzzy_time(time), "50 years ago");
     }
 
     #[test]
     fn test_fuzzy_time_hour_edge_cases() {
         let now = SystemTime::now();
-        
+
         // Test 59 minutes (should still show minutes)
         let time = now.checked_sub(Duration::from_secs(59 * 60)).unwrap();
         assert_eq!(fuzzy_time(time), "59 minutes ago");
-        
+
         // Test 61 minutes (should show "1 hour ago")
         let time = now.checked_sub(Duration::from_secs(61 * 60)).unwrap();
         assert_eq!(fuzzy_time(time), "1 hour ago");
-        
+
         // Test 119 minutes (should show "1 hour ago")
         let time = now.checked_sub(Duration::from_secs(119 * 60)).unwrap();
         assert_eq!(fuzzy_time(time), "1 hour ago");
-        
+
         // Test 120 minutes (should show "2 hours ago")
         let time = now.checked_sub(Duration::from_secs(120 * 60)).unwrap();
         assert_eq!(fuzzy_time(time), "2 hours ago");

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -312,7 +312,7 @@ mod tests {
     fn test_get_item_icon() {
         // Create a mock metadata for a file
         let metadata = fs::metadata("Cargo.toml").unwrap();
-        
+
         // Test unknown file type returns generic icon
         let icon = get_item_icon(&metadata, "test.unknown");
         assert_eq!(icon, Icon::GenericFile);
@@ -351,7 +351,7 @@ mod tests {
         assert_eq!(icons.get("LICENSE"), Some(&Icon::TextFile));
         assert_eq!(icons.get("Rakefile"), Some(&Icon::RubyFile));
         assert_eq!(icons.get("Gemfile"), Some(&Icon::RubyFile));
-        
+
         // Test unknown filename
         assert_eq!(icons.get("unknown.txt"), None);
     }
@@ -360,9 +360,12 @@ mod tests {
     fn test_folder_icons() {
         // Test known folder names
         assert_eq!(folder_icons().get(".git"), Some(&Icon::GitFile));
-        assert_eq!(folder_icons().get("node_modules"), Some(&Icon::NodeModulesFolder));
+        assert_eq!(
+            folder_icons().get("node_modules"),
+            Some(&Icon::NodeModulesFolder)
+        );
         assert_eq!(folder_icons().get(".vscode"), Some(&Icon::VsCodeFolder));
-        
+
         // Test unknown folder name
         assert_eq!(folder_icons().get("unknown_folder"), None);
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -47,15 +47,11 @@ fn test_config_file() {
 #[test]
 fn test_long_format() {
     let mut cmd = Command::cargo_bin("lsp").unwrap();
-    cmd.arg("-l")
-        .assert()
-        .success();
+    cmd.arg("-l").assert().success();
 }
 
 #[test]
 fn test_multiple_paths() {
     let mut cmd = Command::cargo_bin("lsp").unwrap();
-    cmd.args([".", "Cargo.toml"])
-        .assert()
-        .success();
+    cmd.args([".", "Cargo.toml"]).assert().success();
 }


### PR DESCRIPTION
- add default derive to Params instead of manual implementation
- add a makefile to use `cargo-llvm-cov` and `cargo-nextest` tasks.
- auto-format the test files for consistency