### PR TITLE
feat: add GNU `ls` compatibility mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ with time! 😁
 - [Usage](#usage)
   - [Fuzzy Time](#fuzzy-time)
   - [Icons](#icons)
+  - [Compatibility Mode](#compatibility-mode)
   - [Configuration File](#configuration-file)
   - [Aliases](#aliases)
 - [Development](#development)
@@ -139,6 +140,44 @@ a Pull Request implementing it! 😁
 
 You can disable the icons by using the `--no-icons` option.
 
+### Compatibility Mode
+
+`lsp` has two CLI modes:
+
+- `native` - the default `lsplus` command-line interface
+- `gnu` - a GNU `ls` compatibility mode intended for aliases and scripts
+
+You can enable GNU compatibility mode in either of these ways:
+
+```toml
+compat_mode = "gnu"
+```
+
+or:
+
+```sh
+LSP_COMPAT_MODE=gnu lsp
+```
+
+The `LSP_COMPAT_MODE` environment variable takes precedence over the config
+file.
+
+At the moment, compatibility mode only changes the CLI surface and help output.
+It does not yet implement the missing GNU meanings for the conflicting short
+flags `-D`, `-I`, `-N`, and `-Z`; those flags are reserved in `gnu` mode and
+will error until their GNU behavior is implemented.
+
+The current `lsplus` features behind those four native short flags are still
+available in `gnu` mode through their long forms only:
+
+- `--group-directories-first` (replaces the original `--sort-dirs`)
+- `--gitignore`
+- `--no-color`
+- `--fuzzy-time`
+
+In `gnu` mode, `-p` uses the GNU-style long form `--indicator-style=slash`
+instead of the native `--slash-dirs`.
+
 ### Configuration File
 
 You can set options using the configuration file so they will apply to every run
@@ -153,6 +192,10 @@ The `lsp` command can be aliased to `ls` by adding the following line to your
 ```sh
 alias ls='lsp'
 ```
+
+If you want that alias to behave more like GNU `ls`, enable `gnu`
+compatibility mode in your config file or set `LSP_COMPAT_MODE=gnu` in your
+shell environment.
 
 You will need to restart your shell or source your configuration file for the
 alias to take effect.

--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,12 @@
 - [ ] using the config file, allow extending the existing file and folder
       mapping, or deleting specific maps.
 - [ ] add a -R flag to recursively list files in a directory.
+- [ ] Rework short-mode file indicators so symlinks use `@` independently of
+      `-p`, and implement the remaining GNU-style indicator modes together,
+      including their preferred GNU short forms where they exist
+      (`--indicator-style=file-type` / `--file-type`,
+      `--indicator-style=classify` / `-F`, and
+      `--indicator-style=none`).
 - [ ] When adding recursion or tree-style output, revisit whether directory
       traversal should move over to the `ignore` crate instead of the current
       custom walker.

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -123,7 +123,7 @@ The following is an example configuration file that sets several options. Any
 options that are not set will use the default values:
 
 ```toml
-compat_mode = "gnu"
+# compat_mode = "native"  # or "gnu" for GNU ls compatibility
 show_all = true
 append_slash = true
 dirs_first = true

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -10,10 +10,26 @@ location:
 The configuration file is optional and if it is not found, `lsplus` will use the
 default settings.
 
+`lsplus` also supports an `LSP_COMPAT_MODE` environment variable. When set, it
+overrides the `compat_mode` value from the config file.
+
 ## Available Options
 
 The following options are available in the configuration file and correspond to
 the relevant command line options:
+
+### compat_mode
+
+- Permitted values: `"native"` or `"gnu"`
+- Default value: `"native"`
+
+This option selects which command-line interface `lsp` uses at startup.
+`native` keeps the standard `lsplus` CLI, while `gnu` enables the GNU `ls`
+compatibility surface intended for aliases and scripts.
+
+At the moment, `gnu` mode changes the CLI surface and help output only. The
+conflicting GNU short flags `-D`, `-I`, `-N`, and `-Z` are reserved in that
+mode and will error until their GNU behavior is implemented.
 
 ### show_all
 
@@ -38,14 +54,18 @@ will display all files and directories if set to `true`, except for `.` and
 - Default value: `false`
 
 This option corresponds to the `-p` or `--slash-dirs` command line option and
-will append a slash to directories if set to `true`.
+will append a slash to directories if set to `true`. In `gnu` compatibility
+mode, the equivalent long option is `--indicator-style=slash`.
 
 ### dirs_first
 
 - Permitted values: `true` or `false`
 - Default value: `false`
 
-This option corresponds to the `--sort-dirs` command line option and will
+This option corresponds to the `--sort-dirs` command line option and will sort
+directories before files when set to `true`. In `gnu` compatibility mode, the
+equivalent long option is `--group-directories-first` (replacing the original
+`--sort-dirs`).
 
 ### long_format
 
@@ -103,6 +123,7 @@ The following is an example configuration file that sets several options. Any
 options that are not set will use the default values:
 
 ```toml
+compat_mode = "gnu"
 show_all = true
 append_slash = true
 dirs_first = true

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -39,6 +39,33 @@ When `-I` is enabled, `lsp` checks the same ignore sources Git normally uses:
 merged `.gitignore` files in the worktree, `.git/info/exclude`, and the
 configured global Git excludes file.
 
+## Compatibility Mode
+
+`lsp` has two CLI modes:
+
+- `native` - the default `lsplus` command-line interface
+- `gnu` - a GNU `ls` compatibility mode intended for aliases and scripts
+
+You can enable GNU compatibility mode by setting `compat_mode = "gnu"` in the
+config file or by setting `LSP_COMPAT_MODE=gnu` in the environment. The
+environment variable takes precedence over the config file.
+
+At the moment, `gnu` mode changes the CLI surface and help output only. It does
+not yet implement the missing GNU meanings for the conflicting short flags
+`-D`, `-I`, `-N`, and `-Z`; those flags are reserved in `gnu` mode and will
+error until their GNU behavior is implemented.
+
+The current `lsplus` features behind those four native short flags are still
+available in `gnu` mode through their long forms only:
+
+- `--group-directories-first` (replaces the original `--sort-dirs`)
+- `--gitignore`
+- `--no-color`
+- `--fuzzy-time`
+
+In `gnu` mode, `-p` uses the GNU-style long form `--indicator-style=slash`
+instead of the native `--slash-dirs`.
+
 ## Fuzzy Time
 
 The `-Z` option will show a fuzzy time for file modification times. This will
@@ -63,6 +90,10 @@ The `lsp` command can be aliased to `ls` by adding the following line to your
 ```sh
 alias ls='lsp'
 ```
+
+If you want that alias to behave more like GNU `ls`, enable `gnu`
+compatibility mode in your config file or set `LSP_COMPAT_MODE=gnu` in your
+shell environment.
 
 You will need to restart your shell or source your configuration file for the
 alias to take effect.

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -111,6 +111,7 @@ You can also use the configuration file to set the default options you want.
 
 ![lsp output](./images/screenshot.png)
 
-If you add the '-D' option to the command, directories will be sorted first:
+If you add the `-D` option to the command (native mode only; use
+`--group-directories-first` in gnu mode), directories will be sorted first:
 
 ![lsp output](./images/screenshot2.png)

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,14 @@ use crate::utils::file::collect_file_info;
 
 pub fn run_with_flags(args: cli::Flags) -> io::Result<()> {
     let config = settings::load_config();
-    let params = Params::merge(&args, &config);
+    run_with_flags_and_config(args, &config)
+}
+
+pub fn run_with_flags_and_config(
+    args: cli::Flags,
+    config: &Params,
+) -> io::Result<()> {
+    let params = Params::merge(&args, config);
     utils::color::configure_color_output(&params);
     let patterns = patterns_from_args(args.paths);
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,11 +8,16 @@ use crate::settings;
 use crate::utils;
 use crate::utils::file::collect_file_info;
 
+/// Run `lsplus` using parsed CLI flags and config loaded from disk.
 pub fn run_with_flags(args: cli::Flags) -> io::Result<()> {
     let config = settings::load_config();
     run_with_flags_and_config(args, &config)
 }
 
+/// Run `lsplus` using parsed CLI flags and an explicit config value.
+///
+/// This is primarily useful in tests and library-style entry points that want
+/// to inject config without relying on filesystem state.
 pub fn run_with_flags_and_config(
     args: cli::Flags,
     config: &Params,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,9 @@
-// Set up the CLI arguments
+//! CLI parsing for `lsplus`.
+//!
+//! The command line can be parsed in either native `lsplus` mode or GNU
+//! compatibility mode. Both modes map into the same internal [`Flags`] type so
+//! the rest of the application can work with one normalized representation.
+
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use std::env;
 use std::ffi::OsString;
@@ -20,7 +25,9 @@ const ARG_HELP: &str = "help";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompatMode {
+    /// Parse arguments using the native `lsplus` option set.
     Native,
+    /// Parse arguments using the GNU-compatible option set.
     Gnu,
 }
 
@@ -40,21 +47,34 @@ impl CompatMode {
 
 #[derive(Debug)]
 pub struct Flags {
+    /// Show entries whose names start with `.`.
     pub show_all: bool,
+    /// Hide `.` and `..` while still showing other dotfiles.
     pub almost_all: bool,
+    /// Render long-format output.
     pub long: bool,
+    /// Render human-readable file sizes in long format.
     pub human_readable: bool,
+    /// Raw path arguments collected from the CLI.
     pub paths: Vec<String>,
+    /// Append a directory indicator in the active CLI mode.
     pub slash: bool,
+    /// Group directories before files.
     pub dirs_first: bool,
+    /// Disable file and directory icons.
     pub no_icons: bool,
+    /// Disable colored or styled output.
     pub no_color: bool,
+    /// Dim paths matched by `.gitignore` rules.
     pub gitignore: bool,
+    /// Print version information and exit.
     pub version: bool,
+    /// Render humanized relative timestamps.
     pub fuzzy_time: bool,
 }
 
 impl Flags {
+    /// Parse native-mode CLI arguments, exiting on parse failure.
     pub fn parse_from<I, T>(args: I) -> Self
     where
         I: IntoIterator<Item = T>,
@@ -72,6 +92,10 @@ impl Flags {
     }
 }
 
+/// Parse CLI arguments using the requested compatibility mode.
+///
+/// This is the main entry point used after startup mode selection has already
+/// resolved whether `lsplus` should behave in native or GNU-compatible mode.
 pub fn parse_from_mode(mode: CompatMode) -> Flags {
     let matches = build_command(mode).get_matches();
     flags_from_matches(mode, &matches)
@@ -296,6 +320,7 @@ fn flags_from_matches(mode: CompatMode, matches: &ArgMatches) -> Flags {
     }
 }
 
+/// Format the user-facing version output from package metadata values.
 pub(crate) fn format_version_info(
     version: &str,
     authors: &str,
@@ -320,6 +345,7 @@ pub(crate) fn format_version_info(
     )
 }
 
+/// Return the formatted version banner for the current build.
 pub fn version_info() -> String {
     let version = env!("CARGO_PKG_VERSION");
     let authors = env!("CARGO_PKG_AUTHORS");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,38 @@
 // Set up the CLI arguments
-use clap::{Arg, ArgAction, Parser};
+use clap::{Arg, ArgAction, CommandFactory, Parser, ValueEnum};
+#[cfg(test)]
+use std::ffi::OsString;
+use std::{env, process::exit};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompatMode {
+    Native,
+    Gnu,
+}
+
+impl CompatMode {
+    pub(crate) fn parse_value(value: &str) -> Result<Self, String> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "native" => Ok(Self::Native),
+            "gnu" => Ok(Self::Gnu),
+            _ => Err(format!(
+                "unsupported compatibility mode `{}`; expected `native` or \
+                 `gnu`",
+                value
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum IndicatorStyle {
+    Slash,
+}
+
+const GNU_INDICATOR_STYLE_HELP_FROM: &str = "  -p, --indicator-style[=<WORD>]  Append indicator with style WORD to \
+     entry names [possible values: slash]\n";
+const GNU_INDICATOR_STYLE_HELP_TO: &str =
+    "  -p, --indicator-style=slash     Append / indicator to directories\n";
 
 #[derive(Parser)]
 #[command(
@@ -82,6 +115,161 @@ pub struct Flags {
 
     #[arg(long = "fuzzy-time", short = 'Z', help = "Use fuzzy time format")]
     pub fuzzy_time: bool,
+}
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "lsplus",
+    author = env!("CARGO_PKG_AUTHORS"),
+    about = env!("CARGO_PKG_DESCRIPTION"),
+    long_about = None,
+    disable_help_flag = true,
+    arg(
+        Arg::new("help")
+            .long("help")
+            .action(ArgAction::Help)
+            .help("Print help information")
+    )
+)]
+struct GnuFlags {
+    #[arg(
+        short = 'a',
+        long = "all",
+        help = "Do not ignore entries starting with ."
+    )]
+    show_all: bool,
+
+    #[arg(
+        short = 'A',
+        long = "almost-all",
+        help = "Do not list implied . and .."
+    )]
+    almost_all: bool,
+
+    #[arg(short = 'l', long = "long", help = "Display detailed information")]
+    long: bool,
+
+    #[arg(
+        short = 'h',
+        long = "human-readable",
+        help = "with -l, print sizes like 1K 234M 2G etc."
+    )]
+    human_readable: bool,
+
+    #[arg(default_value = ".", help = "The path to list")]
+    paths: Vec<String>,
+
+    #[arg(
+        short = 'p',
+        long = "indicator-style",
+        value_enum,
+        value_name = "WORD",
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "slash",
+        help = "Append indicator with style WORD to entry names"
+    )]
+    indicator_style: Option<IndicatorStyle>,
+
+    #[arg(
+        long = "group-directories-first",
+        help = "Group directories before files"
+    )]
+    dirs_first: bool,
+
+    #[arg(long = "no-icons", help = "Do not display file or folder icons")]
+    no_icons: bool,
+
+    #[arg(
+        long = "no-color",
+        help = "Do not display colored or styled output"
+    )]
+    no_color: bool,
+
+    #[arg(
+        long = "gitignore",
+        help = "Dim entries matched by active .gitignore rules"
+    )]
+    gitignore: bool,
+
+    #[arg(
+        long = "version",
+        short = 'V',
+        action = ArgAction::SetTrue,
+        help = "Print version information and exit",
+        global = true
+    )]
+    version: bool,
+
+    #[arg(long = "fuzzy-time", help = "Use fuzzy time format")]
+    fuzzy_time: bool,
+}
+
+impl From<GnuFlags> for Flags {
+    fn from(value: GnuFlags) -> Self {
+        Self {
+            show_all: value.show_all,
+            almost_all: value.almost_all,
+            long: value.long,
+            human_readable: value.human_readable,
+            paths: value.paths,
+            slash: matches!(
+                value.indicator_style,
+                Some(IndicatorStyle::Slash)
+            ),
+            dirs_first: value.dirs_first,
+            no_icons: value.no_icons,
+            no_color: value.no_color,
+            gitignore: value.gitignore,
+            version: value.version,
+            fuzzy_time: value.fuzzy_time,
+        }
+    }
+}
+
+pub fn parse_from_mode(mode: CompatMode) -> Flags {
+    match mode {
+        CompatMode::Native => Flags::parse(),
+        CompatMode::Gnu => {
+            print_gnu_help_and_exit_if_requested();
+            GnuFlags::parse().into()
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn try_parse_from_mode<I, T>(
+    mode: CompatMode,
+    args: I,
+) -> Result<Flags, clap::Error>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    match mode {
+        CompatMode::Native => Flags::try_parse_from(args),
+        CompatMode::Gnu => GnuFlags::try_parse_from(args).map(Into::into),
+    }
+}
+
+fn print_gnu_help_and_exit_if_requested() {
+    if !env::args_os().skip(1).any(|arg| arg == "--help") {
+        return;
+    }
+
+    print!("{}", render_gnu_help());
+    exit(0);
+}
+
+pub(crate) fn render_gnu_help() -> String {
+    let mut command = GnuFlags::command();
+    command = command.bin_name("lsp");
+
+    command.render_help().to_string().replacen(
+        GNU_INDICATOR_STYLE_HELP_FROM,
+        GNU_INDICATOR_STYLE_HELP_TO,
+        1,
+    )
 }
 
 pub(crate) fn format_version_info(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,26 @@
 // Set up the CLI arguments
-use clap::{Arg, ArgAction, CommandFactory, Parser, ValueEnum};
-#[cfg(test)]
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use std::ffi::OsString;
 use std::{env, process::exit};
+
+const ARG_SHOW_ALL: &str = "show_all";
+const ARG_ALMOST_ALL: &str = "almost_all";
+const ARG_LONG: &str = "long";
+const ARG_HUMAN_READABLE: &str = "human_readable";
+const ARG_PATHS: &str = "paths";
+const ARG_SLASH: &str = "slash";
+const ARG_DIRS_FIRST: &str = "dirs_first";
+const ARG_NO_ICONS: &str = "no_icons";
+const ARG_NO_COLOR: &str = "no_color";
+const ARG_GITIGNORE: &str = "gitignore";
+const ARG_VERSION: &str = "version";
+const ARG_FUZZY_TIME: &str = "fuzzy_time";
+const ARG_HELP: &str = "help";
+
+const GNU_INDICATOR_STYLE_HELP_FROM: &str = "  -p, --indicator-style[=<WORD>]  Append indicator with style WORD to \
+     entry names [possible values: slash]\n";
+const GNU_INDICATOR_STYLE_HELP_TO: &str =
+    "  -p, --indicator-style=slash     Append / indicator to directories\n";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompatMode {
@@ -24,217 +42,47 @@ impl CompatMode {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-enum IndicatorStyle {
-    Slash,
-}
-
-const GNU_INDICATOR_STYLE_HELP_FROM: &str = "  -p, --indicator-style[=<WORD>]  Append indicator with style WORD to \
-     entry names [possible values: slash]\n";
-const GNU_INDICATOR_STYLE_HELP_TO: &str =
-    "  -p, --indicator-style=slash     Append / indicator to directories\n";
-
-#[derive(Parser)]
-#[command(
-    name = "lsplus",
-    author = env!("CARGO_PKG_AUTHORS"),
-    about =env!("CARGO_PKG_DESCRIPTION"),
-    long_about = None,
-    disable_help_flag = true,
-    arg(
-        Arg::new("help")
-            .long("help")
-            .action(ArgAction::Help)
-            .help("Print help information")
-    )
-)]
 #[derive(Debug)]
 pub struct Flags {
-    #[arg(
-        short = 'a',
-        long = "all",
-        help = "Do not ignore entries starting with ."
-    )]
     pub show_all: bool,
-
-    #[arg(
-        short = 'A',
-        long = "almost-all",
-        help = "Do not list implied . and .."
-    )]
     pub almost_all: bool,
