### PR TITLE
feat: add indicator style support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Curently, only a sub-set of the standard `ls` options are supported. These are:
 - `-a` / `--all` - Show hidden files
 - `-A` / `--almost-all` - Show hidden files, but don't show `.` and `..
 - `-p` / `--slash-dirs` - Append a '/' to directories
+- `--file-type` - Append type indicators except `*` for executables
+- `-F` / `--classify` - Append type indicators, including `*` for executables
+- `--no-indicators` - Disable file type indicators
 - `-l` / `--long` - Show long format listing
 - `-h` / `--human-readable` - Human readable file sizes
 - `-D` / `--sort-dirs` - Sort directories first
@@ -114,6 +117,18 @@ listing with hidden files, append a '/' to directories, and show human-readable
 file sizes.
 
 Use the `--help` option to see the full list of options.
+
+The indicator characters are:
+
+- `/` for directories
+- `@` for symlinks
+- `|` for FIFOs
+- `=` for sockets
+- `*` for executables, but only with `-F` / `--classify`
+
+In long format, native mode omits the symlink `@` marker because `name ->
+target` and the symlink styling already make the type clear. This also matches
+GNU `ls`, which does not append `@` to symlink names in long format.
 
 When `-I` is enabled, `lsp` checks the same ignore sources Git normally uses:
 merged `.gitignore` files in the worktree, `.git/info/exclude`, and the
@@ -175,8 +190,12 @@ available in `gnu` mode through their long forms only:
 - `--no-color`
 - `--fuzzy-time`
 
-In `gnu` mode, `-p` uses the GNU-style long form `--indicator-style=slash`
-instead of the native `--slash-dirs`.
+GNU indicator options are also available in `gnu` mode:
+
+- `-p` / `--indicator-style=slash`
+- `--file-type` / `--indicator-style=file-type`
+- `-F` / `--indicator-style=classify`
+- `--indicator-style=none`
 
 ### Configuration File
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ be used which are similar to the `ls` command.
 Curently, only a sub-set of the standard `ls` options are supported. These are:
 
 - `-a` / `--all` - Show hidden files
-- `-A` / `--almost-all` - Show hidden files, but don't show `.` and `..
+- `-A` / `--almost-all` - Show hidden files, but don't show `.` and `..`
 - `-p` / `--slash-dirs` - Append a '/' to directories
 - `--file-type` - Append type indicators except `*` for executables
 - `-F` / `--classify` - Append type indicators, including `*` for executables

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -48,14 +48,30 @@ This option corresponds to the `-A` or `--almost-all` command line option and
 will display all files and directories if set to `true`, except for `.` and
 `..`.
 
-### append_slash
+### indicator_style
 
-- Permitted values: `true` or `false`
-- Default value: `false`
+- Permitted values: `"none"`, `"slash"`, `"file-type"`, or `"classify"`
+- Default value: `"none"`
 
-This option corresponds to the `-p` or `--slash-dirs` command line option and
-will append a slash to directories if set to `true`. In `gnu` compatibility
-mode, the equivalent long option is `--indicator-style=slash`.
+This option selects which file type indicators `lsp` appends to entry names.
+In native mode, the related CLI options are `-p` / `--slash-dirs`,
+`--file-type`, `-F` / `--classify`, and `--no-indicators`. In `gnu`
+compatibility mode, the equivalent GNU forms are `-p`,
+`--indicator-style=slash`, `--file-type`,
+`--indicator-style=file-type`, `-F`, `--indicator-style=classify`, and
+`--indicator-style=none`.
+
+The indicator characters are `/` for directories, `@` for symlinks, `|` for
+FIFOs, `=` for sockets, and `*` for executables. The `*` executable marker is
+only added by `"classify"`.
+
+In long format, native mode omits the symlink `@` marker because `name ->
+target` and the symlink styling already make the type clear. This also matches
+GNU `ls`, which does not append `@` to symlink names in long format.
+
+For backward compatibility, `append_slash = true` is still accepted in the
+config file and maps to `indicator_style = "slash"`. If both are present,
+`indicator_style` takes precedence.
 
 ### dirs_first
 
@@ -125,7 +141,7 @@ options that are not set will use the default values:
 ```toml
 # compat_mode = "native"  # or "gnu" for GNU ls compatibility
 show_all = true
-append_slash = true
+indicator_style = "classify"
 dirs_first = true
 human_readable = true
 no_color = true

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -15,6 +15,9 @@ Curently, only a sub-set of the standard `ls` options are supported. These are:
 - `-a` / `--all` - Show hidden files
 - `-A` / `--almost-all` - Show hidden files, but don't show `.` and `..
 - `-p` / `--slash-dirs` - Append a '/' to directories
+- `--file-type` - Append type indicators except `*` for executables
+- `-F` / `--classify` - Append type indicators, including `*` for executables
+- `--no-indicators` - Disable file type indicators
 - `-l` / `--long` - Show long format listing
 - `-h` / `--human-readable` - Human readable file sizes
 - `-D` / `--sort-dirs` - Sort directories first
@@ -29,6 +32,18 @@ listing with hidden files, append a '/' to directories, and show human-readable
 file sizes.
 
 Use the `--help` option to see the full list of options.
+
+The indicator characters are:
+
+- `/` for directories
+- `@` for symlinks
+- `|` for FIFOs
+- `=` for sockets
+- `*` for executables, but only with `-F` / `--classify`
+
+In long format, native mode omits the symlink `@` marker because `name ->
+target` and the symlink styling already make the type clear. This also matches
+GNU `ls`, which does not append `@` to symlink names in long format.
 
 Styled output is enabled automatically when writing to a terminal. Captured,
 piped, and redirected output is plain by default. You can also disable styled
@@ -63,8 +78,12 @@ available in `gnu` mode through their long forms only:
 - `--no-color`
 - `--fuzzy-time`
 
-In `gnu` mode, `-p` uses the GNU-style long form `--indicator-style=slash`
-instead of the native `--slash-dirs`.
+GNU indicator options are also available in `gnu` mode:
+
+- `-p` / `--indicator-style=slash`
+- `--file-type` / `--indicator-style=file-type`
+- `-F` / `--indicator-style=classify`
+- `--indicator-style=none`
 
 ## Fuzzy Time
 

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -13,7 +13,7 @@ be used which are similar to the `ls` command.
 Curently, only a sub-set of the standard `ls` options are supported. These are:
 
 - `-a` / `--all` - Show hidden files
-- `-A` / `--almost-all` - Show hidden files, but don't show `.` and `..
+- `-A` / `--almost-all` - Show hidden files, but don't show `.` and `..`
 - `-p` / `--slash-dirs` - Append a '/' to directories
 - `--file-type` - Append type indicators except `*` for executables
 - `-F` / `--classify` - Append type indicators, including `*` for executables

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,9 +4,12 @@
 //! compatibility mode. Both modes map into the same internal [`Flags`] type so
 //! the rest of the application can work with one normalized representation.
 
+use clap::ArgGroup;
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use std::env;
 use std::ffi::OsString;
+
+use crate::IndicatorStyle;
 
 const ARG_SHOW_ALL: &str = "show_all";
 const ARG_ALMOST_ALL: &str = "almost_all";
