### PR TITLE
Add rustdoc coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/73f67c2ab44548298e0660ca73308729)](https://app.codacy.com/gh/seapagan/lsplus/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![Build Docs](https://github.com/seapagan/lsplus/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/seapagan/lsplus/actions/workflows/gh-pages.yml)
 
-This is currently a very simple (though functional) clone of the Unix 'ls'
-command written in Rust. It is a learning project for me to learn Rust so
-probably contains many inefficiencies and bad practices. I'll get better
-with time! 😁
+LSPlus is a functional Unix `ls` clone written in Rust. I built it as a Rust
+learning project, so some code may still show beginner decisions.
 
 ![lsp output](./docs/src/images/screenshot.png)
 
@@ -35,8 +33,8 @@ with time! 😁
 
 ## Compatibility
 
-This project is currently only compatible with Unix-like systems (Linux,
-MacOs, etc.). Windows support is planned to be added very soon.
+LSPlus supports Unix-like systems: Linux, macOS, and similar platforms. Windows
+support is on the roadmap.
 
 ## Nerd Fonts
 
@@ -54,10 +52,9 @@ the program (or `no_icons=true` in the config file).
 
 ### Download a Binary
 
-For Linux and Mac you can download the latest binary files from the [release
-page](https://github.com/seapagan/lsplus/releases/latest). Unpack the archive
-and move the single file `lsp` to somewhere in your path so it can be located.
-Ensure it is set as executable (though it already should be).
+Download the latest Linux or macOS archive from the [release
+page](https://github.com/seapagan/lsplus/releases/latest). Unpack it, move
+`lsp` into a directory on your `PATH`, and make it executable if needed.
 
 These binaries are auto-generated for each release.
 
@@ -91,11 +88,10 @@ Run this command in your terminal to list files in the current directory:
 lsp <options> <path | file>
 ```
 
-Both the options and the path are optional. If no path is provided, the current
-directory will be listed. If no options are provided, the default options will
-be used which are similar to the `ls` command.
+Options and paths are optional. With no path, `lsp` lists the current
+directory. With no options, it uses defaults similar to `ls`.
 
-Curently, only a sub-set of the standard `ls` options are supported. These are:
+Currently, only a sub-set of the standard `ls` options are supported. These are:
 
 - `-a` / `--all` - Show hidden files
 - `-A` / `--almost-all` - Show hidden files, but don't show `.` and `..`
@@ -165,10 +161,8 @@ show the time in a human-readable format, e.g. '2 hours ago', 'yesterday', etc.
 
 ### Icons
 
-Icons are added to folders, files, and links. There is only a limited set of
-mappings implemented at the moment, but more will be added in the future. Add
-an issue if you have a specific icon you would like to see - even better, add
-a Pull Request implementing it! 😁
+`lsp` shows icons for folders, files, and links. The current mappings cover
+common names and extensions. Open an issue or PR if you want another icon.
 
 You can disable the icons by using the `--no-icons` option.
 
@@ -216,9 +210,9 @@ GNU indicator options are also available in `gnu` mode:
 
 ### Configuration File
 
-You can set options using the configuration file so they will apply to every run
-and not need to be specified on the command line. See the relevant section on
-the [website](https://seapagan.github.io/lsplus/config.html) for full details.
+Put options in the config file to apply them to each run instead of passing them
+on the command line. See the relevant section on the
+[website](https://seapagan.github.io/lsplus/config.html) for full details.
 
 ### Aliases
 
@@ -274,5 +268,4 @@ cargo install cargo-deny
 
 ## Future Plans
 
-I am planning to add many more features to this project in the future. Check out
-the [TODO](./TODO.md) file for a list of planned features and improvements.
+See [TODO](./TODO.md) for planned work.

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -1,22 +1,19 @@
 # Configuration File
 
-It is possible to configure `lsplus` using a configuration file. The
-configuration file is a simple **`TOML`** file that is placed in the following
-location:
+Configure `lsplus` with a **`TOML`** file at:
 
 - Linux: `~/.config/lsplus/config.toml`
 - MacOS: `~/.config/lsplus/config.toml`
 
-The configuration file is optional and if it is not found, `lsplus` will use the
-default settings.
+The configuration file is optional. `lsplus` uses default settings when the file
+does not exist.
 
 `lsplus` also supports an `LSP_COMPAT_MODE` environment variable. When set, it
 overrides the `compat_mode` value from the config file.
 
 ## Available Options
 
-The following options are available in the configuration file and correspond to
-the relevant command line options:
+The configuration file supports these command-line options:
 
 ### compat_mode
 
@@ -36,17 +33,16 @@ mode and will error until their GNU behavior is implemented.
 - Permitted values: `true` or `false`
 - Default value: `false`
 
-This option corresponds to the `-a` or `--all` command line option and will
-display all files and directories if set to `true`, including hidden files.
+This option corresponds to `-a` or `--all` and displays hidden files when set to
+`true`.
 
 ### almost_all
 
 - Permitted values: `true` or `false`
 - Default value: `false`
 
-This option corresponds to the `-A` or `--almost-all` command line option and
-will display all files and directories if set to `true`, except for `.` and
-`..`.
+This option corresponds to `-A` or `--almost-all` and displays hidden files
+except `.` and `..` when set to `true`.
 
 ### indicator_style
 
@@ -78,8 +74,8 @@ config file and maps to `indicator_style = "slash"`. If both are present,
 - Permitted values: `true` or `false`
 - Default value: `false`
 
-This option corresponds to the `--sort-dirs` command line option and will sort
-directories before files when set to `true`. In `gnu` compatibility mode, the
+This option corresponds to `--sort-dirs` and sorts directories before files when
+set to `true`. In `gnu` compatibility mode, the
 equivalent long option is `--group-directories-first` (replacing the original
 `--sort-dirs`).
 
@@ -88,32 +84,31 @@ equivalent long option is `--group-directories-first` (replacing the original
 - Permitted values: `true` or `false`
 - Default value: `false`
 
-This option corresponds to the `--long` command line option and will display the
-output in long format if set to `true`.
+This option corresponds to `--long` and displays output in long format when set
+to `true`.
 
 ### human_readable
 
 - Permitted values: `true` or `false`
 - Default value: `false`
 
-This option corresponds to the `-h` or `--human-readable` command line option
-and will display file sizes in human readable format if set to `true`.
+This option corresponds to `-h` or `--human-readable` and displays
+human-readable file sizes when set to `true`.
 
 ### no_icons
 
 - Permitted values: `true` or `false`
 - Default value: `false`
 
-This option corresponds to the `--no-icons` command line option and will not
-display icons if set to `true`.
+This option corresponds to `--no-icons` and hides icons when set to `true`.
 
 ### no_color
 
 - Permitted values: `true` or `false`
 - Default value: `false`
 
-This option corresponds to the `-N` or `--no-color` command line option and
-will disable colored and styled output if set to `true`.
+This option corresponds to `-N` or `--no-color` and disables colored and styled
+output when set to `true`.
 
 ### permission_colors
 
@@ -152,23 +147,21 @@ This option controls long-format large-size colors. Set it to `false`, or pass
 - Permitted values: `true` or `false`
 - Default value: `false`
 
-This option corresponds to the `-I` or `--gitignore` command line option and
-will dim entries that are matched by the active Git ignore rules, including
-merged `.gitignore` files, `.git/info/exclude`, and the configured global Git
-excludes file.
+This option corresponds to `-I` or `--gitignore` and dims entries matched by the
+active Git ignore rules, including merged `.gitignore` files,
+`.git/info/exclude`, and the configured global Git excludes file.
 
 ### fuzzy_time
 
 - Permitted values: `true` or `false`
 - Default value: `false`
 
-This option corresponds to the `-Z` or `--fuzzy-time` command line option and
-will display the time in a 'fuzzy' format if set to `true`.
+This option corresponds to `-Z` or `--fuzzy-time` and displays timestamps in a
+fuzzy format when set to `true`.
 
 ## Example Configuration File
 
-The following is an example configuration file that sets several options. Any
-options that are not set will use the default values:
+This example sets several options. Omitted options use default values:
 
 ```toml
 # compat_mode = "native"  # or "gnu" for GNU ls compatibility

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -3,7 +3,7 @@
 Configure `lsplus` with a **`TOML`** file at:
 
 - Linux: `~/.config/lsplus/config.toml`
-- MacOS: `~/.config/lsplus/config.toml`
+- macOS: `~/.config/lsplus/config.toml`
 
 The configuration file is optional. `lsplus` uses default settings when the file
 does not exist.

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,13 +1,10 @@
 # Installation
 
-To install the latest release of this package, you can use the following command:
-
 ## Download a Binary
 
-For Linux and Mac you can download the latest binary files from the [release
-page](https://github.com/seapagan/lsplus/releases/latest). Unpack the archive
-and move the single file `lsp` to somewhere in your path so it can be located.
-Ensure it is set as executable (though it already should be).
+Download the latest Linux or macOS archive from the [release
+page](https://github.com/seapagan/lsplus/releases/latest). Unpack it, move
+`lsp` into a directory on your `PATH`, and make it executable if needed.
 
 These binaries are auto-generated for each release.
 
@@ -26,12 +23,10 @@ can run the `lsp` command from anywhere.
 
 ## From Source
 
-You can also install the package from the GitHub repository by running the
-following command:
+Install the package from the GitHub repository with:
 
 ```bash
 cargo install --git https://github.com/seapagan/lsplus.git
 ```
 
-This may allow you to access the latest features and bug fixes that have not
-yet been released.
+This uses unreleased commits from the default branch.

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -1,25 +1,23 @@
 # An `ls` replacement written in `Rust`
 
 
-This is currently a very simple (though functional) clone of the Unix 'ls'
-command written in Rust. It is a learning project for me to learn Rust so
-probably contains many inefficiencies and bad practices. I'll get better 😁
+LSPlus is a functional Unix `ls` clone written in Rust. I built it as a Rust
+learning project, so some code may still show beginner decisions.
 
 ![lsp output](./images/screenshot.png)
 
 ## Compatibility
 
-This project is currently only compatible with Unix-like systems (Linux,
-MacOs, etc.). Windows support is planned to be added very soon.
+LSPlus supports Unix-like systems: Linux, macOS, and similar platforms. Windows
+support is on the roadmap.
 
 ## Nerd Fonts
 
-To display the folder and file icons, you need to first install a 'Nerd Font'
-for your terminal. You can find a great selection of Nerd Fonts
-[here](https://www.nerdfonts.com/)
+Install a Nerd Font in your terminal to display folder and file icons. The
+[Nerd Fonts website](https://www.nerdfonts.com/) has a broad selection.
 
-My personal favourite is `MesoLG Nerd Font`, but there are many others to choose
-from. You will also need to set up your terminal to use that font.
+My personal favourite is `MesoLG Nerd Font`. Configure your terminal to use the
+font after installing it.
 
 If you **DO NOT** want to install a Nerd Font, pass the `--no-icons` switch to
 the program.

--- a/docs/src/todo.md
+++ b/docs/src/todo.md
@@ -1,9 +1,7 @@
 # Future Plans
 
-Below is the content of the project's TODO.md file.
+This page includes the project TODO list.
 
-If you have any suggestions for features or improvements, please open an issue
-on the project's GitHub page.
+Open a GitHub issue to suggest another feature or improvement.
 
 {{#include ../../TODO.md}}
-

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -6,11 +6,10 @@ Run this command in your terminal to list files in the current directory:
 lsp <options> <path | file>
 ```
 
-Both the options and the path are optional. If no path is provided, the current
-directory will be listed. If no options are provided, the default options will
-be used which are similar to the `ls` command.
+Options and paths are optional. With no path, `lsp` lists the current
+directory. With no options, it uses defaults similar to `ls`.
 
-Curently, only a sub-set of the standard `ls` options are supported. These are:
+Currently, only a sub-set of the standard `ls` options are supported. These are:
 
 - `-a` / `--all` - Show hidden files
 - `-A` / `--almost-all` - Show hidden files, but don't show `.` and `..`
@@ -104,24 +103,21 @@ GNU indicator options are also available in `gnu` mode:
 
 ## Fuzzy Time
 
-The `-Z` option will show a fuzzy time for file modification times. This will
-show the time in a human-readable format, e.g. '2 hours ago', 'yesterday', etc.
+The `-Z` option shows file modification times in a human-readable format, e.g.
+'2 hours ago', 'yesterday', etc.
 
 ![fuzzy date output](./images/screenshot3.png)
 
 ## Icons
 
-Icons are added to folders, files, and links. There is only a limited set of
-mappings implemented at the moment, but more will be added in the future. Add
-an issue if you have a specific icon you would like to see - even better, add
-a Pull Request implementing it! :grin:
+`lsp` shows icons for folders, files, and links. The current mappings cover
+common names and extensions. Open an issue or PR if you want another icon.
 
-You can disable the icons by using the `--no-icons` option.
+Disable icons with the `--no-icons` option.
 
 ## Aliases
 
-The `lsp` command can be aliased to `ls` by adding the following line to your
-`.bashrc`, `.zshrc` or similar file:
+Add this line to `.bashrc`, `.zshrc`, or a similar file to alias `ls` to `lsp`:
 
 ```sh
 alias ls='lsp'
@@ -131,23 +127,22 @@ If you want that alias to behave more like GNU `ls`, enable `gnu`
 compatibility mode in your config file or set `LSP_COMPAT_MODE=gnu` in your
 shell environment.
 
-You will need to restart your shell or source your configuration file for the
-alias to take effect.
+Restart your shell or source your configuration file to load the alias.
 
-The example below shows an alias for ls that uses many of the current options:
+This alias enables several common options:
 
 ```sh
 alias ll='lsp -laph'
 ```
 
-This will show a long format listing with hidden files, append a '/' to
-directories, and show human readable file sizes.
+This shows a long-format listing with hidden files, appends `/` to directories,
+and shows human-readable file sizes.
 
-You can also use the configuration file to set the default options you want.
+Set default options in the configuration file.
 
 ![lsp output](./images/screenshot.png)
 
-If you add the `-D` option to the command (native mode only; use
-`--group-directories-first` in gnu mode), directories will be sorted first:
+Add `-D` in native mode, or `--group-directories-first` in GNU mode, to sort
+directories first:
 
 ![lsp output](./images/screenshot2.png)

--- a/src/app.rs
+++ b/src/app.rs
@@ -55,8 +55,8 @@ fn run_multi(patterns: &[String], params: &Params) -> io::Result<()> {
 
 /// Expand path patterns and collect display data for all matching entries.
 ///
-/// Missing patterns are reported to stderr and skipped, matching the existing
-/// command-line behavior rather than failing the whole run.
+/// `collect_matches` reports missing patterns to stderr, skips them, and
+/// continues with other patterns.
 pub(crate) fn collect_matches(
     patterns: &[String],
     params: &Params,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,8 @@
+//! Runtime orchestration for listing paths and rendering output.
+//!
+//! This module bridges parsed CLI flags, config parameters, glob expansion,
+//! filesystem metadata collection, and the selected output renderer.
+
 use glob::glob;
 use std::io;
 use std::path::PathBuf;
@@ -29,6 +34,7 @@ pub fn run_with_flags_and_config(
     run_multi(&patterns, &params)
 }
 
+/// Return explicit CLI paths or the default current-directory pattern.
 pub(crate) fn patterns_from_args(paths: Vec<String>) -> Vec<String> {
     if paths.is_empty() {
         vec![String::from(".")]
@@ -47,6 +53,10 @@ fn run_multi(patterns: &[String], params: &Params) -> io::Result<()> {
     }
 }
 
+/// Expand path patterns and collect display data for all matching entries.
+///
+/// Missing patterns are reported to stderr and skipped, matching the existing
+/// command-line behavior rather than failing the whole run.
 pub(crate) fn collect_matches(
     patterns: &[String],
     params: &Params,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,7 @@ const ARG_FUZZY_TIME: &str = "fuzzy_time";
 const ARG_HELP: &str = "help";
 const ARG_INDICATOR_GROUP: &str = "indicator_style_group";
 
+/// CLI compatibility mode used when building the clap command.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CompatMode {
     /// Parse arguments using the native `lsplus` option set.
@@ -43,6 +44,7 @@ pub enum CompatMode {
 }
 
 impl CompatMode {
+    /// Parse a config or environment value into a compatibility mode.
     pub(crate) fn parse_value(value: &str) -> Result<Self, String> {
         match value.trim().to_ascii_lowercase().as_str() {
             "native" => Ok(Self::Native),
@@ -56,6 +58,7 @@ impl CompatMode {
     }
 }
 
+/// Parsed command-line flags before they are merged with config defaults.
 #[derive(Debug)]
 pub struct Flags {
     /// Show entries whose names start with `.`.
@@ -100,6 +103,7 @@ impl Flags {
         Self::try_parse_from(args).unwrap_or_else(|err| err.exit())
     }
 
+    /// Parse native-mode CLI arguments without exiting on parse failure.
     pub fn try_parse_from<I, T>(args: I) -> Result<Self, clap::Error>
     where
         I: IntoIterator<Item = T>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+//! Binary entry point for the `lsp` executable.
+
 use std::process::exit;
 
 use lsplus::cli;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,3 +1,8 @@
+//! Config-file and startup-mode loading.
+//!
+//! Runtime display options come from `~/.config/lsplus/config.toml`, while
+//! compatibility mode can be forced with [`COMPAT_MODE_ENV_VAR`].
+
 use std::path::PathBuf;
 
 use config::{Config, File, FileFormat};
@@ -14,6 +19,7 @@ use crate::structs::RawParams;
 /// file.
 pub const COMPAT_MODE_ENV_VAR: &str = "LSP_COMPAT_MODE";
 
+/// Startup-time settings needed before parsing the main CLI.
 #[derive(Debug, PartialEq)]
 pub struct StartupConfig {
     /// Runtime parameters loaded from the config file.
@@ -33,6 +39,7 @@ fn config_path() -> Option<PathBuf> {
     config_path_from_home(home_dir())
 }
 
+/// Return the default config path for a home directory, when one is known.
 pub(crate) fn config_path_from_home(home: Option<PathBuf>) -> Option<PathBuf> {
     let mut path = home?;
     path.push(".config/lsplus/config.toml");
@@ -46,6 +53,7 @@ pub fn load_config() -> Params {
     load_config_from_path(config_path())
 }
 
+/// Load runtime parameters from an explicit config path.
 pub(crate) fn load_config_from_path(config_path: Option<PathBuf>) -> Params {
     load_parsed_config_from_path(config_path)
         .map(|config| config.params.into())
@@ -64,6 +72,7 @@ pub fn load_startup_config() -> Result<StartupConfig, String> {
     )
 }
 
+/// Load startup configuration from explicit config and environment sources.
 pub(crate) fn load_startup_config_from(
     config_path: Option<PathBuf>,
     env_mode: Option<String>,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,7 +1,8 @@
 //! Config-file and startup-mode loading.
 //!
-//! Runtime display options come from `~/.config/lsplus/config.toml`, while
-//! compatibility mode can be forced with [`COMPAT_MODE_ENV_VAR`].
+//! `lsplus` reads runtime display options from
+//! `~/.config/lsplus/config.toml`; [`COMPAT_MODE_ENV_VAR`] overrides config
+//! compatibility mode.
 
 use std::path::PathBuf;
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -148,11 +148,10 @@ impl From<RawParams> for Params {
 impl Params {
     /// Merge parsed CLI flags with config-file defaults.
     ///
-    /// Most boolean options are opt-in toggles, so a value is enabled if
-    /// either the command line or the config file enables it. Long-format
-    /// accent options are config-driven defaults that can be disabled by their
-    /// corresponding `--no-*` CLI flags. Indicator style is selected by
-    /// explicit CLI override when present, otherwise the config value is used.
+    /// CLI flags and config both enable opt-in booleans.
+    ///
+    /// CLI `--no-*` flags disable long-format accent defaults from config.
+    /// Explicit CLI indicator flags override the config indicator style.
     pub fn merge(flags: &cli::Flags, config: &Self) -> Self {
         Self {
             show_all: flags.show_all || config.show_all,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -7,16 +7,25 @@ use std::time::SystemTime;
 
 use crate::cli;
 
+/// Entry-name indicator styles supported by `lsplus`.
+///
+/// These map to GNU-style indicator modes and the native `--slash-dirs`,
+/// `--file-type`, `--classify`, and `--no-indicators` options.
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum IndicatorStyle {
+    /// Do not append an indicator suffix.
     #[default]
     None,
+    /// Append `/` to directories.
     Slash,
+    /// Append file-type indicators, excluding executable `*` suffixes.
     FileType,
+    /// Append file-type indicators, including executable `*` suffixes.
     Classify,
 }
 
+/// Runtime options after CLI flags and config defaults have been merged.
 #[derive(Debug, PartialEq)]
 pub struct Params {
     /// Show entries whose names start with `.`.
@@ -69,6 +78,7 @@ impl Default for Params {
 
 #[derive(Debug, Deserialize, PartialEq, Default)]
 #[serde(default)]
+/// Raw config-file parameters before compatibility aliases are normalized.
 pub(crate) struct RawParams {
     show_all: bool,
     dirs_first: bool,
@@ -86,12 +96,17 @@ pub(crate) struct RawParams {
     append_slash: Option<bool>,
 }
 
+/// Visual category used to style names in short-format output.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum NameStyle {
+    /// A regular entry with no special name styling.
     #[default]
     Plain,
+    /// A directory entry.
     Directory,
+    /// A symbolic link entry.
     Symlink,
+    /// A regular executable file.
     Executable,
 }
 
@@ -160,19 +175,33 @@ impl Params {
     }
 }
 
+/// Metadata and pre-rendered name data for one listed filesystem entry.
 #[derive(Debug)]
 pub struct FileInfo {
+    /// Long-format file-type character such as `d`, `-`, `l`, or `?`.
     pub file_type: String,
+    /// Unix-style `rwxrwxrwx` permission string.
     pub mode: String,
+    /// Link count from filesystem metadata.
     pub nlink: u64,
+    /// Owner name, or numeric user ID when lookup fails.
     pub user: String,
+    /// Group name, or numeric group ID when lookup fails.
     pub group: String,
+    /// Size in bytes.
     pub size: u64,
+    /// Last modification time.
     pub mtime: SystemTime,
+    /// Optional icon selected from the entry type or name.
     pub item_icon: Option<Icon>,
+    /// Sanitized entry name used by short-format rendering.
     pub short_name: String,
+    /// Styled entry name used by long-format rendering.
     pub display_name: String,
+    /// Styling category for short-format rendering.
     pub name_style: NameStyle,
+    /// Whether the entry should be dimmed as gitignored.
     pub dimmed: bool,
+    /// Full path used for metadata lookups and special display cases.
     pub full_path: PathBuf,
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,8 @@
+//! Utility modules used by the `lsplus` runtime.
+//!
+//! These modules handle filesystem inspection, terminal rendering, color
+//! selection, icon lookup, and small formatting helpers shared by the CLI app.
+
 pub mod color;
 pub mod file;
 pub mod format;

--- a/src/utils/color.rs
+++ b/src/utils/color.rs
@@ -24,7 +24,7 @@ pub(crate) fn configure_color_output(params: &Params) {
     ColorizeConfig::set_color_mode(color_mode_for(params));
 }
 
-/// Terminal color capability available to long-format accent rendering.
+/// Terminal color capability for long-format accent rendering.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum LongFormatColorLevel {
     /// Do not emit long-format accent colors.
@@ -38,7 +38,7 @@ pub(crate) enum LongFormatColorLevel {
 }
 
 impl LongFormatColorLevel {
-    /// Return whether any long-format accent colors can be emitted.
+    /// Return true when long-format accents may emit color.
     pub(crate) fn is_enabled(self) -> bool {
         self != Self::None
     }

--- a/src/utils/color.rs
+++ b/src/utils/color.rs
@@ -1,9 +1,16 @@
+//! Terminal color-mode detection and global color configuration.
+//!
+//! Short-format names use the `colored_text` global color mode. Long-format
+//! accent colors also need a capability level so table style specs and
+//! timestamp gradients can choose named, ANSI 256, or truecolor output.
+
 use colored_text::{ColorMode, ColorizeConfig};
 use std::env;
 use std::io::{self, IsTerminal};
 
 use crate::Params;
 
+/// Return the global color mode implied by runtime parameters.
 pub(crate) fn color_mode_for(params: &Params) -> ColorMode {
     if params.no_color {
         ColorMode::Never
@@ -12,24 +19,35 @@ pub(crate) fn color_mode_for(params: &Params) -> ColorMode {
     }
 }
 
+/// Apply the runtime color setting to the process-wide coloring backend.
 pub(crate) fn configure_color_output(params: &Params) {
     ColorizeConfig::set_color_mode(color_mode_for(params));
 }
 
+/// Terminal color capability available to long-format accent rendering.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum LongFormatColorLevel {
+    /// Do not emit long-format accent colors.
     None,
+    /// Use named ANSI colors only.
     Named,
+    /// Use ANSI 256-color escape sequences.
     Ansi256,
+    /// Use RGB truecolor escape sequences.
     Truecolor,
 }
 
 impl LongFormatColorLevel {
+    /// Return whether any long-format accent colors can be emitted.
     pub(crate) fn is_enabled(self) -> bool {
         self != Self::None
     }
 }
 
+/// Detect the color capability for long-format accents.
+///
+/// This respects `--no-color`, `NO_COLOR`, the configured `colored_text` mode,
+/// stdout terminal detection, and common `COLORTERM`/`TERM` capability names.
 pub(crate) fn long_format_color_level(
     params: &Params,
 ) -> LongFormatColorLevel {

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -1,3 +1,10 @@
+//! Filesystem inspection and entry-name formatting.
+//!
+//! This module collects the metadata needed by renderers, applies visibility
+//! and directory-ordering rules, sanitizes terminal output, and prepares
+//! styled names for regular files, directories, symlinks, and gitignored
+//! entries.
+
 use colored_text::{Colorize, StyledText};
 use nix::unistd::{Group, User};
 use std::ffi::{OsStr, OsString};
@@ -28,9 +35,13 @@ struct FileDetails {
     group: String,
 }
 
+/// Directory entry data captured before visibility filtering and sorting.
 pub(crate) struct DirectoryEntryData {
+    /// Raw entry name from `read_dir`.
     pub file_name: OsString,
+    /// Full entry path.
     pub path: PathBuf,
+    /// Directory classification captured while reading the entry.
     pub is_dir: Result<bool, io::Error>,
 }
 
@@ -69,6 +80,7 @@ fn get_file_details(metadata: &fs::Metadata) -> FileDetails {
     }
 }
 
+/// Return displayable names for a file path or visible entries in a directory.
 pub fn collect_file_names(
     path: &Path,
     params: &Params,
@@ -111,6 +123,10 @@ pub fn collect_file_names(
     Ok(file_names)
 }
 
+/// Return visible entry names for a directory after sorting and filtering.
+///
+/// Hidden-file handling follows the parsed params, and `dirs_first` preserves
+/// the sorted order within the directory and non-directory groups.
 pub(crate) fn collect_visible_file_names(
     path: &Path,
     entries: Vec<Result<DirectoryEntryData, io::Error>>,
@@ -165,6 +181,7 @@ pub(crate) fn collect_visible_file_names(
     file_names
 }
 
+/// Look up a username, falling back to the numeric UID.
 pub fn get_username(uid: u32) -> String {
     match User::from_uid(uid.into()) {
         Ok(Some(user)) => user.name,
@@ -172,6 +189,7 @@ pub fn get_username(uid: u32) -> String {
     }
 }
 
+/// Look up a group name, falling back to the numeric GID.
 pub fn get_groupname(gid: u32) -> String {
     match Group::from_gid(gid.into()) {
         Ok(Some(group)) => group.name,
@@ -179,6 +197,10 @@ pub fn get_groupname(gid: u32) -> String {
     }
 }
 
+/// Collect display metadata for a file or every visible entry in a directory.
+///
+/// Directory symlinks are followed for directory traversal decisions, while
+/// broken symlinks remain listable as their own entries.
 pub fn collect_file_info(
     path: &Path,
     params: &Params,
@@ -218,6 +240,7 @@ pub fn collect_file_info(
     Ok(file_info)
 }
 
+/// Append display metadata for a list of names under one directory.
 pub(crate) fn append_file_info_for_names(
     file_info: &mut Vec<FileInfo>,
     path: &Path,
@@ -242,6 +265,7 @@ pub(crate) fn append_file_info_for_names(
     }
 }
 
+/// Build display metadata for a single filesystem path.
 pub fn create_file_info(path: &Path, params: &Params) -> io::Result<FileInfo> {
     let mut gitignore_cache = GitignoreCache::default();
     create_file_info_with_gitignore(path, params, &mut gitignore_cache)
@@ -327,6 +351,7 @@ fn create_file_info_from_metadata_with_gitignore(
     }
 }
 
+/// Return the displayed name, preserving special styling for `.` and `..`.
 pub fn check_display_name(info: &FileInfo) -> String {
     match &info.full_path.to_string_lossy() {
         p if p.ends_with("/.") => ".".blue().to_string(),
@@ -371,6 +396,7 @@ fn sort_key(name: &OsStr) -> Vec<u8> {
     }
 }
 
+/// Escape control characters so paths cannot inject terminal control output.
 pub(crate) fn sanitize_for_terminal(text: &str) -> String {
     if text.is_empty() {
         return String::new();
@@ -396,6 +422,7 @@ fn sanitize_path_for_terminal(path: &Path) -> String {
     sanitize_for_terminal(&path.to_string_lossy())
 }
 
+/// Append the configured file-type indicator to a sanitized entry name.
 fn format_name_with_indicator(
     safe_name: &str,
     metadata: &fs::Metadata,
@@ -404,6 +431,10 @@ fn format_name_with_indicator(
     format!("{safe_name}{}", indicator_suffix(metadata, params))
 }
 
+/// Return the suffix for the configured indicator style.
+///
+/// Long-format symlink rows display targets with `->`, so the short-format
+/// `@` symlink marker is suppressed there.
 fn indicator_suffix(metadata: &fs::Metadata, params: &Params) -> &'static str {
     if metadata.is_symlink() && params.long_format {
         return "";
@@ -425,6 +456,7 @@ fn indicator_suffix(metadata: &fs::Metadata, params: &Params) -> &'static str {
     }
 }
 
+/// Return the GNU-style indicator suffix for the entry metadata.
 fn file_type_indicator_suffix(
     metadata: &fs::Metadata,
     classify_executables: bool,
@@ -493,6 +525,7 @@ fn is_executable(metadata: &fs::Metadata) -> bool {
     }
 }
 
+/// Format a symlink name, optionally including and styling its target.
 pub(crate) fn format_symlink_display_name_with_dim(
     source_name: &str,
     path: &Path,
@@ -554,6 +587,7 @@ pub(crate) fn format_symlink_display_name_with_dim(
     }
 }
 
+/// Format a path-related IO error for terminal output.
 pub(crate) fn format_path_error(path: &Path, err: &io::Error) -> String {
     format!("lsplus: {}: {}", sanitize_path_for_terminal(path), err)
 }

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -1,3 +1,6 @@
+//! Formatting helpers for permissions and file sizes.
+
+/// Convert Unix permission bits into an `rwxrwxrwx` string.
 pub fn mode_to_rwx(mode: u32) -> String {
     let mut rwx = String::new();
     let perms = [
@@ -23,6 +26,7 @@ pub fn mode_to_rwx(mode: u32) -> String {
     rwx
 }
 
+/// Scale a byte count into the largest binary unit below 1024.
 pub fn human_readable_format(size: u64) -> (f64, &'static str) {
     const UNITS: [&str; 6] = ["B", "KB", "MB", "GB", "TB", "PB"];
     let mut size = size as f64;
@@ -36,6 +40,7 @@ pub fn human_readable_format(size: u64) -> (f64, &'static str) {
     (size, UNITS[unit_index])
 }
 
+/// Format a size for display and return the optional unit label.
 pub fn show_size(size: u64, human_readable: bool) -> (String, &'static str) {
     if human_readable {
         let (size, unit) = human_readable_format(size);

--- a/src/utils/fuzzy_time.rs
+++ b/src/utils/fuzzy_time.rs
@@ -1,3 +1,8 @@
+//! Human-readable relative timestamp formatting.
+//!
+//! Past timestamps are rendered as phrases such as `2 hours ago`, `yesterday`,
+//! or `last month`; future timestamps are rendered as `in ...` phrases.
+
 use std::fmt;
 use std::time::{Duration, SystemTime};
 
@@ -18,6 +23,7 @@ enum FuzzyTime {
     Yesterday,
 }
 
+/// Format one relative-time unit with simple pluralization.
 fn format_unit(unit: &str, n: u64) -> String {
     format!("{} {}{}", n, unit, if n == 1 { "" } else { "s" })
 }
@@ -54,6 +60,7 @@ impl fmt::Display for FuzzyTime {
     }
 }
 
+/// Format a future timestamp offset.
 fn format_future_time(duration: Duration) -> String {
     let seconds = duration.as_secs();
     let minutes = seconds / 60;
@@ -76,6 +83,7 @@ fn format_future_time(duration: Duration) -> String {
     format!("in {}", format_unit(unit, n))
 }
 
+/// Bucket a past timestamp offset into the phrase used for display.
 fn get_fuzzy_time(duration: Duration) -> FuzzyTime {
     let seconds = duration.as_secs();
     let minutes = seconds / 60;
@@ -100,6 +108,7 @@ fn get_fuzzy_time(duration: Duration) -> FuzzyTime {
     }
 }
 
+/// Return a human-readable relative time string for a system timestamp.
 pub fn fuzzy_time(time: SystemTime) -> String {
     let now = SystemTime::now();
     match now.duration_since(time) {

--- a/src/utils/gitignore.rs
+++ b/src/utils/gitignore.rs
@@ -1,8 +1,8 @@
 //! Gitignore matcher discovery and caching.
 //!
-//! Matchers are built from the worktree root to the listed directory so nested
-//! `.gitignore` files, `.git/info/exclude`, and global gitignore rules can be
-//! applied in the same order as Git-style ignore matching.
+//! The cache builds matchers from the worktree root to the listed directory so
+//! nested `.gitignore` files, `.git/info/exclude`, and global rules match Git
+//! order.
 
 use std::collections::HashMap;
 use std::fs;

--- a/src/utils/gitignore.rs
+++ b/src/utils/gitignore.rs
@@ -1,3 +1,9 @@
+//! Gitignore matcher discovery and caching.
+//!
+//! Matchers are built from the worktree root to the listed directory so nested
+//! `.gitignore` files, `.git/info/exclude`, and global gitignore rules can be
+//! applied in the same order as Git-style ignore matching.
+
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -5,12 +11,14 @@ use std::path::{Path, PathBuf};
 use ignore::Match;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 
+/// Cache of gitignore matchers keyed by listed directory.
 #[derive(Default)]
 pub struct GitignoreCache {
     matchers: HashMap<PathBuf, Option<GitignoreMatcher>>,
 }
 
 impl GitignoreCache {
+    /// Return whether a path is ignored, caching matchers by containing dir.
     pub fn is_ignored(&mut self, path: &Path, is_dir: bool) -> bool {
         let key = matcher_directory(path, is_dir).to_path_buf();
         let matcher = self
@@ -91,6 +99,10 @@ fn matcher_directory(path: &Path, is_dir: bool) -> &Path {
     }
 }
 
+/// Find the worktree root and common git directory for a path.
+///
+/// Linked worktrees store `.git` as a file, so this handles both directory and
+/// `gitdir:` file forms.
 fn find_git_paths(start: &Path) -> Option<GitPaths> {
     let mut current = Some(start);
 
@@ -122,6 +134,7 @@ fn find_git_paths(start: &Path) -> Option<GitPaths> {
 }
 
 #[cfg(test)]
+/// Return git root and common-dir paths for tests.
 pub(crate) fn find_git_paths_parts(
     start: &Path,
 ) -> Option<(PathBuf, PathBuf)> {
@@ -129,6 +142,7 @@ pub(crate) fn find_git_paths_parts(
     Some((git_paths.root, git_paths.common_dir))
 }
 
+/// Collect `.gitignore` files from the worktree root to a directory.
 pub(crate) fn collect_gitignore_files(
     root: &Path,
     directory: &Path,
@@ -179,6 +193,7 @@ fn build_matcher_or_empty(builder: &GitignoreBuilder) -> Gitignore {
     builder.build().unwrap_or_else(|_| Gitignore::empty())
 }
 
+/// Parse a linked worktree `.git` file into its git directory path.
 pub(crate) fn parse_gitdir_file(dot_git: &Path) -> Option<PathBuf> {
     let contents = fs::read_to_string(dot_git).ok()?;
     let value = contents.strip_prefix("gitdir:")?.trim();
@@ -193,6 +208,7 @@ pub(crate) fn parse_gitdir_file(dot_git: &Path) -> Option<PathBuf> {
     }
 }
 
+/// Parse a linked worktree `commondir` file into an absolute-ish path.
 pub(crate) fn parse_commondir(git_dir: &Path) -> Option<PathBuf> {
     let contents = fs::read_to_string(git_dir.join("commondir")).ok()?;
     let common_dir = PathBuf::from(contents.trim());
@@ -209,6 +225,7 @@ fn normalize_path(path: PathBuf) -> PathBuf {
 }
 
 #[cfg(test)]
+/// Return whether a matcher built for a directory ignores a path.
 pub(crate) fn matcher_ignores_path(
     directory: &Path,
     path: &Path,

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -1,9 +1,15 @@
+//! Nerd Font icon selection for files and directories.
+//!
+//! Icons are selected by directory name, exact file name, or longest matching
+//! extension. Unknown files and folders fall back to generic icons.
+
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::OnceLock;
 use std::{fmt, fs};
 
+/// Icon glyphs used for known file and directory categories.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Icon {
     // we define all the possible icons we can use. This will be a growing
@@ -226,7 +232,10 @@ fn get_folder_icon(folder_name: &str) -> Icon {
     *folder_icons().get(folder_name).unwrap_or(&Icon::Folder)
 }
 
-// Helper function to check if a file name ends with an extension
+/// Return whether a file name has a real dotted extension.
+///
+/// Dot-only names and hidden files without a basename are not treated as
+/// extension matches.
 pub(crate) fn has_extension(file_name: &str, ext: &str) -> bool {
     // Guard against empty extension
     if ext.is_empty() {
@@ -264,6 +273,7 @@ fn get_filename_icon(file_name: &str) -> Option<Icon> {
     file_name_icons().get(file_name).cloned()
 }
 
+/// Select an icon for a filesystem entry from metadata and path name.
 pub fn get_item_icon(metadata: &fs::Metadata, file_path: &Path) -> Icon {
     // Work from the final path segment and tolerate non-UTF-8 names.
     let file_name = file_path

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -1,7 +1,7 @@
 //! Nerd Font icon selection for files and directories.
 //!
-//! Icons are selected by directory name, exact file name, or longest matching
-//! extension. Unknown files and folders fall back to generic icons.
+//! Directory names, exact file names, and file extensions map entries to Nerd
+//! Font glyphs. Unknown entries use generic file or folder icons.
 
 use std::collections::HashMap;
 use std::collections::HashSet;

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -1,3 +1,9 @@
+//! Output rendering for long and short listing formats.
+//!
+//! Long format uses `prettytable` rows with optional accent colors. Short
+//! format computes terminal-width-aware columns using visible Unicode width so
+//! ANSI styling and wide glyphs do not distort layout.
+
 use chrono::{DateTime, Local};
 use colored_text::{Colorize, StyledText};
 use prettytable::{Cell, Row, Table};
@@ -20,6 +26,7 @@ const SHORT_CELL_PADDING: usize = 2;
 const LARGE_SIZE_BYTES: u64 = 1024 * 1024;
 const HUGE_SIZE_BYTES: u64 = 1024 * 1024 * 1024;
 
+/// Render long-format rows to stdout.
 pub fn display_long_format(
     file_info: &[FileInfo],
     params: &Params,
@@ -27,6 +34,7 @@ pub fn display_long_format(
     print_table(&build_long_format_table(file_info, params))
 }
 
+/// Build the long-format table without printing it.
 pub(crate) fn build_long_format_table(
     file_info: &[FileInfo],
     params: &Params,
@@ -143,6 +151,7 @@ fn size_cell(
     ))
 }
 
+/// Return the prettytable style spec for a size cell.
 pub(crate) fn size_style_spec_for_color_level(
     size: u64,
     params: &Params,
@@ -159,6 +168,7 @@ pub(crate) fn size_style_spec_for_color_level(
     }
 }
 
+/// Apply timestamp coloring according to age and terminal capability.
 fn long_time_text(
     text: &str,
     mtime: SystemTime,
@@ -275,11 +285,13 @@ fn interpolate(start: u8, end: u8, ratio: f32) -> u8 {
         as u8
 }
 
+/// Render short-format columns to stdout.
 pub fn display_short_format(file_info: &[FileInfo]) -> io::Result<()> {
     let terminal_width = terminal_width_or_default(terminal_size());
     print_short_lines(&render_short_format_lines(file_info, terminal_width))
 }
 
+/// Render short-format rows for a fixed terminal width.
 pub(crate) fn render_short_format_lines(
     file_info: &[FileInfo],
     terminal_width: usize,
@@ -293,6 +305,7 @@ pub(crate) fn render_short_format_lines(
         .collect()
 }
 
+/// Return the detected terminal width, or the standard 80-column fallback.
 pub(crate) fn terminal_width_or_default(
     size: Option<(Width, Height)>,
 ) -> usize {

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -1,5 +1,8 @@
+//! Prettytable construction helpers.
+
 use prettytable::{Table, format::FormatBuilder};
 
+/// Create a borderless table using the spacing expected by `lsplus`.
 pub fn create_table(padding: usize) -> Table {
     let format = FormatBuilder::new()
         .column_separator(' ')

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -1,6 +1,12 @@
+//! Shared duration constants for age bucketing.
+
 use std::time::Duration;
 
+/// One calendar-ish day.
 pub(crate) const DAY: Duration = Duration::from_secs(24 * 60 * 60);
+/// Seven days.
 pub(crate) const WEEK: Duration = Duration::from_secs(7 * DAY.as_secs());
+/// Thirty days, used as the month bucket for display gradients.
 pub(crate) const MONTH: Duration = Duration::from_secs(30 * DAY.as_secs());
+/// Three hundred sixty-five days.
 pub(crate) const YEAR: Duration = Duration::from_secs(365 * DAY.as_secs());


### PR DESCRIPTION
## Summary

Adds Rustdoc coverage across the source modules so the generated API docs explain module responsibilities, shared runtime types, and the helper functions that carry non-obvious behavior.

Also tightens README wording around installation, usage, icons, configuration, and planned work so the project docs read more directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Refreshed README with clearer descriptions of features, compatibility notes (Windows support noted as roadmap), and streamlined installation/usage instructions.
  * Updated comprehensive documentation across installation, introduction, configuration, usage, and roadmap sections for improved clarity.

* **New Features**
  * Added executable file indicator support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->