-
-    #[arg(short = 'l', long = "long", help = "Display detailed information")]
     pub long: bool,
-
-    #[arg(
-        short = 'h',
-        long = "human-readable",
-        help = "with -l, print sizes like 1K 234M 2G etc."
-    )]
     pub human_readable: bool,
-
-    #[arg(default_value = ".", help = "The path to list")]
     pub paths: Vec<String>,
-
-    #[arg(
-        short = 'p',
-        long = "slash-dirs",
-        help = "Append a slash to directories"
-    )]
     pub slash: bool,
-
-    #[arg(short = 'D', long = "sort-dirs", help = "Sort directories first")]
     pub dirs_first: bool,
-
-    #[arg(long = "no-icons", help = "Do not display file or folder icons")]
     pub no_icons: bool,
-
-    #[arg(
-        short = 'N',
-        long = "no-color",
-        help = "Do not display colored or styled output"
-    )]
     pub no_color: bool,
-
-    #[arg(
-        short = 'I',
-        long = "gitignore",
-        help = "Dim entries matched by active .gitignore rules"
-    )]
     pub gitignore: bool,
-
-    #[arg(
-        long = "version",
-        short = 'V',
-        action = ArgAction::SetTrue,
-        help = "Print version information and exit",
-        global = true
-    )]
     pub version: bool,
