### PR TITLE
fix: allow CC0 license in deny check

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,7 @@ allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "BSD-3-Clause",
+    "CC0-1.0",
     "ISC",
     "MIT",
     "Unicode-3.0",


### PR DESCRIPTION
## Summary

This updates the cargo-deny license allow list to explicitly permit `CC0-1.0`, which is used by `tiny-keccak` through the current `config` dependency tree.

The policy remains otherwise unchanged: advisory, ban, license, and source checks still run through the existing `cargo make deny` task.
