### PR TITLE
fix: report glob traversal errors

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,7 @@ use crate::Params;
 use crate::cli;
 use crate::settings;
 use crate::utils;
-use crate::utils::file::collect_file_info;
+use crate::utils::file::{collect_file_info, sanitize_for_terminal};
 
 /// Run `lsplus` using parsed CLI flags and config loaded from disk.
 pub fn run_with_flags(args: cli::Flags) -> io::Result<()> {
@@ -89,7 +89,11 @@ fn append_pattern_matches(
                     Ok(path) => paths.push(path),
                     Err(err) => {
                         had_entry_error = true;
-                        eprintln!("lsplus: {}: {}", pattern, err);
+                        eprintln!(
+                            "lsplus: {}: {}",
+                            sanitize_for_terminal(pattern),
+                            err
+                        );
                     }
                 }
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -98,16 +98,18 @@ fn append_pattern_matches(
                 }
             }
 
-            if paths.is_empty() && !had_entry_error {
-                eprintln!(
-                    "lsplus: {}: No such file or directory",
-                    sanitize_for_terminal(pattern)
-                );
+            if paths.is_empty() {
+                if !had_entry_error {
+                    eprintln!(
+                        "lsplus: {}: No such file or directory",
+                        sanitize_for_terminal(pattern)
+                    );
+                }
             } else {
                 append_paths(all_file_info, &paths, params)?;
             }
         }
-        Err(e) => eprintln!("Failed to read glob pattern: {}", e),
+        Err(e) => eprintln!("lsplus: failed to read glob pattern: {}", e),
     }
 
     Ok(())