-
-    #[arg(long = "fuzzy-time", short = 'Z', help = "Use fuzzy time format")]
     pub fuzzy_time: bool,
 }
 
-#[derive(Parser, Debug)]
-#[command(
-    name = "lsplus",
-    author = env!("CARGO_PKG_AUTHORS"),
-    about = env!("CARGO_PKG_DESCRIPTION"),
-    long_about = None,
-    disable_help_flag = true,
-    arg(
-        Arg::new("help")
-            .long("help")
-            .action(ArgAction::Help)
-            .help("Print help information")
-    )
-)]
-struct GnuFlags {
-    #[arg(
-        short = 'a',
-        long = "all",
-        help = "Do not ignore entries starting with ."
-    )]
-    show_all: bool,
+impl Flags {
+    pub fn parse_from<I, T>(args: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString> + Clone,
+    {
+        Self::try_parse_from(args).unwrap_or_else(|err| err.exit())
+    }
 
-    #[arg(
-        short = 'A',
-        long = "almost-all",
-        help = "Do not list implied . and .."
-    )]
-    almost_all: bool,
-
-    #[arg(short = 'l', long = "long", help = "Display detailed information")]
-    long: bool,
-
-    #[arg(
-        short = 'h',
-        long = "human-readable",
-        help = "with -l, print sizes like 1K 234M 2G etc."
-    )]
-    human_readable: bool,
-
-    #[arg(default_value = ".", help = "The path to list")]
-    paths: Vec<String>,
-
-    #[arg(
-        short = 'p',
-        long = "indicator-style",
-        value_enum,
-        value_name = "WORD",
-        num_args = 0..=1,
-        require_equals = true,
-        default_missing_value = "slash",
-        help = "Append indicator with style WORD to entry names"
-    )]
-    indicator_style: Option<IndicatorStyle>,
-
-    #[arg(
-        long = "group-directories-first",
-        help = "Group directories before files"
-    )]
-    dirs_first: bool,
-
-    #[arg(long = "no-icons", help = "Do not display file or folder icons")]
-    no_icons: bool,
-
-    #[arg(
-        long = "no-color",
-        help = "Do not display colored or styled output"
-    )]
-    no_color: bool,
-
-    #[arg(
-        long = "gitignore",
-        help = "Dim entries matched by active .gitignore rules"
-    )]
-    gitignore: bool,
-
-    #[arg(
-        long = "version",
-        short = 'V',
-        action = ArgAction::SetTrue,
-        help = "Print version information and exit",
-        global = true
-    )]
-    version: bool,
-
-    #[arg(long = "fuzzy-time", help = "Use fuzzy time format")]
-    fuzzy_time: bool,
-}
-
-impl From<GnuFlags> for Flags {
-    fn from(value: GnuFlags) -> Self {
-        Self {
-            show_all: value.show_all,
-            almost_all: value.almost_all,
-            long: value.long,
-            human_readable: value.human_readable,
-            paths: value.paths,
-            slash: matches!(
-                value.indicator_style,
-                Some(IndicatorStyle::Slash)
-            ),
-            dirs_first: value.dirs_first,
-            no_icons: value.no_icons,
-            no_color: value.no_color,
-            gitignore: value.gitignore,
-            version: value.version,
-            fuzzy_time: value.fuzzy_time,
-        }
+    pub fn try_parse_from<I, T>(args: I) -> Result<Self, clap::Error>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString> + Clone,
+    {
+        parse_matches(CompatMode::Native, args)
     }
 }
 
 pub fn parse_from_mode(mode: CompatMode) -> Flags {
-    match mode {
-        CompatMode::Native => Flags::parse(),
-        CompatMode::Gnu => {
-            print_gnu_help_and_exit_if_requested();
-            GnuFlags::parse().into()
-        }
+    if mode == CompatMode::Gnu {
+        print_gnu_help_and_exit_if_requested();
     }
+
+    let matches = build_command(mode).get_matches();
+    flags_from_matches(mode, &matches)
 }
 
 #[cfg(test)]
@@ -246,9 +94,201 @@ where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
+    parse_matches(mode, args)
+}
+
+fn parse_matches<I, T>(mode: CompatMode, args: I) -> Result<Flags, clap::Error>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    let matches = build_command(mode).try_get_matches_from(args)?;
+    Ok(flags_from_matches(mode, &matches))
+}
+
+fn build_command(mode: CompatMode) -> Command {
+    Command::new("lsplus")
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .about(env!("CARGO_PKG_DESCRIPTION"))
+        .long_about(None)
+        .disable_help_flag(true)
+        .arg(show_all_arg())
+        .arg(almost_all_arg())
+        .arg(long_arg())
+        .arg(human_readable_arg())
+        .arg(paths_arg())
+        .arg(slash_arg(mode))
+        .arg(dirs_first_arg(mode))
+        .arg(no_icons_arg())
+        .arg(no_color_arg(mode))
+        .arg(gitignore_arg(mode))
+        .arg(version_arg())
+        .arg(fuzzy_time_arg(mode))
+        .arg(help_arg())
+}
+
+fn help_arg() -> Arg {
+    Arg::new(ARG_HELP)
+        .long("help")
+        .action(ArgAction::Help)
+        .help("Print help information")
+}
+
+fn show_all_arg() -> Arg {
+    Arg::new(ARG_SHOW_ALL)
+        .short('a')
+        .long("all")
+        .action(ArgAction::SetTrue)
+        .help("Do not ignore entries starting with .")
+}
+
+fn almost_all_arg() -> Arg {
+    Arg::new(ARG_ALMOST_ALL)
+        .short('A')
+        .long("almost-all")
+        .action(ArgAction::SetTrue)
+        .help("Do not list implied . and ..")
+}
+
+fn long_arg() -> Arg {
+    Arg::new(ARG_LONG)
+        .short('l')
+        .long("long")
+        .action(ArgAction::SetTrue)
+        .help("Display detailed information")
+}
+
+fn human_readable_arg() -> Arg {
+    Arg::new(ARG_HUMAN_READABLE)
+        .short('h')
+        .long("human-readable")
+        .action(ArgAction::SetTrue)
+        .help("with -l, print sizes like 1K 234M 2G etc.")
+}
+
+fn paths_arg() -> Arg {
+    Arg::new(ARG_PATHS)
+        .help("The path to list")
+        .value_name("PATHS")
+        .default_value(".")
+        .action(ArgAction::Append)
+        .num_args(0..)
+}
+
+fn slash_arg(mode: CompatMode) -> Arg {
     match mode {
-        CompatMode::Native => Flags::try_parse_from(args),
-        CompatMode::Gnu => GnuFlags::try_parse_from(args).map(Into::into),
+        CompatMode::Native => Arg::new(ARG_SLASH)
+            .short('p')
+            .long("slash-dirs")
+            .action(ArgAction::SetTrue)
+            .help("Append a slash to directories"),
+        CompatMode::Gnu => Arg::new(ARG_SLASH)
+            .short('p')
+            .long("indicator-style")
+            .action(ArgAction::Set)
+            .default_missing_value("slash")
+            .require_equals(true)
+            .num_args(0..=1)
+            .value_name("WORD")
+            .value_parser(["slash"])
+            .help("Append indicator with style WORD to entry names"),
+    }
+}
+
+fn dirs_first_arg(mode: CompatMode) -> Arg {
+    match mode {
+        CompatMode::Native => Arg::new(ARG_DIRS_FIRST)
+            .short('D')
+            .long("sort-dirs")
+            .action(ArgAction::SetTrue)
+            .help("Sort directories first"),
+        CompatMode::Gnu => Arg::new(ARG_DIRS_FIRST)
+            .long("group-directories-first")
+            .action(ArgAction::SetTrue)
+            .help("Group directories before files"),
+    }
+}
+
+fn no_icons_arg() -> Arg {
+    Arg::new(ARG_NO_ICONS)
+        .long("no-icons")
+        .action(ArgAction::SetTrue)
+        .help("Do not display file or folder icons")
+}
+
+fn no_color_arg(mode: CompatMode) -> Arg {
+    match mode {
+        CompatMode::Native => Arg::new(ARG_NO_COLOR)
+            .short('N')
+            .long("no-color")
+            .action(ArgAction::SetTrue)
+            .help("Do not display colored or styled output"),
+        CompatMode::Gnu => Arg::new(ARG_NO_COLOR)
+            .long("no-color")
+            .action(ArgAction::SetTrue)
+            .help("Do not display colored or styled output"),
+    }
+}
+
+fn gitignore_arg(mode: CompatMode) -> Arg {
+    match mode {
+        CompatMode::Native => Arg::new(ARG_GITIGNORE)
+            .short('I')
+            .long("gitignore")
+            .action(ArgAction::SetTrue)
+            .help("Dim entries matched by active .gitignore rules"),
+        CompatMode::Gnu => Arg::new(ARG_GITIGNORE)
+            .long("gitignore")
+            .action(ArgAction::SetTrue)
+            .help("Dim entries matched by active .gitignore rules"),
+    }
+}
+
+fn version_arg() -> Arg {
+    Arg::new(ARG_VERSION)
+        .short('V')
+        .long("version")
+        .action(ArgAction::SetTrue)
+        .global(true)
+        .help("Print version information and exit")
+}
+
+fn fuzzy_time_arg(mode: CompatMode) -> Arg {
+    match mode {
+        CompatMode::Native => Arg::new(ARG_FUZZY_TIME)
+            .short('Z')
+            .long("fuzzy-time")
+            .action(ArgAction::SetTrue)
+            .help("Use fuzzy time format"),
+        CompatMode::Gnu => Arg::new(ARG_FUZZY_TIME)
+            .long("fuzzy-time")
+            .action(ArgAction::SetTrue)
+            .help("Use fuzzy time format"),
+    }
+}
+
+fn flags_from_matches(mode: CompatMode, matches: &ArgMatches) -> Flags {
+    Flags {
+        show_all: matches.get_flag(ARG_SHOW_ALL),
+        almost_all: matches.get_flag(ARG_ALMOST_ALL),
+        long: matches.get_flag(ARG_LONG),
+        human_readable: matches.get_flag(ARG_HUMAN_READABLE),
+        paths: matches
+            .get_many::<String>(ARG_PATHS)
+            .map(|values| values.cloned().collect())
+            .unwrap_or_else(|| vec![String::from(".")]),
+        slash: match mode {
+            CompatMode::Native => matches.get_flag(ARG_SLASH),
+            CompatMode::Gnu => matches
+                .get_one::<String>(ARG_SLASH)
+                .is_some_and(|value| value == "slash"),
+        },
+        dirs_first: matches.get_flag(ARG_DIRS_FIRST),
+        no_icons: matches.get_flag(ARG_NO_ICONS),
+        no_color: matches.get_flag(ARG_NO_COLOR),
+        gitignore: matches.get_flag(ARG_GITIGNORE),
+        version: matches.get_flag(ARG_VERSION),
+        fuzzy_time: matches.get_flag(ARG_FUZZY_TIME),
     }
 }
 