@@ -15,6 +18,9 @@ const ARG_HUMAN_READABLE: &str = "human_readable";
 const ARG_PATHS: &str = "paths";
 const ARG_SLASH: &str = "slash";
 const ARG_INDICATOR_STYLE: &str = "indicator_style";
+const ARG_FILE_TYPE: &str = "file_type";
+const ARG_CLASSIFY: &str = "classify";
+const ARG_NO_INDICATORS: &str = "no_indicators";
 const ARG_DIRS_FIRST: &str = "dirs_first";
 const ARG_NO_ICONS: &str = "no_icons";
 const ARG_NO_COLOR: &str = "no_color";
@@ -22,10 +28,12 @@ const ARG_GITIGNORE: &str = "gitignore";
 const ARG_VERSION: &str = "version";
 const ARG_FUZZY_TIME: &str = "fuzzy_time";
 const ARG_HELP: &str = "help";
+const ARG_INDICATOR_GROUP: &str = "indicator_style_group";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CompatMode {
     /// Parse arguments using the native `lsplus` option set.
+    #[default]
     Native,
     /// Parse arguments using the GNU-compatible option set.
     Gnu,
@@ -57,8 +65,8 @@ pub struct Flags {
     pub human_readable: bool,
     /// Raw path arguments collected from the CLI.
     pub paths: Vec<String>,
-    /// Append a directory indicator in the active CLI mode.
-    pub slash: bool,
+    /// Override the configured indicator style for this invocation.
+    pub indicator_style: Option<IndicatorStyle>,
     /// Group directories before files.
     pub dirs_first: bool,
     /// Disable file and directory icons.
@@ -134,18 +142,36 @@ fn build_command(mode: CompatMode) -> Command {
         .arg(human_readable_arg())
         .arg(paths_arg())
         .arg(slash_arg(mode))
+        .arg(file_type_arg(mode))
+        .arg(classify_arg(mode))
         .arg(dirs_first_arg(mode))
         .arg(no_icons_arg())
         .arg(no_color_arg(mode))
         .arg(gitignore_arg(mode))
         .arg(version_arg())
         .arg(fuzzy_time_arg(mode))
-        .arg(help_arg());
+        .arg(help_arg())
+        .group(indicator_group(mode));
 
     match mode {
-        CompatMode::Native => command,
+        CompatMode::Native => command.arg(no_indicators_arg()),
         CompatMode::Gnu => command.arg(indicator_style_arg()),
     }
+}
+
+fn indicator_group(mode: CompatMode) -> ArgGroup {
+    let args = match mode {
+        CompatMode::Native => {
+            vec![ARG_SLASH, ARG_FILE_TYPE, ARG_CLASSIFY, ARG_NO_INDICATORS]
+        }
+        CompatMode::Gnu => {
+            vec![ARG_SLASH, ARG_INDICATOR_STYLE, ARG_FILE_TYPE, ARG_CLASSIFY]
+        }
+    };
+
+    ArgGroup::new(ARG_INDICATOR_GROUP)
+        .multiple(false)
+        .args(args)
 }
 
 fn help_arg() -> Arg {
@@ -210,13 +236,39 @@ fn slash_arg(mode: CompatMode) -> Arg {
     }
 }
 
+fn file_type_arg(_mode: CompatMode) -> Arg {
+    Arg::new(ARG_FILE_TYPE)
+        .long("file-type")
+        .action(ArgAction::SetTrue)
+        .help("Append type indicators except '*' for executables")
+}
+
+fn classify_arg(mode: CompatMode) -> Arg {
+    let arg = Arg::new(ARG_CLASSIFY)
+        .short('F')
+        .action(ArgAction::SetTrue)
+        .help("Append type indicators, including '*' for executables");
+
+    match mode {
+        CompatMode::Native => arg.long("classify"),
+        CompatMode::Gnu => arg,
+    }
+}
+
+fn no_indicators_arg() -> Arg {
+    Arg::new(ARG_NO_INDICATORS)
+        .long("no-indicators")
+        .action(ArgAction::SetTrue)
+        .help("Do not append file type indicators")
+}
+
 fn indicator_style_arg() -> Arg {
     Arg::new(ARG_INDICATOR_STYLE)
         .long("indicator-style")
         .action(ArgAction::Set)
         .require_equals(true)
         .value_name("WORD")
-        .value_parser(["slash"])
+        .value_parser(["none", "slash", "file-type", "classify"])
         .help("Append indicator with style WORD to entry names")
 }
 
@@ -302,21 +354,49 @@ fn flags_from_matches(mode: CompatMode, matches: &ArgMatches) -> Flags {
             .get_many::<String>(ARG_PATHS)
             .map(|values| values.cloned().collect())
             .unwrap_or_else(|| vec![String::from(".")]),
-        slash: match mode {
-            CompatMode::Native => matches.get_flag(ARG_SLASH),
-            CompatMode::Gnu => {
-                matches.get_flag(ARG_SLASH)
-                    || matches
-                        .get_one::<String>(ARG_INDICATOR_STYLE)
-                        .is_some_and(|value| value == "slash")
-            }
-        },
+        indicator_style: indicator_style_from_matches(mode, matches),
         dirs_first: matches.get_flag(ARG_DIRS_FIRST),
         no_icons: matches.get_flag(ARG_NO_ICONS),
         no_color: matches.get_flag(ARG_NO_COLOR),
         gitignore: matches.get_flag(ARG_GITIGNORE),
         version: matches.get_flag(ARG_VERSION),
         fuzzy_time: matches.get_flag(ARG_FUZZY_TIME),
+    }
+}
+
+fn indicator_style_from_matches(
+    mode: CompatMode,
+    matches: &ArgMatches,
+) -> Option<IndicatorStyle> {
+    if matches.get_flag(ARG_SLASH) {
+        return Some(IndicatorStyle::Slash);
+    }
+
+    if matches.get_flag(ARG_FILE_TYPE) {
+        return Some(IndicatorStyle::FileType);
+    }
+
+    if matches.get_flag(ARG_CLASSIFY) {
+        return Some(IndicatorStyle::Classify);
+    }
+
+    match mode {
+        CompatMode::Native => {
+            if matches.get_flag(ARG_NO_INDICATORS) {
+                Some(IndicatorStyle::None)
+            } else {
+                None
+            }
+        }
+        CompatMode::Gnu => matches
+            .get_one::<String>(ARG_INDICATOR_STYLE)
+            .and_then(|value| match value.as_str() {
+                "none" => Some(IndicatorStyle::None),
+                "slash" => Some(IndicatorStyle::Slash),
+                "file-type" => Some(IndicatorStyle::FileType),
+                "classify" => Some(IndicatorStyle::Classify),
+                _ => None,
+            }),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub mod settings;
 pub mod structs;
 pub mod utils;
 
-pub use structs::{FileInfo, NameStyle, Params};
+pub use structs::{FileInfo, IndicatorStyle, NameStyle, Params};
 
 #[cfg(test)]
 #[path = "../tests/crate/app.rs"]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 
 use crate::Params;
 use crate::cli::CompatMode;
+use crate::structs::RawParams;
 
 /// Environment variable that forces the startup compatibility mode.
 ///
@@ -24,7 +25,7 @@ pub struct StartupConfig {
 #[derive(Debug, Deserialize, PartialEq, Default)]
 struct ParsedConfig {
     #[serde(default, flatten)]
-    params: Params,
+    params: RawParams,
     compat_mode: Option<String>,
 }
 
@@ -47,7 +48,7 @@ pub fn load_config() -> Params {
 
 pub(crate) fn load_config_from_path(config_path: Option<PathBuf>) -> Params {
     load_parsed_config_from_path(config_path)
-        .map(|config| config.params)
+        .map(|config| config.params.into())
         .unwrap_or_default()
 }
 
@@ -73,7 +74,7 @@ pub(crate) fn load_startup_config_from(
 
     Ok(StartupConfig {
         params: parsed_config
-            .map(|config| config.params)
+            .map(|config| config.params.into())
             .unwrap_or_default(),
         compat_mode,
     })

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -7,23 +7,22 @@ use std::time::SystemTime;
 
 use crate::cli;
 
-macro_rules! config_to_params {
-    ($settings:expr_2021, $params:ident, $( $field:ident ),* ) => {
-        $(
-            if let Ok(value) = $settings.get_bool(stringify!($field)) {
-                $params.$field = value;
-            }
-        )*
-    };
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum IndicatorStyle {
+    #[default]
+    None,
+    Slash,
+    FileType,
+    Classify,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Default)]
-#[serde(default)]
+#[derive(Debug, PartialEq, Default)]
 pub struct Params {
     /// Show entries whose names start with `.`.
     pub show_all: bool,
-    /// Append a trailing `/` to directory names.
-    pub append_slash: bool,
+    /// Select which file indicator style to render.
+    pub indicator_style: IndicatorStyle,
     /// Group directories before files.
     pub dirs_first: bool,
     /// Hide `.` and `..` while still showing other dotfiles.
@@ -42,6 +41,22 @@ pub struct Params {
     pub fuzzy_time: bool,
 }
 
+#[derive(Debug, Deserialize, PartialEq, Default)]
+#[serde(default)]
+pub(crate) struct RawParams {
+    show_all: bool,
+    dirs_first: bool,
+    almost_all: bool,
+    long_format: bool,
+    human_readable: bool,
+    no_icons: bool,
+    no_color: bool,
+    gitignore: bool,
+    fuzzy_time: bool,
+    indicator_style: Option<IndicatorStyle>,
+    append_slash: Option<bool>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum NameStyle {
     #[default]
@@ -53,24 +68,33 @@ pub enum NameStyle {
 
 impl From<Config> for Params {
     fn from(settings: Config) -> Self {
-        let mut params = Params::default();
+        settings
+            .try_deserialize::<RawParams>()
+            .map(Into::into)
+            .unwrap_or_default()
+    }
+}
 
-        config_to_params!(
-            settings,
-            params,
-            show_all,
-            append_slash,
-            dirs_first,
-            almost_all,
-            long_format,
-            human_readable,
-            no_icons,
-            no_color,
-            gitignore,
-            fuzzy_time
-        );
-
-        params
+impl From<RawParams> for Params {
+    fn from(raw: RawParams) -> Self {
+        Self {
+            show_all: raw.show_all,
+            indicator_style: raw.indicator_style.unwrap_or_else(|| {
+                if raw.append_slash.unwrap_or(false) {
+                    IndicatorStyle::Slash
+                } else {
+                    IndicatorStyle::None
+                }
+            }),
+            dirs_first: raw.dirs_first,
+            almost_all: raw.almost_all,
+            long_format: raw.long_format,
+            human_readable: raw.human_readable,
+            no_icons: raw.no_icons,
+            no_color: raw.no_color,
+            gitignore: raw.gitignore,
+            fuzzy_time: raw.fuzzy_time,
+        }
     }
 }
 
@@ -78,11 +102,15 @@ impl Params {
     /// Merge parsed CLI flags with config-file defaults.
     ///
     /// Boolean options are treated as opt-in toggles, so a value is enabled if
-    /// either the command line or the config file enables it.
+    /// either the command line or the config file enables it. Indicator style
+    /// is selected by explicit CLI override when present, otherwise the config
+    /// value is used.
     pub fn merge(flags: &cli::Flags, config: &Self) -> Self {
         Self {
             show_all: flags.show_all || config.show_all,
-            append_slash: flags.slash || config.append_slash,
+            indicator_style: flags
+                .indicator_style
+                .unwrap_or(config.indicator_style),
             dirs_first: flags.dirs_first || config.dirs_first,
             almost_all: flags.almost_all || config.almost_all,
             long_format: flags.long || config.long_format,

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -433,12 +433,12 @@ fn file_type_indicator_suffix(
         "/"
     } else if metadata.is_symlink() {
         "@"
-    } else if classify_executables && is_executable(metadata) {
-        "*"
     } else if metadata.file_type().is_fifo() {
         "|"
     } else if metadata.file_type().is_socket() {
         "="
+    } else if classify_executables && is_executable(metadata) {
+        "*"
     } else {
         ""
     }

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -3,10 +3,11 @@ use nix::unistd::{Group, User};
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io;
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
+use crate::IndicatorStyle;
 use crate::Params;
 use crate::structs::FileInfo;
 use crate::structs::NameStyle;
@@ -282,11 +283,9 @@ fn create_file_info_from_metadata_with_gitignore(
         file_name = file_name.replacen("./", "", 1);
     }
 
-    let mut safe_file_name = sanitize_for_terminal(&file_name);
-
-    if params.append_slash && metadata.is_dir() {
-        safe_file_name.push('/');
-    }
+    let safe_file_name = sanitize_for_terminal(&file_name);
+    let indicated_file_name =
+        format_name_with_indicator(&safe_file_name, metadata, params);
 
     let ignored = params.gitignore
         && gitignore_cache.is_ignored(path, metadata.is_dir());
@@ -294,19 +293,19 @@ fn create_file_info_from_metadata_with_gitignore(
     let (display_name, short_name, name_style) = if metadata.is_symlink() {
         (
             format_symlink_display_name_with_dim(
-                &safe_file_name,
+                &indicated_file_name,
                 path,
                 fs::read_link(path),
                 params,
                 ignored,
             ),
-            format!("{safe_file_name}{}", symlink_short_suffix(params)),
+            indicated_file_name.clone(),
             NameStyle::Symlink,
         )
     } else {
         (
-            colorize_name_by_metadata(&safe_file_name, metadata, ignored),
-            safe_file_name.clone(),
+            colorize_name_by_metadata(&indicated_file_name, metadata, ignored),
+            indicated_file_name.clone(),
             name_style_by_metadata(metadata),
         )
     };
@@ -397,8 +396,52 @@ fn sanitize_path_for_terminal(path: &Path) -> String {
     sanitize_for_terminal(&path.to_string_lossy())
 }
 
-fn symlink_short_suffix(params: &Params) -> &'static str {
-    if params.append_slash { "*" } else { "" }
+fn format_name_with_indicator(
+    safe_name: &str,
+    metadata: &fs::Metadata,
+    params: &Params,
+) -> String {
+    format!("{safe_name}{}", indicator_suffix(metadata, params))
+}
+
+fn indicator_suffix(metadata: &fs::Metadata, params: &Params) -> &'static str {
+    if metadata.is_symlink() && params.long_format {
+        return "";
+    }
+
+    match params.indicator_style {
+        IndicatorStyle::None => "",
+        IndicatorStyle::Slash => {
+            if metadata.is_dir() {
+                "/"
+            } else {
+                ""
+            }
+        }
+        IndicatorStyle::FileType => {
+            file_type_indicator_suffix(metadata, false)
+        }
+        IndicatorStyle::Classify => file_type_indicator_suffix(metadata, true),
+    }
+}
+
+fn file_type_indicator_suffix(
+    metadata: &fs::Metadata,
+    classify_executables: bool,
+) -> &'static str {
+    if metadata.is_dir() {
+        "/"
+    } else if metadata.is_symlink() {
+        "@"
+    } else if classify_executables && is_executable(metadata) {
+        "*"
+    } else if metadata.file_type().is_fifo() {
+        "|"
+    } else if metadata.file_type().is_socket() {
+        "="
+    } else {
+        ""
+    }
 }
 
 fn apply_dim(style: StyledText, dimmed: bool) -> StyledText {
@@ -451,7 +494,7 @@ fn is_executable(metadata: &fs::Metadata) -> bool {
 }
 
 pub(crate) fn format_symlink_display_name_with_dim(
-    safe_file_name: &str,
+    source_name: &str,
     path: &Path,
     target: io::Result<PathBuf>,
     params: &Params,
@@ -479,14 +522,14 @@ pub(crate) fn format_symlink_display_name_with_dim(
                 if target_path.exists() {
                     format!(
                         "{}{}{}",
-                        apply_dim(safe_file_name.cyan(), dimmed),
+                        apply_dim(source_name.cyan(), dimmed),
                         plain_text(" -> ", dimmed),
                         display_target
                     )
                 } else {
                     format!(
                         "{}{}{}{}{}",
-                        apply_dim(safe_file_name.cyan(), dimmed),
+                        apply_dim(source_name.cyan(), dimmed),
                         plain_text(" -> ", dimmed),
                         display_target,
                         plain_text(" ", dimmed),
@@ -494,34 +537,18 @@ pub(crate) fn format_symlink_display_name_with_dim(
                     )
                 }
             } else {
-                apply_dim(
-                    format!(
-                        "{safe_file_name}{}",
-                        symlink_short_suffix(params)
-                    )
-                    .cyan(),
-                    dimmed,
-                )
-                .to_string()
+                apply_dim(source_name.cyan(), dimmed).to_string()
             }
         }
         Err(_) => {
             if params.long_format {
                 apply_dim(
-                    format!("{safe_file_name} -> (unreadable)").red(),
+                    format!("{source_name} -> (unreadable)").red(),
                     dimmed,
                 )
                 .to_string()
             } else {
-                apply_dim(
-                    format!(
-                        "{safe_file_name}{}",
-                        symlink_short_suffix(params)
-                    )
-                    .cyan(),
-                    dimmed,
-                )
-                .to_string()
+                apply_dim(source_name.cyan(), dimmed).to_string()
             }
         }
     }

--- a/tests/crate/app.rs
+++ b/tests/crate/app.rs
@@ -78,7 +78,7 @@ fn test_run_with_flags_lists_matching_entries() {
             long: false,
             human_readable: false,
             paths: vec![temp_dir.path().display().to_string()],
-            slash: false,
+            indicator_style: None,
             dirs_first: false,
             no_icons: true,
             no_color: false,

--- a/tests/crate/cli.rs
+++ b/tests/crate/cli.rs
@@ -1,3 +1,4 @@
+use crate::IndicatorStyle;
 use crate::cli::{
     CompatMode, Flags, format_version_info, try_parse_from_mode, version_info,
 };
@@ -9,7 +10,7 @@ fn test_default_flags() {
     assert!(!args.almost_all);
     assert!(!args.long);
     assert!(!args.human_readable);
-    assert!(!args.slash);
+    assert_eq!(args.indicator_style, None);
     assert!(!args.dirs_first);
     assert!(!args.no_icons);
     assert!(!args.no_color);
@@ -47,7 +48,7 @@ fn test_all_flags() {
     assert!(args.almost_all);
     assert!(args.long);
     assert!(args.human_readable);
-    assert!(args.slash);
+    assert_eq!(args.indicator_style, Some(IndicatorStyle::Slash));
     assert!(args.dirs_first);
     assert!(args.no_icons);
     assert!(args.no_color);
@@ -142,7 +143,7 @@ fn test_parse_from_mode_gnu_accepts_long_options_for_conflicts() {
     )
     .unwrap();
 
-    assert!(args.slash);
+    assert_eq!(args.indicator_style, Some(IndicatorStyle::Slash));
     assert!(args.dirs_first);
     assert!(args.gitignore);
     assert!(args.no_color);
@@ -156,6 +157,8 @@ fn test_parse_from_mode_gnu_help_omits_conflicting_short_flags() {
     let help = err.to_string();
 
     assert!(help.contains("-p"));
+    assert!(help.contains("--file-type"));
+    assert!(help.contains("-F"));
     assert!(help.contains("--indicator-style"));
     assert!(help.contains("--group-directories-first"));
     assert!(!help.contains("--slash-dirs"));
@@ -169,7 +172,63 @@ fn test_parse_from_mode_gnu_help_omits_conflicting_short_flags() {
 fn test_parse_from_mode_gnu_short_p_sets_slash() {
     let args = try_parse_from_mode(CompatMode::Gnu, ["lsplus", "-p"]).unwrap();
 
-    assert!(args.slash);
+    assert_eq!(args.indicator_style, Some(IndicatorStyle::Slash));
+}
+
+#[test]
+fn test_parse_from_mode_native_accepts_file_type_and_classify_options() {
+    let file_type =
+        try_parse_from_mode(CompatMode::Native, ["lsplus", "--file-type"])
+            .unwrap();
+    let classify =
+        try_parse_from_mode(CompatMode::Native, ["lsplus", "-F"]).unwrap();
+    let no_indicators =
+        try_parse_from_mode(CompatMode::Native, ["lsplus", "--no-indicators"])
+            .unwrap();
+
+    assert_eq!(file_type.indicator_style, Some(IndicatorStyle::FileType));
+    assert_eq!(classify.indicator_style, Some(IndicatorStyle::Classify));
+    assert_eq!(no_indicators.indicator_style, Some(IndicatorStyle::None));
+}
+
+#[test]
+fn test_parse_from_mode_gnu_accepts_indicator_style_variants() {
+    let file_type = try_parse_from_mode(
+        CompatMode::Gnu,
+        ["lsplus", "--indicator-style=file-type"],
+    )
+    .unwrap();
+    let classify = try_parse_from_mode(
+        CompatMode::Gnu,
+        ["lsplus", "--indicator-style=classify"],
+    )
+    .unwrap();
+    let none = try_parse_from_mode(
+        CompatMode::Gnu,
+        ["lsplus", "--indicator-style=none"],
+    )
+    .unwrap();
+
+    assert_eq!(file_type.indicator_style, Some(IndicatorStyle::FileType));
+    assert_eq!(classify.indicator_style, Some(IndicatorStyle::Classify));
+    assert_eq!(none.indicator_style, Some(IndicatorStyle::None));
+}
+
+#[test]
+fn test_parse_from_mode_rejects_conflicting_indicator_options() {
+    let native_err = try_parse_from_mode(
+        CompatMode::Native,
+        ["lsplus", "-p", "--file-type"],
+    )
+    .unwrap_err();
+    let gnu_err = try_parse_from_mode(
+        CompatMode::Gnu,
+        ["lsplus", "-F", "--indicator-style=file-type"],
+    )
+    .unwrap_err();
+
+    assert!(native_err.to_string().contains("cannot be used"));
+    assert!(gnu_err.to_string().contains("cannot be used"));
 }
 
 #[test]
@@ -179,6 +238,17 @@ fn test_parse_from_mode_gnu_rejects_native_slash_dirs_long_option() {
 
     assert!(err.to_string().contains("unexpected argument"));
     assert!(err.to_string().contains("--slash-dirs"));
+}
+
+#[test]
+fn test_parse_from_mode_gnu_rejects_native_classify_and_no_indicators() {
+    for flag in ["--classify", "--no-indicators"] {
+        let err = try_parse_from_mode(CompatMode::Gnu, ["lsplus", flag])
+            .unwrap_err();
+
+        assert!(err.to_string().contains("unexpected argument"));
+        assert!(err.to_string().contains(flag));
+    }
 }
 
 #[test]

--- a/tests/crate/file.rs
+++ b/tests/crate/file.rs
@@ -736,4 +736,5 @@ fn test_format_symlink_display_name_unreadable_short_format_omits_marker_without
 
     assert!(short.contains("link"));
     assert!(!short.contains('*'));
+    assert!(!short.contains('@'));
 }

--- a/tests/crate/file.rs
+++ b/tests/crate/file.rs
@@ -19,6 +19,8 @@ use tempfile::tempdir;
 
 #[cfg(unix)]
 use std::os::unix::ffi::OsStringExt;
+#[cfg(unix)]
+use std::os::unix::net::UnixListener;
 
 const BLUE_DOT: &str = "\u{1b}[34m.\u{1b}[0m";
 const BLUE_DOTDOT: &str = "\u{1b}[34m..\u{1b}[0m";
@@ -398,6 +400,40 @@ fn test_create_file_info_marks_fifo_as_unknown_type() {
     let info = create_file_info(&fifo_path, &Params::default()).unwrap();
 
     assert_eq!(info.file_type, "?");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_create_file_info_classify_prefers_fifo_and_socket_indicators() {
+    let temp_dir = tempdir().unwrap();
+    let fifo_path = temp_dir.path().join("pipe");
+    let socket_path = temp_dir.path().join("socket");
+    let status = Command::new("mkfifo").arg(&fifo_path).status().unwrap();
+    assert!(status.success());
+
+    let _listener = UnixListener::bind(&socket_path).unwrap();
+
+    fs::set_permissions(&fifo_path, fs::Permissions::from_mode(0o755))
+        .unwrap();
+    fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o755))
+        .unwrap();
+
+    let fifo_metadata = fs::symlink_metadata(&fifo_path).unwrap();
+    let socket_metadata = fs::symlink_metadata(&socket_path).unwrap();
+    assert_ne!(fifo_metadata.permissions().mode() & 0o111, 0);
+    assert_ne!(socket_metadata.permissions().mode() & 0o111, 0);
+
+    let params = Params {
+        indicator_style: IndicatorStyle::Classify,
+        ..Params::default()
+    };
+    let fifo_info = create_file_info(&fifo_path, &params).unwrap();
+    let socket_info = create_file_info(&socket_path, &params).unwrap();
+
+    assert!(strip_str(&fifo_info.display_name).ends_with('|'));
+    assert!(!strip_str(&fifo_info.display_name).ends_with('*'));
+    assert!(strip_str(&socket_info.display_name).ends_with('='));
+    assert!(!strip_str(&socket_info.display_name).ends_with('*'));
 }
 
 #[cfg(unix)]

--- a/tests/crate/file.rs
+++ b/tests/crate/file.rs
@@ -553,31 +553,7 @@ fn test_format_symlink_display_name_short_format_uses_at_for_file_type() {
 
 #[test]
 #[cfg(unix)]
-fn test_create_file_info_omits_symlink_at_in_native_long_mode() {
-    let temp_dir = tempdir().unwrap();
-    let target = temp_dir.path().join("target.txt");
-    let link = temp_dir.path().join("link");
-
-    fs::write(&target, "target").unwrap();
-    std::os::unix::fs::symlink(&target, &link).unwrap();
-
-    let info = create_file_info(
-        &link,
-        &Params {
-            long_format: true,
-            indicator_style: IndicatorStyle::FileType,
-            ..Params::default()
-        },
-    )
-    .unwrap();
-
-    assert!(strip_str(&info.display_name).contains("link -> "));
-    assert!(!strip_str(&info.display_name).contains("link@ -> "));
-}
-
-#[test]
-#[cfg(unix)]
-fn test_create_file_info_keeps_symlink_at_in_gnu_long_mode() {
+fn test_create_file_info_omits_symlink_at_in_long_mode() {
     let temp_dir = tempdir().unwrap();
     let target = temp_dir.path().join("target.txt");
     let link = temp_dir.path().join("link");

--- a/tests/crate/file.rs
+++ b/tests/crate/file.rs
@@ -4,7 +4,7 @@ use crate::utils::file::{
     create_file_info, format_path_error, format_symlink_display_name_with_dim,
     get_groupname, get_username, sanitize_for_terminal,
 };
-use crate::{FileInfo, NameStyle, Params};
+use crate::{FileInfo, IndicatorStyle, NameStyle, Params};
 use colored_text::{ColorMode, ColorizeConfig};
 use std::ffi::OsString;
 use std::fs::{self, File};
@@ -304,7 +304,7 @@ fn test_create_file_info_handles_regular_files_symlinks_and_special_cases() {
     let dir_info = create_file_info(
         &dir_path,
         &Params {
-            append_slash: true,
+            indicator_style: IndicatorStyle::Slash,
             ..Params::default()
         },
     )
@@ -469,7 +469,7 @@ fn test_get_username_and_groupname_fall_back_to_ids() {
 fn test_format_symlink_display_name_handles_unreadable_targets() {
     let params = Params {
         long_format: true,
-        append_slash: true,
+        indicator_style: IndicatorStyle::FileType,
         ..Params::default()
     };
     let unreadable = format_symlink_display_name_with_dim(
@@ -482,16 +482,16 @@ fn test_format_symlink_display_name_handles_unreadable_targets() {
     assert!(unreadable.contains("(unreadable)"));
 
     let short = format_symlink_display_name_with_dim(
-        "broken-link",
+        "broken-link@",
         Path::new("/tmp/broken-link"),
         Err(io::Error::other("boom")),
         &Params {
-            append_slash: true,
+            indicator_style: IndicatorStyle::FileType,
             ..Params::default()
         },
         false,
     );
-    assert!(short.contains('*'));
+    assert!(short.contains('@'));
 }
 
 #[test]
@@ -518,7 +518,7 @@ fn test_collect_visible_file_names_handles_empty_entries() {
 }
 
 #[test]
-fn test_format_symlink_display_name_short_format_omits_marker_without_append_slash()
+fn test_format_symlink_display_name_short_format_omits_marker_without_indicator()
  {
     let short = format_symlink_display_name_with_dim(
         "link",
@@ -530,23 +530,73 @@ fn test_format_symlink_display_name_short_format_omits_marker_without_append_sla
 
     assert!(short.contains("link"));
     assert!(!short.contains('*'));
+    assert!(!short.contains('@'));
 }
 
 #[test]
-fn test_format_symlink_display_name_short_format_marks_append_slash() {
+fn test_format_symlink_display_name_short_format_uses_at_for_file_type() {
     let short = format_symlink_display_name_with_dim(
-        "link",
+        "link@",
         Path::new("/tmp/link"),
         Ok(PathBuf::from("target")),
         &Params {
-            append_slash: true,
+            indicator_style: IndicatorStyle::FileType,
             ..Params::default()
         },
         false,
     );
 
     assert!(short.contains("link"));
-    assert!(short.contains('*'));
+    assert!(short.contains('@'));
+    assert!(!short.contains('*'));
+}
+
+#[test]
+#[cfg(unix)]
+fn test_create_file_info_omits_symlink_at_in_native_long_mode() {
+    let temp_dir = tempdir().unwrap();
+    let target = temp_dir.path().join("target.txt");
+    let link = temp_dir.path().join("link");
+
+    fs::write(&target, "target").unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let info = create_file_info(
+        &link,
+        &Params {
+            long_format: true,
+            indicator_style: IndicatorStyle::FileType,
+            ..Params::default()
+        },
+    )
+    .unwrap();
+
+    assert!(strip_str(&info.display_name).contains("link -> "));
+    assert!(!strip_str(&info.display_name).contains("link@ -> "));
+}
+
+#[test]
+#[cfg(unix)]
+fn test_create_file_info_keeps_symlink_at_in_gnu_long_mode() {
+    let temp_dir = tempdir().unwrap();
+    let target = temp_dir.path().join("target.txt");
+    let link = temp_dir.path().join("link");
+
+    fs::write(&target, "target").unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let info = create_file_info(
+        &link,
+        &Params {
+            long_format: true,
+            indicator_style: IndicatorStyle::FileType,
+            ..Params::default()
+        },
+    )
+    .unwrap();
+
+    assert!(strip_str(&info.display_name).contains("link -> "));
+    assert!(!strip_str(&info.display_name).contains("link@ -> "));
 }
 
 #[test]
@@ -662,7 +712,7 @@ fn test_gitignored_entries_are_dimmed_when_color_is_enabled() {
 }
 
 #[test]
-fn test_format_symlink_display_name_unreadable_short_format_omits_marker_without_append_slash()
+fn test_format_symlink_display_name_unreadable_short_format_omits_marker_without_indicator()
  {
     let short = format_symlink_display_name_with_dim(
         "link",

--- a/tests/crate/settings.rs
+++ b/tests/crate/settings.rs
@@ -1,9 +1,9 @@
-use crate::Params;
 use crate::cli::CompatMode;
 use crate::settings::{
     StartupConfig, config_path_from_home, load_config, load_config_from_path,
     load_startup_config_from,
 };
+use crate::{IndicatorStyle, Params};
 use std::fs;
 use std::path::PathBuf;
 use tempfile::tempdir;
@@ -53,7 +53,7 @@ fn test_load_config_reads_boolean_settings_from_home_config() {
         config_dir.join("config.toml"),
         r#"
             show_all = true
-            append_slash = true
+            indicator_style = "classify"
             dirs_first = true
             almost_all = true
             long_format = true
@@ -71,7 +71,7 @@ fn test_load_config_reads_boolean_settings_from_home_config() {
             load_config(),
             Params {
                 show_all: true,
-                append_slash: true,
+                indicator_style: IndicatorStyle::Classify,
                 dirs_first: true,
                 almost_all: true,
                 long_format: true,
@@ -80,6 +80,47 @@ fn test_load_config_reads_boolean_settings_from_home_config() {
                 no_color: true,
                 gitignore: true,
                 fuzzy_time: true,
+            }
+        );
+    });
+}
+
+#[test]
+fn test_load_config_maps_append_slash_alias_to_indicator_style() {
+    let temp_dir = tempdir().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("lsplus");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(config_dir.join("config.toml"), "append_slash = true\n")
+        .unwrap();
+
+    temp_env::with_var("HOME", Some(temp_dir.path()), || {
+        assert_eq!(
+            load_config(),
+            Params {
+                indicator_style: IndicatorStyle::Slash,
+                ..Params::default()
+            }
+        );
+    });
+}
+
+#[test]
+fn test_load_config_prefers_indicator_style_over_append_slash_alias() {
+    let temp_dir = tempdir().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("lsplus");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(
+        config_dir.join("config.toml"),
+        "append_slash = true\nindicator_style = \"file-type\"\n",
+    )
+    .unwrap();
+
+    temp_env::with_var("HOME", Some(temp_dir.path()), || {
+        assert_eq!(
+            load_config(),
+            Params {
+                indicator_style: IndicatorStyle::FileType,
+                ..Params::default()
             }
         );
     });

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -878,8 +878,11 @@ fn test_gnu_compat_mode_accepts_indicator_style_slash() {
     let (stdout, _stderr) = run_and_capture(&mut cmd);
 
     assert!(stdout.contains("child/"));
-    assert!(stdout.contains("link"));
-    assert!(!stdout.contains("link@"));
+    #[cfg(unix)]
+    {
+        assert!(stdout.contains("link"));
+        assert!(!stdout.contains("link@"));
+    }
 }
 
 #[test]
@@ -901,8 +904,11 @@ fn test_gnu_compat_mode_accepts_short_p() {
     let (stdout, _stderr) = run_and_capture(&mut cmd);
 
     assert!(stdout.contains("child/"));
-    assert!(stdout.contains("link"));
-    assert!(!stdout.contains("link@"));
+    #[cfg(unix)]
+    {
+        assert!(stdout.contains("link"));
+        assert!(!stdout.contains("link@"));
+    }
 }
 
 #[cfg(unix)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,6 +6,9 @@ use std::time::{Duration, SystemTime};
 use strip_ansi_escapes::strip_str;
 use tempfile::tempdir;
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 fn run_and_capture(cmd: &mut Command) -> (String, String) {
     let output = cmd.output().unwrap();
     assert!(
@@ -37,13 +40,35 @@ fn has_ansi(text: &str) -> bool {
     text.contains("\u{1b}[")
 }
 
+#[cfg(unix)]
+fn create_indicator_fixture() -> tempfile::TempDir {
+    let temp_dir = tempdir().unwrap();
+    let child_dir = temp_dir.path().join("child");
+    let exec_path = temp_dir.path().join("run.sh");
+    let target_path = temp_dir.path().join("target.txt");
+    let link_path = temp_dir.path().join("link");
+
+    fs::create_dir(&child_dir).unwrap();
+    fs::write(&exec_path, "#!/bin/sh\nexit 0\n").unwrap();
+    fs::set_permissions(&exec_path, fs::Permissions::from_mode(0o755))
+        .unwrap();
+    fs::write(&target_path, "target").unwrap();
+    std::os::unix::fs::symlink(&target_path, &link_path).unwrap();
+
+    temp_dir
+}
+
 #[test]
 fn test_version_flag() {
-    let mut cmd = Command::cargo_bin("lsp").unwrap();
-    cmd.arg("--version")
-        .assert()
-        .success()
-        .stdout(predicates::str::contains("lsplus"));
+    let temp_dir = tempdir().unwrap();
+
+    temp_env::with_var("HOME", Some(temp_dir.path()), || {
+        let mut cmd = Command::cargo_bin("lsp").unwrap();
+        cmd.arg("--version")
+            .assert()
+            .success()
+            .stdout(predicates::str::contains("lsplus"));
+    });
 }
 
 #[test]
@@ -123,17 +148,20 @@ fn test_no_icons_omits_file_icons() {
     let rust_file = temp_dir.path().join("example.rs");
     fs::write(&rust_file, "fn main() {}").unwrap();
 
-    let mut with_icons = Command::cargo_bin("lsp").unwrap();
-    with_icons.arg(&rust_file);
-    let (stdout_with_icons, _stderr) = run_and_capture(&mut with_icons);
+    temp_env::with_var("HOME", Some(temp_dir.path()), || {
+        let mut with_icons = Command::cargo_bin("lsp").unwrap();
+        with_icons.arg(&rust_file);
+        let (stdout_with_icons, _stderr) = run_and_capture(&mut with_icons);
 
-    let mut without_icons = Command::cargo_bin("lsp").unwrap();
-    without_icons.arg("--no-icons").arg(&rust_file);
-    let (stdout_without_icons, _stderr) = run_and_capture(&mut without_icons);
+        let mut without_icons = Command::cargo_bin("lsp").unwrap();
+        without_icons.arg("--no-icons").arg(&rust_file);
+        let (stdout_without_icons, _stderr) =
+            run_and_capture(&mut without_icons);
 
-    assert!(stdout_with_icons.contains(""));
-    assert!(!stdout_without_icons.contains(""));
-    assert!(stdout_without_icons.contains("example.rs"));
+        assert!(stdout_with_icons.contains(""));
+        assert!(!stdout_without_icons.contains(""));
+        assert!(stdout_without_icons.contains("example.rs"));
+    });
 }
 
 #[test]
@@ -835,7 +863,12 @@ fn test_gnu_compat_mode_accepts_fuzzy_time_long_option() {
 fn test_gnu_compat_mode_accepts_indicator_style_slash() {
     let temp_dir = tempdir().unwrap();
     let child_dir = temp_dir.path().join("child");
+    let target_path = temp_dir.path().join("target.txt");
+    let link_path = temp_dir.path().join("link");
     fs::create_dir(&child_dir).unwrap();
+    fs::write(&target_path, "target").unwrap();
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&target_path, &link_path).unwrap();
 
     let mut cmd = Command::cargo_bin("lsp").unwrap();
     cmd.env("LSP_COMPAT_MODE", "gnu")
@@ -845,13 +878,20 @@ fn test_gnu_compat_mode_accepts_indicator_style_slash() {
     let (stdout, _stderr) = run_and_capture(&mut cmd);
 
     assert!(stdout.contains("child/"));
+    assert!(stdout.contains("link"));
+    assert!(!stdout.contains("link@"));
 }
 
 #[test]
 fn test_gnu_compat_mode_accepts_short_p() {
     let temp_dir = tempdir().unwrap();
     let child_dir = temp_dir.path().join("child");
+    let target_path = temp_dir.path().join("target.txt");
+    let link_path = temp_dir.path().join("link");
     fs::create_dir(&child_dir).unwrap();
+    fs::write(&target_path, "target").unwrap();
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&target_path, &link_path).unwrap();
 
     let mut cmd = Command::cargo_bin("lsp").unwrap();
     cmd.env("LSP_COMPAT_MODE", "gnu")
@@ -861,6 +901,149 @@ fn test_gnu_compat_mode_accepts_short_p() {
     let (stdout, _stderr) = run_and_capture(&mut cmd);
 
     assert!(stdout.contains("child/"));
+    assert!(stdout.contains("link"));
+    assert!(!stdout.contains("link@"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_native_file_type_and_classify_indicator_output() {
+    let temp_dir = create_indicator_fixture();
+
+    temp_env::with_var("HOME", Some(temp_dir.path()), || {
+        let mut file_type = Command::cargo_bin("lsp").unwrap();
+        file_type
+            .arg("--file-type")
+            .arg("--no-icons")
+            .arg(temp_dir.path());
+        let (file_type_stdout, _stderr) = run_and_capture(&mut file_type);
+
+        assert!(file_type_stdout.contains("child/"));
+        assert!(file_type_stdout.contains("link@"));
+        assert!(file_type_stdout.contains("run.sh"));
+        assert!(!file_type_stdout.contains("run.sh*"));
+
+        let mut classify = Command::cargo_bin("lsp").unwrap();
+        classify.arg("-F").arg("--no-icons").arg(temp_dir.path());
+        let (classify_stdout, _stderr) = run_and_capture(&mut classify);
+
+        assert!(classify_stdout.contains("child/"));
+        assert!(classify_stdout.contains("link@"));
+        assert!(classify_stdout.contains("run.sh*"));
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn test_native_long_mode_omits_symlink_at_indicator() {
+    let temp_dir = create_indicator_fixture();
+
+    temp_env::with_var("HOME", Some(temp_dir.path()), || {
+        let mut cmd = Command::cargo_bin("lsp").unwrap();
+        cmd.arg("-l")
+            .arg("--file-type")
+            .arg("--no-icons")
+            .arg(temp_dir.path());
+        let (stdout, _stderr) = run_and_capture(&mut cmd);
+
+        assert!(stdout.contains("link -> "));
+        assert!(!stdout.contains("link@ -> "));
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn test_native_no_indicators_overrides_config_indicator_style() {
+    let temp_dir = create_indicator_fixture();
+    let config_dir = temp_dir.path().join(".config").join("lsplus");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(
+        config_dir.join("config.toml"),
+        "indicator_style = \"classify\"\n",
+    )
+    .unwrap();
+
+    temp_env::with_var("HOME", Some(temp_dir.path()), || {
+        let mut cmd = Command::cargo_bin("lsp").unwrap();
+        cmd.arg("--no-indicators")
+            .arg("--no-icons")
+            .arg(temp_dir.path());
+        let (stdout, _stderr) = run_and_capture(&mut cmd);
+
+        assert!(stdout.contains("child"));
+        assert!(stdout.contains("link"));
+        assert!(stdout.contains("run.sh"));
+        assert!(!stdout.contains("child/"));
+        assert!(!stdout.contains("link@"));
+        assert!(!stdout.contains("run.sh*"));
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn test_gnu_compat_mode_accepts_file_type_and_classify_output() {
+    let temp_dir = create_indicator_fixture();
+
+    let mut file_type = Command::cargo_bin("lsp").unwrap();
+    file_type
+        .env("LSP_COMPAT_MODE", "gnu")
+        .arg("--file-type")
+        .arg("--no-icons")
+        .arg(temp_dir.path());
+    let (file_type_stdout, _stderr) = run_and_capture(&mut file_type);
+
+    assert!(file_type_stdout.contains("child/"));
+    assert!(file_type_stdout.contains("link@"));
+    assert!(!file_type_stdout.contains("run.sh*"));
+
+    let mut classify = Command::cargo_bin("lsp").unwrap();
+    classify
+        .env("LSP_COMPAT_MODE", "gnu")
+        .arg("-F")
+        .arg("--no-icons")
+        .arg(temp_dir.path());
+    let (classify_stdout, _stderr) = run_and_capture(&mut classify);
+
+    assert!(classify_stdout.contains("child/"));
+    assert!(classify_stdout.contains("link@"));
+    assert!(classify_stdout.contains("run.sh*"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_gnu_compat_mode_omits_symlink_at_indicator_in_long_mode() {
+    let temp_dir = create_indicator_fixture();
+
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.env("LSP_COMPAT_MODE", "gnu")
+        .arg("-l")
+        .arg("--file-type")
+        .arg("--no-icons")
+        .arg(temp_dir.path());
+    let (stdout, _stderr) = run_and_capture(&mut cmd);
+
+    assert!(stdout.contains("link -> "));
+    assert!(!stdout.contains("link@ -> "));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_gnu_compat_mode_accepts_indicator_style_none() {
+    let temp_dir = create_indicator_fixture();
+
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.env("LSP_COMPAT_MODE", "gnu")
+        .arg("--indicator-style=none")
+        .arg("--no-icons")
+        .arg(temp_dir.path());
+    let (stdout, _stderr) = run_and_capture(&mut cmd);
+
+    assert!(stdout.contains("child"));
+    assert!(stdout.contains("link"));
+    assert!(stdout.contains("run.sh"));
+    assert!(!stdout.contains("child/"));
+    assert!(!stdout.contains("link@"));
+    assert!(!stdout.contains("run.sh*"));
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1030,6 +1030,7 @@ fn test_gnu_compat_mode_omits_symlink_at_indicator_in_long_mode() {
 
     assert!(stdout.contains("link -> "));
     assert!(!stdout.contains("link@ -> "));
+    assert!(stdout.contains("target.txt"));
 }
 
 #[cfg(unix)]

--- a/tests/seams.rs
+++ b/tests/seams.rs
@@ -1,7 +1,7 @@
-use lsplus::Params;
 use lsplus::app::run_with_flags;
 use lsplus::cli::Flags;
 use lsplus::utils::file::create_file_info;
+use lsplus::{IndicatorStyle, Params};
 use std::fs;
 use tempfile::tempdir;
 
@@ -18,16 +18,17 @@ fn test_public_create_file_info_formats_short_symlinks() {
     let short = create_file_info(&link, &Params::default()).unwrap();
     assert!(short.display_name.contains("link"));
     assert!(!short.display_name.contains('*'));
+    assert!(!short.display_name.contains('@'));
 
     let short_with_marker = create_file_info(
         &link,
         &Params {
-            append_slash: true,
+            indicator_style: IndicatorStyle::FileType,
             ..Params::default()
         },
     )
     .unwrap();
-    assert!(short_with_marker.display_name.contains('*'));
+    assert!(short_with_marker.display_name.contains('@'));
 }
 
 #[test]
@@ -38,7 +39,7 @@ fn test_public_run_with_flags_accepts_missing_patterns() {
         long: false,
         human_readable: false,
         paths: vec![String::from("**/definitely_missing_coverage_pattern")],
-        slash: false,
+        indicator_style: None,
         dirs_first: false,
         no_icons: false,
         no_color: false,

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -1,6 +1,6 @@
 use config::Config;
-use lsplus::Params;
 use lsplus::cli::Flags;
+use lsplus::{IndicatorStyle, Params};
 use std::fs;
 use tempfile::tempdir;
 
@@ -8,7 +8,7 @@ use tempfile::tempdir;
 fn test_default_params() {
     let params = Params::default();
     assert!(!params.show_all);
-    assert!(!params.append_slash);
+    assert_eq!(params.indicator_style, IndicatorStyle::None);
     assert!(!params.dirs_first);
     assert!(!params.almost_all);
     assert!(!params.long_format);
@@ -28,7 +28,7 @@ fn test_config_conversion() {
         &config_path,
         r#"
             show_all = true
-            append_slash = true
+            indicator_style = "file-type"
             dirs_first = true
             almost_all = true
             long_format = true
@@ -52,7 +52,7 @@ fn test_config_conversion() {
         params,
         Params {
             show_all: true,
-            append_slash: true,
+            indicator_style: IndicatorStyle::FileType,
             dirs_first: true,
             almost_all: true,
             long_format: true,
@@ -66,10 +66,48 @@ fn test_config_conversion() {
 }
 
 #[test]
+fn test_config_conversion_maps_append_slash_alias_to_slash_style() {
+    let temp_dir = tempdir().unwrap();
+    let config_path = temp_dir.path().join("config.toml");
+
+    fs::write(&config_path, "append_slash = true\n").unwrap();
+
+    let config = Config::builder()
+        .add_source(config::File::from(config_path))
+        .build()
+        .unwrap();
+
+    let params: Params = config.into();
+
+    assert_eq!(params.indicator_style, IndicatorStyle::Slash);
+}
+
+#[test]
+fn test_config_conversion_prefers_indicator_style_over_append_slash_alias() {
+    let temp_dir = tempdir().unwrap();
+    let config_path = temp_dir.path().join("config.toml");
+
+    fs::write(
+        &config_path,
+        "append_slash = true\nindicator_style = \"classify\"\n",
+    )
+    .unwrap();
+
+    let config = Config::builder()
+        .add_source(config::File::from(config_path))
+        .build()
+        .unwrap();
+
+    let params: Params = config.into();
+
+    assert_eq!(params.indicator_style, IndicatorStyle::Classify);
+}
+
+#[test]
 fn test_params_merge_prefers_true_from_either_source() {
     let config = Params {
         show_all: true,
-        append_slash: true,
+        indicator_style: IndicatorStyle::FileType,
         dirs_first: false,
         almost_all: false,
         long_format: true,
@@ -85,7 +123,7 @@ fn test_params_merge_prefers_true_from_either_source() {
         paths: vec![],
         show_all: false,
         almost_all: true,
-        slash: false,
+        indicator_style: Some(IndicatorStyle::Classify),
         dirs_first: true,
         long: false,
         human_readable: false,
@@ -98,7 +136,7 @@ fn test_params_merge_prefers_true_from_either_source() {
     let params = Params::merge(&flags, &config);
 
     assert!(params.show_all);
-    assert!(params.append_slash);
+    assert_eq!(params.indicator_style, IndicatorStyle::Classify);
     assert!(params.dirs_first);
     assert!(params.almost_all);
     assert!(params.long_format);
@@ -116,7 +154,7 @@ fn test_params_merge_keeps_false_when_both_sources_are_false() {
         paths: vec![],
         show_all: false,
         almost_all: false,
-        slash: false,
+        indicator_style: None,
         dirs_first: false,
         long: false,
         human_readable: false,


### PR DESCRIPTION
## Summary
Implement configurable indicator styles across native and GNU compatibility modes.

## What Changed
- add indicator-style runtime and config support with backward compatibility for `append_slash`
- add native and GNU CLI surfaces for `slash`, `file-type`, `classify`, and `none`
- rework file rendering so symlink, directory, FIFO, socket, and executable markers follow the selected style
- omit the symlink `@` marker in long mode to match GNU `ls`
- expand unit and integration coverage for parsing, config precedence, and rendered output
- document the new options, config values, and indicator characters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added file-type indicator flags: --file-type, -F/--classify, and --no-indicators.
  * Introduced indicator_style config: "none", "slash", "file-type", "classify".
  * File markers now include / (dir), @ (symlink), | (FIFO), = (socket) and * (executable, with classify).

* **Bug Fixes**
  * Symlink indicator suppressed in native long listings to match GNU ls.

* **Documentation**
  * Updated usage and config docs; append_slash = true maps to indicator_style = "slash".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->