--- a/src/app.rs
+++ b/src/app.rs
@@ -99,7 +99,10 @@ fn append_pattern_matches(
             }
 
             if paths.is_empty() && !had_entry_error {
-                eprintln!("lsplus: {}: No such file or directory", pattern);
+                eprintln!(
+                    "lsplus: {}: No such file or directory",
+                    sanitize_for_terminal(pattern)
+                );
             } else {
                 append_paths(all_file_info, &paths, params)?;
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -81,8 +81,20 @@ fn append_pattern_matches(
 ) -> io::Result<()> {
     match glob(pattern) {
         Ok(entries) => {
-            let paths: Vec<PathBuf> = entries.filter_map(Result::ok).collect();
-            if paths.is_empty() {
+            let mut paths: Vec<PathBuf> = Vec::new();
+            let mut had_entry_error = false;
+
+            for entry in entries {
+                match entry {
+                    Ok(path) => paths.push(path),
+                    Err(err) => {
+                        had_entry_error = true;
+                        eprintln!("lsplus: {}: {}", pattern, err);
+                    }
+                }
+            }
+
+            if paths.is_empty() && !had_entry_error {
                 eprintln!("lsplus: {}: No such file or directory", pattern);
             } else {
                 append_paths(all_file_info, &paths, params)?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -91,8 +91,10 @@ fn append_pattern_matches(
                         had_entry_error = true;
                         eprintln!(
                             "lsplus: {}: {}",
-                            sanitize_for_terminal(pattern),
-                            err
+                            sanitize_for_terminal(
+                                &err.path().to_string_lossy()
+                            ),
+                            err.error()
                         );
                     }
                 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -82,6 +82,14 @@ fn test_invalid_path() {
         .stderr(predicates::str::contains("No such file or directory"));
 }
 
+#[test]
+fn test_invalid_glob_pattern_reports_lsplus_prefix() {
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.arg("[invalid-glob-pattern").assert().success().stderr(
+        predicates::str::contains("lsplus: failed to read glob pattern"),
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn test_glob_entry_error_reports_stderr_and_lists_matches() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -80,6 +80,30 @@ fn test_invalid_path() {
         .stderr(predicates::str::contains("No such file or directory"));
 }
 
+#[cfg(unix)]
+#[test]
+fn test_glob_entry_error_reports_stderr_and_lists_matches() {
+    let temp_dir = tempdir().unwrap();
+    let readable_file = temp_dir.path().join("visible.txt");
+    let unreadable_dir = temp_dir.path().join("private");
+    fs::write(&readable_file, "visible").unwrap();
+    fs::create_dir(&unreadable_dir).unwrap();
+    fs::set_permissions(&unreadable_dir, fs::Permissions::from_mode(0o000))
+        .unwrap();
+
+    let pattern = format!("{}/**/*.txt", temp_dir.path().display());
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.arg(pattern);
+    let (stdout, stderr) = run_and_capture(&mut cmd);
+
+    fs::set_permissions(&unreadable_dir, fs::Permissions::from_mode(0o700))
+        .unwrap();
+
+    assert!(stdout.contains("visible.txt"));
+    assert!(stderr.contains("attempting to read"));
+    assert!(stderr.contains("private"));
+}
+
 #[test]
 fn test_list_current_directory() {
     let temp_dir = tempdir().unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7,6 +7,8 @@ use strip_ansi_escapes::strip_str;
 use tempfile::tempdir;
 
 #[cfg(unix)]
+use nix::unistd::Uid;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
 fn run_and_capture(cmd: &mut Command) -> (String, String) {
@@ -83,6 +85,10 @@ fn test_invalid_path() {
 #[cfg(unix)]
 #[test]
 fn test_glob_entry_error_reports_stderr_and_lists_matches() {
+    if Uid::effective().is_root() {
+        return;
+    }
+
     let temp_dir = tempdir().unwrap();
     let readable_file = temp_dir.path().join("visible.txt");
     let unreadable_dir = temp_dir.path().join("private");
@@ -100,7 +106,8 @@ fn test_glob_entry_error_reports_stderr_and_lists_matches() {
         .unwrap();
 
     assert!(stdout.contains("visible.txt"));
-    assert!(stderr.contains("attempting to read"));
+    assert!(stderr.contains("lsplus:"));
+    assert!(stderr.contains(temp_dir.path().to_string_lossy().as_ref()));
     assert!(stderr.contains("private"));
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -93,6 +93,19 @@ fn test_invalid_glob_pattern_reports_lsplus_prefix() {
 #[cfg(unix)]
 #[test]
 fn test_glob_entry_error_reports_stderr_and_lists_matches() {
+    struct PermissionGuard {
+        path: std::path::PathBuf,
+    }
+
+    impl Drop for PermissionGuard {
+        fn drop(&mut self) {
+            let _ = fs::set_permissions(
+                &self.path,
+                fs::Permissions::from_mode(0o700),
+            );
+        }
+    }
+
     if Uid::effective().is_root() {
         return;
     }
@@ -104,14 +117,14 @@ fn test_glob_entry_error_reports_stderr_and_lists_matches() {
     fs::create_dir(&unreadable_dir).unwrap();
     fs::set_permissions(&unreadable_dir, fs::Permissions::from_mode(0o000))
         .unwrap();
+    let _guard = PermissionGuard {
+        path: unreadable_dir.clone(),
+    };
 
     let pattern = format!("{}/**/*.txt", temp_dir.path().display());
     let mut cmd = Command::cargo_bin("lsp").unwrap();
     cmd.arg(pattern);
     let (stdout, stderr) = run_and_capture(&mut cmd);
-
-    fs::set_permissions(&unreadable_dir, fs::Permissions::from_mode(0o700))
-        .unwrap();
 
     assert!(stdout.contains("visible.txt"));
     assert!(stderr.contains("lsplus:"));


### PR DESCRIPTION
Report per-entry glob traversal errors instead of dropping them during pattern expansion.

Add a Unix regression test that lists readable matches while surfacing unreadable traversal errors on stderr.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved glob pattern error reporting: individual entry failures on the file system are now written to stderr (with a consistent `lsplus:` prefix) while successfully matched files continue to be shown in stdout. Generic “no such file or directory” messaging is suppressed when per-entry errors occur. Updated error text for failing to read glob patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->