@@ -262,14 +302,15 @@ fn print_gnu_help_and_exit_if_requested() {
 }
 
 pub(crate) fn render_gnu_help() -> String {
-    let mut command = GnuFlags::command();
-    command = command.bin_name("lsp");
-
-    command.render_help().to_string().replacen(
-        GNU_INDICATOR_STYLE_HELP_FROM,
-        GNU_INDICATOR_STYLE_HELP_TO,
-        1,
-    )
+    build_command(CompatMode::Gnu)
+        .bin_name("lsp")
+        .render_help()
+        .to_string()
+        .replacen(
+            GNU_INDICATOR_STYLE_HELP_FROM,
+            GNU_INDICATOR_STYLE_HELP_TO,
+            1,
+        )
 }
 
 pub(crate) fn format_version_info(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 // Set up the CLI arguments
 use clap::{Arg, ArgAction, ArgMatches, Command};
+use std::env;
 use std::ffi::OsString;
-use std::{env, process::exit};
 
 const ARG_SHOW_ALL: &str = "show_all";
 const ARG_ALMOST_ALL: &str = "almost_all";
@@ -9,6 +9,7 @@ const ARG_LONG: &str = "long";
 const ARG_HUMAN_READABLE: &str = "human_readable";
 const ARG_PATHS: &str = "paths";
 const ARG_SLASH: &str = "slash";
+const ARG_INDICATOR_STYLE: &str = "indicator_style";
 const ARG_DIRS_FIRST: &str = "dirs_first";
 const ARG_NO_ICONS: &str = "no_icons";
 const ARG_NO_COLOR: &str = "no_color";
@@ -16,11 +17,6 @@ const ARG_GITIGNORE: &str = "gitignore";
 const ARG_VERSION: &str = "version";
 const ARG_FUZZY_TIME: &str = "fuzzy_time";
 const ARG_HELP: &str = "help";
-
-const GNU_INDICATOR_STYLE_HELP_FROM: &str = "  -p, --indicator-style[=<WORD>]  Append indicator with style WORD to \
-     entry names [possible values: slash]\n";
-const GNU_INDICATOR_STYLE_HELP_TO: &str =
-    "  -p, --indicator-style=slash     Append / indicator to directories\n";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompatMode {
@@ -77,10 +73,6 @@ impl Flags {
 }
 
 pub fn parse_from_mode(mode: CompatMode) -> Flags {
-    if mode == CompatMode::Gnu {
-        print_gnu_help_and_exit_if_requested();
-    }
-
     let matches = build_command(mode).get_matches();
     flags_from_matches(mode, &matches)
 }
@@ -107,7 +99,7 @@ where
 }
 
 fn build_command(mode: CompatMode) -> Command {
-    Command::new("lsplus")
+    let command = Command::new("lsplus")
         .author(env!("CARGO_PKG_AUTHORS"))
         .about(env!("CARGO_PKG_DESCRIPTION"))
         .long_about(None)
@@ -124,7 +116,12 @@ fn build_command(mode: CompatMode) -> Command {
         .arg(gitignore_arg(mode))
         .arg(version_arg())
         .arg(fuzzy_time_arg(mode))
-        .arg(help_arg())
+        .arg(help_arg());
+
+    match mode {
+        CompatMode::Native => command,
+        CompatMode::Gnu => command.arg(indicator_style_arg()),
+    }
 }
 
 fn help_arg() -> Arg {
@@ -184,15 +181,19 @@ fn slash_arg(mode: CompatMode) -> Arg {
             .help("Append a slash to directories"),
         CompatMode::Gnu => Arg::new(ARG_SLASH)
             .short('p')
-            .long("indicator-style")
-            .action(ArgAction::Set)
-            .default_missing_value("slash")
-            .require_equals(true)
-            .num_args(0..=1)
-            .value_name("WORD")
-            .value_parser(["slash"])
-            .help("Append indicator with style WORD to entry names"),
+            .action(ArgAction::SetTrue)
+            .help("Append / indicator to directories"),
     }
+}
+
+fn indicator_style_arg() -> Arg {
+    Arg::new(ARG_INDICATOR_STYLE)
+        .long("indicator-style")
+        .action(ArgAction::Set)
+        .require_equals(true)
+        .value_name("WORD")
+        .value_parser(["slash"])
+        .help("Append indicator with style WORD to entry names")
 }
 
 fn dirs_first_arg(mode: CompatMode) -> Arg {
@@ -279,9 +280,12 @@ fn flags_from_matches(mode: CompatMode, matches: &ArgMatches) -> Flags {
             .unwrap_or_else(|| vec![String::from(".")]),
         slash: match mode {
             CompatMode::Native => matches.get_flag(ARG_SLASH),
-            CompatMode::Gnu => matches
-                .get_one::<String>(ARG_SLASH)
-                .is_some_and(|value| value == "slash"),
+            CompatMode::Gnu => {
+                matches.get_flag(ARG_SLASH)
+                    || matches
+                        .get_one::<String>(ARG_INDICATOR_STYLE)
+                        .is_some_and(|value| value == "slash")
+            }
         },
         dirs_first: matches.get_flag(ARG_DIRS_FIRST),
         no_icons: matches.get_flag(ARG_NO_ICONS),
@@ -290,27 +294,6 @@ fn flags_from_matches(mode: CompatMode, matches: &ArgMatches) -> Flags {
         version: matches.get_flag(ARG_VERSION),
         fuzzy_time: matches.get_flag(ARG_FUZZY_TIME),
     }
-}
-
-fn print_gnu_help_and_exit_if_requested() {
-    if !env::args_os().skip(1).any(|arg| arg == "--help") {
-        return;
-    }
-
-    print!("{}", render_gnu_help());
-    exit(0);
-}
-
-pub(crate) fn render_gnu_help() -> String {
-    build_command(CompatMode::Gnu)
-        .bin_name("lsp")
-        .render_help()
-        .to_string()
-        .replacen(
-            GNU_INDICATOR_STYLE_HELP_FROM,
-            GNU_INDICATOR_STYLE_HELP_TO,
-            1,
-        )
 }
 
 pub(crate) fn format_version_info(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+//! Library entry points for `lsplus`.
+//!
+//! The crate exposes the runtime building blocks behind the `lsp` binary,
+//! including CLI parsing, startup configuration, and file-listing helpers.
+//! `lsplus` supports both its native CLI surface and a GNU compatibility mode
+//! for users who want `ls`-style option parsing.
+
 pub mod app;
 pub mod cli;
 pub mod settings;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,25 @@
-use clap::Parser;
 use std::process::exit;
 
 use lsplus::cli;
 
 fn main() {
-    let args = cli::Flags::parse();
+    let startup = match lsplus::settings::load_startup_config() {
+        Ok(config) => config,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
+
+    let args = cli::parse_from_mode(startup.compat_mode);
     if args.version {
         println!("{}", cli::version_info());
         exit(0);
     }
 
-    if let Err(e) = lsplus::app::run_with_flags(args) {
+    if let Err(e) =
+        lsplus::app::run_with_flags_and_config(args, &startup.params)
+    {
         eprintln!("Error: {}", e);
         exit(1);
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,8 +2,25 @@ use std::path::PathBuf;
 
 use config::{Config, File, FileFormat};
 use dirs_next::home_dir;
+use serde::Deserialize;
 
 use crate::Params;
+use crate::cli::CompatMode;
+
+pub const COMPAT_MODE_ENV_VAR: &str = "LSP_COMPAT_MODE";
+
+#[derive(Debug, PartialEq)]
+pub struct StartupConfig {
+    pub params: Params,
+    pub compat_mode: CompatMode,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Default)]
+struct ParsedConfig {
+    #[serde(default, flatten)]
+    params: Params,
+    compat_mode: Option<String>,
+}
 
 fn config_path() -> Option<PathBuf> {
     config_path_from_home(home_dir())
@@ -20,12 +37,41 @@ pub fn load_config() -> Params {
 }
 
 pub(crate) fn load_config_from_path(config_path: Option<PathBuf>) -> Params {
-    let Some(config_path) = config_path else {
-        return Params::default();
-    };
+    load_parsed_config_from_path(config_path)
+        .map(|config| config.params)
+        .unwrap_or_default()
+}
+
+pub fn load_startup_config() -> Result<StartupConfig, String> {
+    load_startup_config_from(
+        config_path(),
+        std::env::var(COMPAT_MODE_ENV_VAR).ok(),
+    )
+}
+
+pub(crate) fn load_startup_config_from(
+    config_path: Option<PathBuf>,
+    env_mode: Option<String>,
+) -> Result<StartupConfig, String> {
+    let parsed_config = load_parsed_config_from_path(config_path);
+    let compat_mode =
+        resolve_compat_mode(env_mode.as_deref(), parsed_config.as_ref())?;
+
+    Ok(StartupConfig {
+        params: parsed_config
+            .map(|config| config.params)
+            .unwrap_or_default(),
+        compat_mode,
+    })
+}
+
+fn load_parsed_config_from_path(
+    config_path: Option<PathBuf>,
+) -> Option<ParsedConfig> {
+    let config_path = config_path?;
 
     if !config_path.is_file() {
-        return Params::default();
+        return None;
     }
 
     let settings = Config::builder()
@@ -33,10 +79,36 @@ pub(crate) fn load_config_from_path(config_path: Option<PathBuf>) -> Params {
         .build();
 
     match settings {
-        Ok(config) => config.into(),
+        Ok(config) => match config.try_deserialize::<ParsedConfig>() {
+            Ok(parsed_config) => Some(parsed_config),
+            Err(e) => {
+                eprintln!("Error loading config: {}", e);
+                None
+            }
+        },
         Err(e) => {
             eprintln!("Error loading config: {}", e);
-            Params::default()
+            None
         }
     }
+}
+
+fn resolve_compat_mode(
+    env_mode: Option<&str>,
+    parsed_config: Option<&ParsedConfig>,
+) -> Result<CompatMode, String> {
+    if let Some(mode) = env_mode {
+        return CompatMode::parse_value(mode).map_err(|err| {
+            format!("invalid {} value: {}", COMPAT_MODE_ENV_VAR, err)
+        });
+    }
+
+    if let Some(mode) =
+        parsed_config.and_then(|config| config.compat_mode.as_deref())
+    {
+        return CompatMode::parse_value(mode)
+            .map_err(|err| format!("invalid compat_mode setting: {}", err));
+    }
+
+    Ok(CompatMode::Native)
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,11 +7,17 @@ use serde::Deserialize;
 use crate::Params;
 use crate::cli::CompatMode;
 
+/// Environment variable that forces the startup compatibility mode.
+///
+/// When set, this takes precedence over the `compat_mode` value in the config
+/// file.
 pub const COMPAT_MODE_ENV_VAR: &str = "LSP_COMPAT_MODE";
 
 #[derive(Debug, PartialEq)]
 pub struct StartupConfig {
+    /// Runtime parameters loaded from the config file.
     pub params: Params,
+    /// CLI compatibility mode selected for this process.
     pub compat_mode: CompatMode,
 }
 
@@ -32,6 +38,9 @@ pub(crate) fn config_path_from_home(home: Option<PathBuf>) -> Option<PathBuf> {
     Some(path)
 }
 
+/// Load runtime parameters from the default config file path.
+///
+/// Invalid or missing config files fall back to the default [`Params`] values.
 pub fn load_config() -> Params {
     load_config_from_path(config_path())
 }
@@ -42,6 +51,11 @@ pub(crate) fn load_config_from_path(config_path: Option<PathBuf>) -> Params {
         .unwrap_or_default()
 }
 
+/// Load startup configuration, including the active compatibility mode.
+///
+/// Compatibility mode resolution prefers [`COMPAT_MODE_ENV_VAR`] over the
+/// `compat_mode` setting in the config file, and falls back to native mode
+/// when neither source is set.
 pub fn load_startup_config() -> Result<StartupConfig, String> {
     load_startup_config_from(
         config_path(),

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -20,15 +20,25 @@ macro_rules! config_to_params {
 #[derive(Debug, Deserialize, PartialEq, Default)]
 #[serde(default)]
 pub struct Params {
+    /// Show entries whose names start with `.`.
     pub show_all: bool,
+    /// Append a trailing `/` to directory names.
     pub append_slash: bool,
+    /// Group directories before files.
     pub dirs_first: bool,
+    /// Hide `.` and `..` while still showing other dotfiles.
     pub almost_all: bool,
+    /// Render long-format output.
     pub long_format: bool,
+    /// Render human-readable file sizes in long format.
     pub human_readable: bool,
+    /// Disable file and directory icons.
     pub no_icons: bool,
+    /// Disable colored or styled output.
     pub no_color: bool,
+    /// Dim paths matched by `.gitignore` rules.
     pub gitignore: bool,
+    /// Render humanized relative timestamps.
     pub fuzzy_time: bool,
 }
 
@@ -65,6 +75,10 @@ impl From<Config> for Params {
 }
 
 impl Params {
+    /// Merge parsed CLI flags with config-file defaults.
+    ///
+    /// Boolean options are treated as opt-in toggles, so a value is enabled if
+    /// either the command line or the config file enables it.
     pub fn merge(flags: &cli::Flags, config: &Self) -> Self {
         Self {
             show_all: flags.show_all || config.show_all,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -18,6 +18,7 @@ macro_rules! config_to_params {
 }
 
 #[derive(Debug, Deserialize, PartialEq, Default)]
+#[serde(default)]
 pub struct Params {
     pub show_all: bool,
     pub append_slash: bool,

--- a/tests/crate/cli.rs
+++ b/tests/crate/cli.rs
@@ -1,6 +1,5 @@
 use crate::cli::{
-    CompatMode, Flags, format_version_info, render_gnu_help,
-    try_parse_from_mode, version_info,
+    CompatMode, Flags, format_version_info, try_parse_from_mode, version_info,
 };
 
 #[test]
@@ -156,6 +155,7 @@ fn test_parse_from_mode_gnu_help_omits_conflicting_short_flags() {
         .unwrap_err();
     let help = err.to_string();
 
+    assert!(help.contains("-p"));
     assert!(help.contains("--indicator-style"));
     assert!(help.contains("--group-directories-first"));
     assert!(!help.contains("--slash-dirs"));
@@ -166,13 +166,10 @@ fn test_parse_from_mode_gnu_help_omits_conflicting_short_flags() {
 }
 
 #[test]
-fn test_render_gnu_help_uses_literal_indicator_style_line() {
-    let help = render_gnu_help();
+fn test_parse_from_mode_gnu_short_p_sets_slash() {
+    let args = try_parse_from_mode(CompatMode::Gnu, ["lsplus", "-p"]).unwrap();
 
-    assert!(help.contains(
-        "-p, --indicator-style=slash     Append / indicator to directories"
-    ));
-    assert!(!help.contains("--indicator-style[=<WORD>]"));
+    assert!(args.slash);
 }
 
 #[test]

--- a/tests/crate/cli.rs
+++ b/tests/crate/cli.rs
@@ -2,7 +2,6 @@ use crate::cli::{
     CompatMode, Flags, format_version_info, render_gnu_help,
     try_parse_from_mode, version_info,
 };
-use clap::Parser;
 
 #[test]
 fn test_default_flags() {

--- a/tests/crate/cli.rs
+++ b/tests/crate/cli.rs
@@ -1,4 +1,7 @@
-use crate::cli::{Flags, format_version_info, version_info};
+use crate::cli::{
+    CompatMode, Flags, format_version_info, render_gnu_help,
+    try_parse_from_mode, version_info,
+};
 use clap::Parser;
 
 #[test]
@@ -99,4 +102,94 @@ fn test_help_flag() {
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert!(err.to_string().contains("Usage:"));
+}
+
+#[test]
+fn test_parse_from_mode_native_keeps_conflicting_short_flags() {
+    let args = try_parse_from_mode(
+        CompatMode::Native,
+        ["lsplus", "-D", "-I", "-N", "-Z"],
+    )
+    .unwrap();
+
+    assert!(args.dirs_first);
+    assert!(args.gitignore);
+    assert!(args.no_color);
+    assert!(args.fuzzy_time);
+}
+
+#[test]
+fn test_parse_from_mode_gnu_rejects_conflicting_short_flags() {
+    for flag in ["-D", "-I", "-N", "-Z"] {
+        let err = try_parse_from_mode(CompatMode::Gnu, ["lsplus", flag])
+            .unwrap_err();
+
+        assert!(err.to_string().contains("unexpected argument"));
+        assert!(err.to_string().contains(flag));
+    }
+}
+
+#[test]
+fn test_parse_from_mode_gnu_accepts_long_options_for_conflicts() {
+    let args = try_parse_from_mode(
+        CompatMode::Gnu,
+        [
+            "lsplus",
+            "--indicator-style=slash",
+            "--group-directories-first",
+            "--gitignore",
+            "--no-color",
+            "--fuzzy-time",
+        ],
+    )
+    .unwrap();
+
+    assert!(args.slash);
+    assert!(args.dirs_first);
+    assert!(args.gitignore);
+    assert!(args.no_color);
+    assert!(args.fuzzy_time);
+}
+
+#[test]
+fn test_parse_from_mode_gnu_help_omits_conflicting_short_flags() {
+    let err = try_parse_from_mode(CompatMode::Gnu, ["lsplus", "--help"])
+        .unwrap_err();
+    let help = err.to_string();
+
+    assert!(help.contains("--indicator-style"));
+    assert!(help.contains("--group-directories-first"));
+    assert!(!help.contains("--slash-dirs"));
+    assert!(!help.contains("-D,"));
+    assert!(!help.contains("-I,"));
+    assert!(!help.contains("-N,"));
+    assert!(!help.contains("-Z,"));
+}
+
+#[test]
+fn test_render_gnu_help_uses_literal_indicator_style_line() {
+    let help = render_gnu_help();
+
+    assert!(help.contains(
+        "-p, --indicator-style=slash     Append / indicator to directories"
+    ));
+    assert!(!help.contains("--indicator-style[=<WORD>]"));
+}
+
+#[test]
+fn test_parse_from_mode_gnu_rejects_native_slash_dirs_long_option() {
+    let err = try_parse_from_mode(CompatMode::Gnu, ["lsplus", "--slash-dirs"])
+        .unwrap_err();
+
+    assert!(err.to_string().contains("unexpected argument"));
+    assert!(err.to_string().contains("--slash-dirs"));
+}
+
+#[test]
+fn test_parse_from_mode_gnu_rejects_native_sort_dirs_long_option() {
+    let err = try_parse_from_mode(CompatMode::Gnu, ["lsplus", "--sort-dirs"])
+        .unwrap_err();
+
+    assert!(err.to_string().contains("unexpected argument"));
+    assert!(err.to_string().contains("--sort-dirs"));
 }

--- a/tests/crate/settings.rs
+++ b/tests/crate/settings.rs
@@ -1,6 +1,8 @@
 use crate::Params;
+use crate::cli::CompatMode;
 use crate::settings::{
-    config_path_from_home, load_config, load_config_from_path,
+    StartupConfig, config_path_from_home, load_config, load_config_from_path,
+    load_startup_config_from,
 };
 use std::fs;
 use std::path::PathBuf;
@@ -81,4 +83,96 @@ fn test_load_config_reads_boolean_settings_from_home_config() {
             }
         );
     });
+}
+
+#[test]
+fn test_load_startup_config_defaults_to_native_without_sources() {
+    assert_eq!(
+        load_startup_config_from(None, None).unwrap(),
+        StartupConfig {
+            params: Params::default(),
+            compat_mode: CompatMode::Native,
+        }
+    );
+}
+
+#[test]
+fn test_load_startup_config_reads_compat_mode_from_config() {
+    let temp_dir = tempdir().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("lsplus");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(
+        config_dir.join("config.toml"),
+        r#"
+            compat_mode = "gnu"
+            no_color = true
+        "#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        load_startup_config_from(Some(config_dir.join("config.toml")), None,)
+            .unwrap(),
+        StartupConfig {
+            params: Params {
+                no_color: true,
+                ..Params::default()
+            },
+            compat_mode: CompatMode::Gnu,
+        }
+    );
+}
+
+#[test]
+fn test_load_startup_config_env_overrides_config_mode() {
+    let temp_dir = tempdir().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("lsplus");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(
+        config_dir.join("config.toml"),
+        r#"
+            compat_mode = "native"
+            fuzzy_time = true
+        "#,
+    )
+    .unwrap();
+
+    let startup = load_startup_config_from(
+        Some(config_dir.join("config.toml")),
+        Some(String::from("gnu")),
+    )
+    .unwrap();
+
+    assert_eq!(startup.compat_mode, CompatMode::Gnu);
+    assert!(startup.params.fuzzy_time);
+}
+
+#[test]
+fn test_load_startup_config_rejects_invalid_env_mode() {
+    let err = load_startup_config_from(None, Some(String::from("bogus")))
+        .unwrap_err();
+
+    assert!(err.contains("LSP_COMPAT_MODE"));
+    assert!(err.contains("bogus"));
+}
+
+#[test]
+fn test_load_startup_config_rejects_invalid_config_mode() {
+    let temp_dir = tempdir().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("lsplus");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(
+        config_dir.join("config.toml"),
+        r#"
+            compat_mode = "bogus"
+        "#,
+    )
+    .unwrap();
+
+    let err =
+        load_startup_config_from(Some(config_dir.join("config.toml")), None)
+            .unwrap_err();
+
+    assert!(err.contains("compat_mode"));
+    assert!(err.contains("bogus"));
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -629,6 +629,26 @@ fn test_gnu_compat_mode_from_env_rejects_conflicting_short_flag() {
 }
 
 #[test]
+fn test_gnu_compat_mode_from_env_rejects_gitignore_short_flag() {
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.env("LSP_COMPAT_MODE", "gnu")
+        .arg("-I")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("unexpected argument '-I'"));
+}
+
+#[test]
+fn test_gnu_compat_mode_from_env_rejects_fuzzy_time_short_flag() {
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.env("LSP_COMPAT_MODE", "gnu")
+        .arg("-Z")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("unexpected argument '-Z'"));
+}
+
+#[test]
 fn test_gnu_compat_mode_from_config_rejects_conflicting_short_flag() {
     let temp_dir = tempdir().unwrap();
     let config_dir = temp_dir.path().join(".config").join("lsplus");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -159,7 +159,9 @@ fn test_dirs_first_lists_directories_before_files() {
     fs::write(temp_dir.path().join("alpha.txt"), "alpha").unwrap();
 
     let mut cmd = Command::cargo_bin("lsp").unwrap();
-    cmd.arg("-D").arg(temp_dir.path());
+    cmd.env("LSP_COMPAT_MODE", "native")
+        .arg("-D")
+        .arg(temp_dir.path());
     let (stdout, _stderr) = run_and_capture(&mut cmd);
 
     let dir_position = stdout.find("zeta_dir").unwrap();
@@ -182,7 +184,10 @@ fn test_fuzzy_time_uses_human_readable_timestamp() {
     filetime::set_file_mtime(&file_path, old_time).unwrap();
 
     let mut cmd = Command::cargo_bin("lsp").unwrap();
-    cmd.arg("-l").arg("-Z").arg(&file_path);
+    cmd.env("LSP_COMPAT_MODE", "native")
+        .arg("-l")
+        .arg("-Z")
+        .arg(&file_path);
     let (stdout, _stderr) = run_and_capture(&mut cmd);
 
     assert!(stdout.contains("aged.txt"));
@@ -256,7 +261,10 @@ fn test_no_color_flag_keeps_short_output_plain() {
     fs::write(&file_path, "plain").unwrap();
 
     let mut cmd = Command::cargo_bin("lsp").unwrap();
-    cmd.arg("-N").arg("--no-icons").arg(&file_path);
+    cmd.env("LSP_COMPAT_MODE", "native")
+        .arg("-N")
+        .arg("--no-icons")
+        .arg(&file_path);
     let (stdout, _stderr) = run_and_capture_raw(&mut cmd);
 
     assert!(!has_ansi(&stdout));
@@ -345,7 +353,10 @@ fn test_gitignore_flag_keeps_captured_short_output_plain() {
     fs::write(temp_dir.path().join(visible_name), "visible").unwrap();
 
     let mut cmd = Command::cargo_bin("lsp").unwrap();
-    cmd.arg("-I").arg("--no-icons").arg(temp_dir.path());
+    cmd.env("LSP_COMPAT_MODE", "native")
+        .arg("-I")
+        .arg("--no-icons")
+        .arg(temp_dir.path());
     let (stdout, _stderr) = run_and_capture_raw(&mut cmd);
 
     let ignored_line = stdout
@@ -370,7 +381,8 @@ fn test_gitignore_flag_keeps_captured_long_output_plain() {
     fs::write(temp_dir.path().join("visible.txt"), "visible").unwrap();
 
     let mut cmd = Command::cargo_bin("lsp").unwrap();
-    cmd.arg("-l")
+    cmd.env("LSP_COMPAT_MODE", "native")
+        .arg("-l")
         .arg("-I")
         .arg("--no-icons")
         .arg(temp_dir.path());
@@ -405,7 +417,10 @@ fn test_gitignore_flag_honors_nested_unignore_rules() {
     fs::write(nested_dir.join(kept_name), "kept").unwrap();
 
     let mut cmd = Command::cargo_bin("lsp").unwrap();
-    cmd.arg("-I").arg("--no-icons").arg(&nested_dir);
+    cmd.env("LSP_COMPAT_MODE", "native")
+        .arg("-I")
+        .arg("--no-icons")
+        .arg(&nested_dir);
     let (stdout, _stderr) = run_and_capture_raw(&mut cmd);
 
     let ignored_line = stdout
@@ -430,7 +445,10 @@ fn test_gitignore_flag_dims_explicit_file_arguments() {
     fs::write(&ignored_file, "ignored").unwrap();
 
     let mut cmd = Command::cargo_bin("lsp").unwrap();
-    cmd.arg("-I").arg("--no-icons").arg(&ignored_file);
+    cmd.env("LSP_COMPAT_MODE", "native")
+        .arg("-I")
+        .arg("--no-icons")
+        .arg(&ignored_file);
     let (stdout, _stderr) = run_and_capture_raw(&mut cmd);
 
     let ignored_line = stdout
@@ -447,7 +465,10 @@ fn test_gitignore_flag_does_not_dim_outside_git_worktree() {
     fs::write(temp_dir.path().join("plain.log"), "plain").unwrap();
 
     let mut cmd = Command::cargo_bin("lsp").unwrap();
-    cmd.arg("-I").arg("--no-icons").arg(temp_dir.path());
+    cmd.env("LSP_COMPAT_MODE", "native")
+        .arg("-I")
+        .arg("--no-icons")
+        .arg(temp_dir.path());
     let (stdout, _stderr) = run_and_capture_raw(&mut cmd);
 
     let plain_line = stdout
@@ -480,7 +501,8 @@ fn test_gitignore_flag_honors_git_info_exclude() {
     fs::write(temp_dir.path().join(visible_name), "visible").unwrap();
 
     let mut cmd = Command::cargo_bin("lsp").unwrap();
-    cmd.arg("-I")
+    cmd.env("LSP_COMPAT_MODE", "native")
+        .arg("-I")
         .arg("--no-icons")
         .arg(&ignored_file)
         .arg(temp_dir.path().join(visible_name));
@@ -534,6 +556,7 @@ fn test_gitignore_flag_honors_global_excludes() {
     let mut cmd = Command::cargo_bin("lsp").unwrap();
     cmd.current_dir(&repo_dir)
         .env("HOME", &home_dir)
+        .env("LSP_COMPAT_MODE", "native")
         .arg("-I")
         .arg("--no-icons")
         .arg(&ignored_file)
@@ -593,4 +616,222 @@ fn test_broken_symlink_argument_long_format() {
         .success()
         .stdout(predicates::str::contains("[Broken Link]"))
         .stdout(predicates::str::contains("broken_link"));
+}
+
+#[test]
+fn test_gnu_compat_mode_from_env_rejects_conflicting_short_flag() {
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.env("LSP_COMPAT_MODE", "gnu")
+        .arg("-D")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("unexpected argument '-D'"));
+}
+
+#[test]
+fn test_gnu_compat_mode_from_config_rejects_conflicting_short_flag() {
+    let temp_dir = tempdir().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("lsplus");
+
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(config_dir.join("config.toml"), "compat_mode = \"gnu\"\n")
+        .unwrap();
+
+    temp_env::with_var("HOME", Some(temp_dir.path()), || {
+        let mut cmd = Command::cargo_bin("lsp").unwrap();
+        cmd.arg("-N")
+            .assert()
+            .failure()
+            .stderr(predicates::str::contains("unexpected argument '-N'"));
+    });
+}
+
+#[test]
+fn test_invalid_env_compat_mode_fails_startup() {
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.env("LSP_COMPAT_MODE", "bogus")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("invalid LSP_COMPAT_MODE value"))
+        .stderr(predicates::str::contains("bogus"));
+}
+
+#[test]
+fn test_invalid_config_compat_mode_fails_startup() {
+    let temp_dir = tempdir().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("lsplus");
+
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(config_dir.join("config.toml"), "compat_mode = \"bogus\"\n")
+        .unwrap();
+
+    temp_env::with_var("HOME", Some(temp_dir.path()), || {
+        let mut cmd = Command::cargo_bin("lsp").unwrap();
+        cmd.assert()
+            .failure()
+            .stderr(predicates::str::contains("invalid compat_mode setting"))
+            .stderr(predicates::str::contains("bogus"));
+    });
+}
+
+#[test]
+fn test_env_compat_mode_overrides_config_mode() {
+    let temp_dir = tempdir().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("lsplus");
+
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(config_dir.join("config.toml"), "compat_mode = \"gnu\"\n")
+        .unwrap();
+    fs::create_dir(temp_dir.path().join("zeta_dir")).unwrap();
+    fs::write(temp_dir.path().join("alpha.txt"), "alpha").unwrap();
+
+    temp_env::with_var("HOME", Some(temp_dir.path()), || {
+        let mut cmd = Command::cargo_bin("lsp").unwrap();
+        cmd.env("LSP_COMPAT_MODE", "native")
+            .arg("-D")
+            .arg(temp_dir.path());
+        let (stdout, _stderr) = run_and_capture(&mut cmd);
+
+        let dir_position = stdout.find("zeta_dir").unwrap();
+        let file_position = stdout.find("alpha.txt").unwrap();
+
+        assert!(dir_position < file_position);
+    });
+}
+
+#[test]
+fn test_gnu_compat_mode_help_omits_conflicting_short_flags() {
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.env("LSP_COMPAT_MODE", "gnu").arg("--help");
+    let output = cmd.output().unwrap();
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(
+        "-p, --indicator-style=slash     Append / indicator to directories"
+    ));
+    assert!(!stdout.contains("--indicator-style[=<WORD>]"));
+    assert!(stdout.contains("--group-directories-first"));
+    assert!(!stdout.contains("-D,"));
+    assert!(!stdout.contains("-I,"));
+    assert!(!stdout.contains("-N,"));
+    assert!(!stdout.contains("-Z,"));
+}
+
+#[test]
+fn test_gnu_compat_mode_accepts_group_directories_first_long_option() {
+    let temp_dir = tempdir().unwrap();
+    fs::create_dir(temp_dir.path().join("zeta_dir")).unwrap();
+    fs::write(temp_dir.path().join("alpha.txt"), "alpha").unwrap();
+
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.env("LSP_COMPAT_MODE", "gnu")
+        .arg("--group-directories-first")
+        .arg(temp_dir.path());
+    let (stdout, _stderr) = run_and_capture(&mut cmd);
+
+    let dir_position = stdout.find("zeta_dir").unwrap();
+    let file_position = stdout.find("alpha.txt").unwrap();
+
+    assert!(dir_position < file_position);
+}
+
+#[test]
+fn test_gnu_compat_mode_rejects_native_sort_dirs_long_option() {
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.env("LSP_COMPAT_MODE", "gnu")
+        .arg("--sort-dirs")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "unexpected argument '--sort-dirs'",
+        ));
+}
+
+#[test]
+fn test_gnu_compat_mode_accepts_no_color_long_option() {
+    let temp_dir = tempdir().unwrap();
+    let file_path = temp_dir.path().join("plain.txt");
+    fs::write(&file_path, "plain").unwrap();
+
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.env("LSP_COMPAT_MODE", "gnu")
+        .arg("--no-color")
+        .arg("--no-icons")
+        .arg(&file_path);
+    let (stdout, _stderr) = run_and_capture_raw(&mut cmd);
+
+    assert!(!has_ansi(&stdout));
+    assert!(stdout.contains("plain.txt"));
+}
+
+#[test]
+fn test_gnu_compat_mode_accepts_gitignore_long_option() {
+    let temp_dir = tempdir().unwrap();
+    let ignored_file = temp_dir.path().join("ignored.log");
+    fs::create_dir(temp_dir.path().join(".git")).unwrap();
+    fs::write(temp_dir.path().join(".gitignore"), "*.log\n").unwrap();
+    fs::write(&ignored_file, "ignored").unwrap();
+
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.env("LSP_COMPAT_MODE", "gnu")
+        .arg("--gitignore")
+        .arg("--no-icons")
+        .arg(&ignored_file);
+    let (stdout, _stderr) = run_and_capture_raw(&mut cmd);
+
+    assert!(stdout.contains("ignored.log"));
+}
+
+#[test]
+fn test_gnu_compat_mode_accepts_fuzzy_time_long_option() {
+    let temp_dir = tempdir().unwrap();
+    let file_path = temp_dir.path().join("aged.txt");
+    fs::write(&file_path, "aged").unwrap();
+
+    let old_time = FileTime::from_system_time(
+        SystemTime::now()
+            .checked_sub(Duration::from_secs(2 * 60 * 60))
+            .unwrap(),
+    );
+    filetime::set_file_mtime(&file_path, old_time).unwrap();
+
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.env("LSP_COMPAT_MODE", "gnu")
+        .arg("-l")
+        .arg("--fuzzy-time")
+        .arg(&file_path);
+    let (stdout, _stderr) = run_and_capture(&mut cmd);
+
+    assert!(stdout.contains("aged.txt"));
+    assert!(stdout.contains("2 hours ago"));
+}
+
+#[test]
+fn test_gnu_compat_mode_accepts_indicator_style_slash() {
+    let temp_dir = tempdir().unwrap();
+    let child_dir = temp_dir.path().join("child");
+    fs::create_dir(&child_dir).unwrap();
+
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.env("LSP_COMPAT_MODE", "gnu")
+        .arg("--indicator-style=slash")
+        .arg("--no-icons")
+        .arg(temp_dir.path());
+    let (stdout, _stderr) = run_and_capture(&mut cmd);
+
+    assert!(stdout.contains("child/"));
+}
+
+#[test]
+fn test_gnu_compat_mode_rejects_native_slash_dirs_long_option() {
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.env("LSP_COMPAT_MODE", "gnu")
+        .arg("--slash-dirs")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "unexpected argument '--slash-dirs'",
+        ));
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -708,11 +708,14 @@ fn test_gnu_compat_mode_help_omits_conflicting_short_flags() {
     assert!(output.status.success());
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains(
-        "-p, --indicator-style=slash     Append / indicator to directories"
-    ));
-    assert!(!stdout.contains("--indicator-style[=<WORD>]"));
+    assert!(stdout.contains("-p"));
+    assert!(stdout.contains("Append / indicator to directories"));
+    assert!(stdout.contains("--indicator-style=<WORD>"));
+    assert!(
+        stdout.contains("Append indicator with style WORD to entry names")
+    );
     assert!(stdout.contains("--group-directories-first"));
+    assert!(!stdout.contains("--slash-dirs"));
     assert!(!stdout.contains("-D,"));
     assert!(!stdout.contains("-I,"));
     assert!(!stdout.contains("-N,"));
@@ -817,6 +820,22 @@ fn test_gnu_compat_mode_accepts_indicator_style_slash() {
     let mut cmd = Command::cargo_bin("lsp").unwrap();
     cmd.env("LSP_COMPAT_MODE", "gnu")
         .arg("--indicator-style=slash")
+        .arg("--no-icons")
+        .arg(temp_dir.path());
+    let (stdout, _stderr) = run_and_capture(&mut cmd);
+
+    assert!(stdout.contains("child/"));
+}
+
+#[test]
+fn test_gnu_compat_mode_accepts_short_p() {
+    let temp_dir = tempdir().unwrap();
+    let child_dir = temp_dir.path().join("child");
+    fs::create_dir(&child_dir).unwrap();
+
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.env("LSP_COMPAT_MODE", "gnu")
+        .arg("-p")
         .arg("--no-icons")
         .arg(temp_dir.path());
     let (stdout, _stderr) = run_and_capture(&mut cmd);


### PR DESCRIPTION
## Summary
Add a bootstrap GNU compatibility mode without changing native `lsplus` behavior.

This introduces startup mode selection from `LSP_COMPAT_MODE` or `compat_mode` in config, reserves the conflicting GNU short flags in `gnu` mode, and keeps the current `lsplus`-specific behavior in `native` mode.

## What changed
- add compatibility mode selection with env-over-config precedence
- build the CLI with the `clap` builder API so shared options stay in one parser path
- reserve `-D`, `-I`, `-N`, and `-Z` for GNU semantics in `gnu` mode and reject them until implemented
- expose GNU-mode names where supported, including `--group-directories-first` and `--indicator-style=slash`
- keep GNU mode on standard `clap` help output, with `-p` and `--indicator-style=slash` as separate entry points to the same behavior
- add and update tests for mode selection, parser behavior, help output, and integration coverage
- document the new compatibility mode in the README and mdBook docs

## Why
This gives `lsp` a functional GNU-compatible CLI surface for aliasing or scripting, without breaking the existing native command set. It also establishes the parser structure needed to implement the remaining GNU behaviors incrementally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Compatibility Mode with two CLI surfaces: native (default) and GNU-style; enable via config or LSP_COMPAT_MODE (env wins)
  * GNU-mode maps certain flags (e.g., -p → indicator-style=slash) and reserves conflicting short flags to error until implemented

* **Documentation**
  * Added comprehensive docs and examples for Compatibility Mode, config, environment override, and alias guidance

* **Tests**
  * Added unit and integration tests covering startup config precedence, invalid-mode errors, and GNU vs native CLI behaviours
<!-- end of auto-generated comment: release notes by coderabbit.ai -->