### PR TITLE
fix: render special permission bits

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,8 @@
       modes.
 - [ ] Consider separating config-loaded values from effective runtime params so
       merge behavior is more explicit than the current shared `Params` type.
-- [ ] Review crate/module visibility and reduce the public surface where items
-      do not need to be exported.
+- [ ] Review `src/lib.rs` and crate/module visibility. Keep the current
+      out-of-source unit test layout, but reduce the accidental public library
+      API for this app crate where modules/items do not need to be exported.
 - [ ] Continue shifting tests toward behavior-focused checks at module seams
       (`app`, `settings`, `render`) instead of broad smoke-style coverage.

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -177,9 +177,11 @@ impl Params {
 /// Metadata and pre-rendered name data for one listed filesystem entry.
 #[derive(Debug)]
 pub struct FileInfo {
-    /// Long-format file-type character such as `d`, `-`, `l`, or `?`.
+    /// Long-format file-type character: `d`, `-`, `l`, `s`, `p`, `c`, `b`,
+    /// or `?`.
     pub file_type: String,
-    /// Unix-style `rwxrwxrwx` permission string.
+    /// Unix-style permission string, possibly including `s`, `S`, `t`, or
+    /// `T` special-bit overlays.
     pub mode: String,
     /// Link count from filesystem metadata.
     pub nlink: u64,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -108,6 +108,14 @@ pub enum NameStyle {
     Symlink,
     /// A regular executable file.
     Executable,
+    /// A Unix socket.
+    Socket,
+    /// A Unix FIFO/pipe.
+    Fifo,
+    /// A Unix character device.
+    CharDevice,
+    /// A Unix block device.
+    BlockDevice,
 }
 
 impl From<Config> for Params {

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -52,6 +52,8 @@ fn get_file_details(metadata: &fs::Metadata) -> FileDetails {
         "-"
     } else if metadata.is_symlink() {
         "l"
+    } else if metadata.file_type().is_socket() {
+        "s"
     } else {
         "?"
     }

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -35,6 +35,55 @@ struct FileDetails {
     group: String,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LongFormatFileType {
+    Directory,
+    Regular,
+    Symlink,
+    Socket,
+    Fifo,
+    CharDevice,
+    BlockDevice,
+    Unknown,
+}
+
+impl LongFormatFileType {
+    pub(crate) fn as_char(self) -> char {
+        match self {
+            Self::Directory => 'd',
+            Self::Regular => '-',
+            Self::Symlink => 'l',
+            Self::Socket => 's',
+            Self::Fifo => 'p',
+            Self::CharDevice => 'c',
+            Self::BlockDevice => 'b',
+            Self::Unknown => '?',
+        }
+    }
+}
+
+pub(crate) fn long_format_file_type(
+    metadata: &fs::Metadata,
+) -> LongFormatFileType {
+    if metadata.is_dir() {
+        LongFormatFileType::Directory
+    } else if metadata.is_file() {
+        LongFormatFileType::Regular
+    } else if metadata.is_symlink() {
+        LongFormatFileType::Symlink
+    } else if metadata.file_type().is_socket() {
+        LongFormatFileType::Socket
+    } else if metadata.file_type().is_fifo() {
+        LongFormatFileType::Fifo
+    } else if metadata.file_type().is_char_device() {
+        LongFormatFileType::CharDevice
+    } else if metadata.file_type().is_block_device() {
+        LongFormatFileType::BlockDevice
+    } else {
+        LongFormatFileType::Unknown
+    }
+}
+
 /// Directory entry data captured before visibility filtering and sorting.
 pub(crate) struct DirectoryEntryData {
     /// Raw entry name from `read_dir`.
@@ -46,18 +95,7 @@ pub(crate) struct DirectoryEntryData {
 }
 
 fn get_file_details(metadata: &fs::Metadata) -> FileDetails {
-    let file_type = if metadata.is_dir() {
-        "d"
-    } else if metadata.is_file() {
-        "-"
-    } else if metadata.is_symlink() {
-        "l"
-    } else if metadata.file_type().is_socket() {
-        "s"
-    } else {
-        "?"
-    }
-    .to_string();
+    let file_type = long_format_file_type(metadata).as_char().to_string();
 
     let permissions = metadata.permissions();
     let mode = permissions.mode();

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -501,18 +501,30 @@ fn file_type_indicator_suffix(
     metadata: &fs::Metadata,
     classify_executables: bool,
 ) -> &'static str {
-    if metadata.is_dir() {
-        "/"
-    } else if metadata.is_symlink() {
-        "@"
-    } else if metadata.file_type().is_fifo() {
-        "|"
-    } else if metadata.file_type().is_socket() {
-        "="
-    } else if classify_executables && is_executable(metadata) {
-        "*"
-    } else {
-        ""
+    file_type_indicator_suffix_for_type(
+        long_format_file_type(metadata),
+        classify_executables,
+        is_executable(metadata),
+    )
+}
+
+pub(crate) fn file_type_indicator_suffix_for_type(
+    file_type: LongFormatFileType,
+    classify_executables: bool,
+    executable: bool,
+) -> &'static str {
+    match file_type {
+        LongFormatFileType::Directory => "/",
+        LongFormatFileType::Symlink => "@",
+        LongFormatFileType::Fifo => "|",
+        LongFormatFileType::Socket => "=",
+        LongFormatFileType::Regular if classify_executables && executable => {
+            "*"
+        }
+        LongFormatFileType::Regular
+        | LongFormatFileType::CharDevice
+        | LongFormatFileType::BlockDevice
+        | LongFormatFileType::Unknown => "",
     }
 }
 

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -524,16 +524,29 @@ fn plain_text(text: impl Into<String>, dimmed: bool) -> String {
     apply_dim(StyledText::plain(text), dimmed).to_string()
 }
 
-fn name_style_by_metadata(metadata: &fs::Metadata) -> NameStyle {
-    if metadata.is_symlink() {
-        NameStyle::Symlink
-    } else if metadata.is_dir() {
-        NameStyle::Directory
-    } else if is_executable(metadata) {
-        NameStyle::Executable
-    } else {
-        NameStyle::Plain
+pub(crate) fn name_style_for_file_type(
+    file_type: LongFormatFileType,
+    executable: bool,
+) -> NameStyle {
+    match file_type {
+        LongFormatFileType::Symlink => NameStyle::Symlink,
+        LongFormatFileType::Directory => NameStyle::Directory,
+        LongFormatFileType::Socket => NameStyle::Socket,
+        LongFormatFileType::Fifo => NameStyle::Fifo,
+        LongFormatFileType::CharDevice => NameStyle::CharDevice,
+        LongFormatFileType::BlockDevice => NameStyle::BlockDevice,
+        LongFormatFileType::Regular if executable => NameStyle::Executable,
+        LongFormatFileType::Regular | LongFormatFileType::Unknown => {
+            NameStyle::Plain
+        }
     }
+}
+
+fn name_style_by_metadata(metadata: &fs::Metadata) -> NameStyle {
+    name_style_for_file_type(
+        long_format_file_type(metadata),
+        is_executable(metadata),
+    )
 }
 
 fn colorize_name_by_metadata(
@@ -548,6 +561,13 @@ fn colorize_name_by_metadata(
         }
         NameStyle::Executable => {
             apply_dim(safe_name.green().bold(), dimmed).to_string()
+        }
+        NameStyle::Socket => {
+            apply_dim(safe_name.magenta().bold(), dimmed).to_string()
+        }
+        NameStyle::Fifo => apply_dim(safe_name.yellow(), dimmed).to_string(),
+        NameStyle::CharDevice | NameStyle::BlockDevice => {
+            apply_dim(safe_name.yellow().bold(), dimmed).to_string()
         }
         NameStyle::Plain => plain_text(safe_name, dimmed),
     }

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -2,33 +2,25 @@
 
 /// Convert Unix permission bits into an `rwxrwxrwx` string.
 pub fn mode_to_rwx(mode: u32) -> String {
-    let mut rwx = String::new();
-    let perms = [
-        (mode & 0o400, 'r'),
-        (mode & 0o200, 'w'),
-        (mode & 0o100, 'x'), // Owner
-        (mode & 0o040, 'r'),
-        (mode & 0o020, 'w'),
-        (mode & 0o010, 'x'), // Group
-        (mode & 0o004, 'r'),
-        (mode & 0o002, 'w'),
-        (mode & 0o001, 'x'), // Others
-    ];
+    let mut rwx = String::with_capacity(9);
 
-    for (bit, chr) in perms.iter() {
-        if *bit != 0 {
-            rwx.push(*chr);
-        } else {
-            rwx.push('-');
-        }
-    }
+    rwx.push(permission_char(mode, 0o400, 'r'));
+    rwx.push(permission_char(mode, 0o200, 'w'));
+    rwx.push(special_execute_char(mode, 0o4000, 0o100, 's', 'S'));
 
-    let mut chars: Vec<char> = rwx.chars().collect();
-    chars[2] = special_execute_char(mode, 0o4000, 0o100, 's', 'S');
-    chars[5] = special_execute_char(mode, 0o2000, 0o010, 's', 'S');
-    chars[8] = special_execute_char(mode, 0o1000, 0o001, 't', 'T');
+    rwx.push(permission_char(mode, 0o040, 'r'));
+    rwx.push(permission_char(mode, 0o020, 'w'));
+    rwx.push(special_execute_char(mode, 0o2000, 0o010, 's', 'S'));
 
-    chars.into_iter().collect()
+    rwx.push(permission_char(mode, 0o004, 'r'));
+    rwx.push(permission_char(mode, 0o002, 'w'));
+    rwx.push(special_execute_char(mode, 0o1000, 0o001, 't', 'T'));
+
+    rwx
+}
+
+fn permission_char(mode: u32, bit: u32, value: char) -> char {
+    if mode & bit != 0 { value } else { '-' }
 }
 
 fn special_execute_char(

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -23,7 +23,27 @@ pub fn mode_to_rwx(mode: u32) -> String {
         }
     }
 
-    rwx
+    let mut chars: Vec<char> = rwx.chars().collect();
+    chars[2] = special_execute_char(mode, 0o4000, 0o100, 's', 'S');
+    chars[5] = special_execute_char(mode, 0o2000, 0o010, 's', 'S');
+    chars[8] = special_execute_char(mode, 0o1000, 0o001, 't', 'T');
+
+    chars.into_iter().collect()
+}
+
+fn special_execute_char(
+    mode: u32,
+    special_bit: u32,
+    execute_bit: u32,
+    execute_char: char,
+    no_execute_char: char,
+) -> char {
+    match (mode & special_bit != 0, mode & execute_bit != 0) {
+        (true, true) => execute_char,
+        (true, false) => no_execute_char,
+        (false, true) => 'x',
+        (false, false) => '-',
+    }
 }
 
 /// Scale a byte count into the largest binary unit below 1024.

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -9,6 +9,8 @@ use std::path::Path;
 use std::sync::OnceLock;
 use std::{fmt, fs};
 
+use crate::utils::file::{LongFormatFileType, long_format_file_type};
+
 /// Icon glyphs used for known file and directory categories.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Icon {
@@ -17,6 +19,10 @@ pub enum Icon {
     Folder = '\u{f07c}' as isize,
     Symlink = '\u{f1177}' as isize,
     GenericFile = '\u{f15b}' as isize,
+    SocketFile = '\u{f0318}' as isize,
+    PipeFile = '\u{f07e5}' as isize,
+    CharDeviceFile = '\u{f0fb0}' as isize,
+    BlockDeviceFile = '\u{f02ca}' as isize,
 
     // specific folder types
     CacheFolder = '\u{f163f}' as isize,
@@ -281,14 +287,33 @@ pub fn get_item_icon(metadata: &fs::Metadata, file_path: &Path) -> Icon {
         .map(|name| name.to_string_lossy())
         .unwrap_or_default();
 
-    // Return the icon for the item based on its metadata and name
-    if metadata.is_dir() {
-        // Icon::Folder
-        get_folder_icon(file_name.as_ref())
-    } else if metadata.is_symlink() {
-        Icon::Symlink
-    } else {
-        get_filename_icon(file_name.as_ref())
-            .unwrap_or_else(|| get_file_icon(file_name.as_ref()))
+    let file_type = long_format_file_type(metadata);
+    if let Some(icon) = special_file_type_icon(file_type) {
+        return icon;
+    }
+
+    match file_type {
+        LongFormatFileType::Directory => get_folder_icon(file_name.as_ref()),
+        LongFormatFileType::Symlink => Icon::Symlink,
+        LongFormatFileType::Regular | LongFormatFileType::Unknown => {
+            get_filename_icon(file_name.as_ref())
+                .unwrap_or_else(|| get_file_icon(file_name.as_ref()))
+        }
+        LongFormatFileType::Socket
+        | LongFormatFileType::Fifo
+        | LongFormatFileType::CharDevice
+        | LongFormatFileType::BlockDevice => unreachable!(),
+    }
+}
+
+pub(crate) fn special_file_type_icon(
+    file_type: LongFormatFileType,
+) -> Option<Icon> {
+    match file_type {
+        LongFormatFileType::Socket => Some(Icon::SocketFile),
+        LongFormatFileType::Fifo => Some(Icon::PipeFile),
+        LongFormatFileType::CharDevice => Some(Icon::CharDeviceFile),
+        LongFormatFileType::BlockDevice => Some(Icon::BlockDeviceFile),
+        _ => None,
     }
 }

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -441,6 +441,9 @@ fn style_short_segment(info: &FileInfo, text: String) -> String {
         NameStyle::Directory => text.blue(),
         NameStyle::Symlink => text.cyan(),
         NameStyle::Executable => text.green().bold(),
+        NameStyle::Socket => text.magenta().bold(),
+        NameStyle::Fifo => text.yellow(),
+        NameStyle::CharDevice | NameStyle::BlockDevice => text.yellow().bold(),
     };
 
     if info.dimmed {

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -121,6 +121,7 @@ fn write_file_type_char(output: &mut String, value: char) {
     match value {
         'd' => write!(output, "{}", value.blue()).unwrap(),
         'l' => write!(output, "{}", value.cyan()).unwrap(),
+        's' => write!(output, "{}", value.magenta().bold()).unwrap(),
         '-' => write!(output, "{}", value.dim()).unwrap(),
         _ => output.push(value),
     }

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -122,6 +122,8 @@ fn write_file_type_char(output: &mut String, value: char) {
         'd' => write!(output, "{}", value.blue()).unwrap(),
         'l' => write!(output, "{}", value.cyan()).unwrap(),
         's' => write!(output, "{}", value.magenta().bold()).unwrap(),
+        'p' => write!(output, "{}", value.yellow()).unwrap(),
+        'c' | 'b' => write!(output, "{}", value.yellow().bold()).unwrap(),
         '-' | '?' => write!(output, "{}", value.dim()).unwrap(),
         _ => output.push(value),
     }

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -122,7 +122,7 @@ fn write_file_type_char(output: &mut String, value: char) {
         'd' => write!(output, "{}", value.blue()).unwrap(),
         'l' => write!(output, "{}", value.cyan()).unwrap(),
         's' => write!(output, "{}", value.magenta().bold()).unwrap(),
-        '-' => write!(output, "{}", value.dim()).unwrap(),
+        '-' | '?' => write!(output, "{}", value.dim()).unwrap(),
         _ => output.push(value),
     }
 }
@@ -131,8 +131,8 @@ fn write_permission_char(output: &mut String, value: char) {
     match value {
         'r' => write!(output, "{}", value.green()).unwrap(),
         'w' => write!(output, "{}", value.yellow()).unwrap(),
-        'x' => write!(output, "{}", value.red().bold()).unwrap(),
-        '-' => write!(output, "{}", value.dim()).unwrap(),
+        'x' | 's' | 't' => write!(output, "{}", value.red().bold()).unwrap(),
+        '-' | 'S' | 'T' => write!(output, "{}", value.dim()).unwrap(),
         _ => output.push(value),
     }
 }

--- a/tests/crate/file.rs
+++ b/tests/crate/file.rs
@@ -406,6 +406,7 @@ fn test_create_file_info_classify_prefers_fifo_and_socket_indicators() {
     let fifo_info = create_file_info(&fifo_path, &params).unwrap();
     let socket_info = create_file_info(&socket_path, &params).unwrap();
 
+    assert_eq!(socket_info.file_type, "s");
     assert!(strip_str(&fifo_info.display_name).ends_with('|'));
     assert!(!strip_str(&fifo_info.display_name).ends_with('*'));
     assert!(strip_str(&socket_info.display_name).ends_with('='));

--- a/tests/crate/file.rs
+++ b/tests/crate/file.rs
@@ -4,7 +4,8 @@ use crate::common_tests::{
 use crate::utils::file::{
     DirectoryEntryData, LongFormatFileType, append_file_info_for_names,
     check_display_name, collect_file_info, collect_file_names,
-    collect_visible_file_names, create_file_info, format_path_error,
+    collect_visible_file_names, create_file_info,
+    file_type_indicator_suffix_for_type, format_path_error,
     format_symlink_display_name_with_dim, get_groupname, get_username,
     name_style_for_file_type, sanitize_for_terminal,
 };
@@ -418,6 +419,33 @@ fn test_create_file_info_classify_prefers_fifo_and_socket_indicators() {
     assert!(!strip_str(&fifo_info.display_name).ends_with('*'));
     assert!(strip_str(&socket_info.display_name).ends_with('='));
     assert!(!strip_str(&socket_info.display_name).ends_with('*'));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_file_type_indicator_suffix_for_unix_special_types() {
+    let cases = [
+        (LongFormatFileType::Directory, false, true, "/"),
+        (LongFormatFileType::Symlink, false, true, "@"),
+        (LongFormatFileType::Fifo, true, true, "|"),
+        (LongFormatFileType::Socket, true, true, "="),
+        (LongFormatFileType::Regular, true, true, "*"),
+        (LongFormatFileType::Regular, false, true, ""),
+        (LongFormatFileType::CharDevice, true, true, ""),
+        (LongFormatFileType::BlockDevice, true, true, ""),
+        (LongFormatFileType::Unknown, true, true, ""),
+    ];
+
+    for (file_type, classify_executables, executable, expected) in cases {
+        assert_eq!(
+            file_type_indicator_suffix_for_type(
+                file_type,
+                classify_executables,
+                executable
+            ),
+            expected
+        );
+    }
 }
 
 #[cfg(unix)]

--- a/tests/crate/file.rs
+++ b/tests/crate/file.rs
@@ -6,8 +6,9 @@ use crate::utils::file::{
     check_display_name, collect_file_info, collect_file_names,
     collect_visible_file_names, create_file_info, format_path_error,
     format_symlink_display_name_with_dim, get_groupname, get_username,
-    sanitize_for_terminal,
+    name_style_for_file_type, sanitize_for_terminal,
 };
+use crate::utils::icons::Icon;
 use crate::{FileInfo, IndicatorStyle, NameStyle, Params};
 use colored_text::ColorMode;
 use std::ffi::OsString;
@@ -409,10 +410,43 @@ fn test_create_file_info_classify_prefers_fifo_and_socket_indicators() {
 
     assert_eq!(fifo_info.file_type, "p");
     assert_eq!(socket_info.file_type, "s");
+    assert_eq!(fifo_info.name_style, NameStyle::Fifo);
+    assert_eq!(socket_info.name_style, NameStyle::Socket);
+    assert_eq!(fifo_info.item_icon, Some(Icon::PipeFile));
+    assert_eq!(socket_info.item_icon, Some(Icon::SocketFile));
     assert!(strip_str(&fifo_info.display_name).ends_with('|'));
     assert!(!strip_str(&fifo_info.display_name).ends_with('*'));
     assert!(strip_str(&socket_info.display_name).ends_with('='));
     assert!(!strip_str(&socket_info.display_name).ends_with('*'));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_create_file_info_colors_special_file_names() {
+    with_color_output_enabled(|| {
+        let temp_dir = tempdir().unwrap();
+        let fifo_path = temp_dir.path().join("pipe");
+        let socket_path = temp_dir.path().join("socket");
+        let status = Command::new("mkfifo").arg(&fifo_path).status().unwrap();
+        assert!(status.success());
+
+        let _listener = UnixListener::bind(&socket_path).unwrap();
+
+        fs::set_permissions(&fifo_path, fs::Permissions::from_mode(0o755))
+            .unwrap();
+        fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o755))
+            .unwrap();
+
+        let fifo_info =
+            create_file_info(&fifo_path, &Params::default()).unwrap();
+        let socket_info =
+            create_file_info(&socket_path, &Params::default()).unwrap();
+
+        assert!(fifo_info.display_name.contains("\u{1b}[33m"));
+        assert!(!fifo_info.display_name.contains("\u{1b}[1;32m"));
+        assert!(socket_info.display_name.contains("\u{1b}[1;35m"));
+        assert!(!socket_info.display_name.contains("\u{1b}[1;32m"));
+    });
 }
 
 #[cfg(unix)]
@@ -428,6 +462,23 @@ fn test_long_format_file_type_chars_for_unix_special_types() {
 
     for (file_type, expected) in cases {
         assert_eq!(file_type.as_char(), expected);
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn test_name_style_for_unix_special_file_types() {
+    let cases = [
+        (LongFormatFileType::Socket, NameStyle::Socket),
+        (LongFormatFileType::Fifo, NameStyle::Fifo),
+        (LongFormatFileType::CharDevice, NameStyle::CharDevice),
+        (LongFormatFileType::BlockDevice, NameStyle::BlockDevice),
+        (LongFormatFileType::Regular, NameStyle::Executable),
+        (LongFormatFileType::Unknown, NameStyle::Plain),
+    ];
+
+    for (file_type, expected) in cases {
+        assert_eq!(name_style_for_file_type(file_type, true), expected);
     }
 }
 

--- a/tests/crate/file.rs
+++ b/tests/crate/file.rs
@@ -2,10 +2,11 @@ use crate::common_tests::{
     ColorModeGuard, has_ansi, with_color_output_enabled,
 };
 use crate::utils::file::{
-    DirectoryEntryData, append_file_info_for_names, check_display_name,
-    collect_file_info, collect_file_names, collect_visible_file_names,
-    create_file_info, format_path_error, format_symlink_display_name_with_dim,
-    get_groupname, get_username, sanitize_for_terminal,
+    DirectoryEntryData, LongFormatFileType, append_file_info_for_names,
+    check_display_name, collect_file_info, collect_file_names,
+    collect_visible_file_names, create_file_info, format_path_error,
+    format_symlink_display_name_with_dim, get_groupname, get_username,
+    sanitize_for_terminal,
 };
 use crate::{FileInfo, IndicatorStyle, NameStyle, Params};
 use colored_text::ColorMode;
@@ -367,7 +368,7 @@ fn test_create_file_info_returns_plain_names_when_color_is_disabled() {
 
 #[cfg(unix)]
 #[test]
-fn test_create_file_info_marks_fifo_as_unknown_type() {
+fn test_create_file_info_marks_fifo_as_pipe_type() {
     let temp_dir = tempdir().unwrap();
     let fifo_path = temp_dir.path().join("pipe");
     let status = Command::new("mkfifo").arg(&fifo_path).status().unwrap();
@@ -375,7 +376,7 @@ fn test_create_file_info_marks_fifo_as_unknown_type() {
 
     let info = create_file_info(&fifo_path, &Params::default()).unwrap();
 
-    assert_eq!(info.file_type, "?");
+    assert_eq!(info.file_type, "p");
 }
 
 #[cfg(unix)]
@@ -406,11 +407,28 @@ fn test_create_file_info_classify_prefers_fifo_and_socket_indicators() {
     let fifo_info = create_file_info(&fifo_path, &params).unwrap();
     let socket_info = create_file_info(&socket_path, &params).unwrap();
 
+    assert_eq!(fifo_info.file_type, "p");
     assert_eq!(socket_info.file_type, "s");
     assert!(strip_str(&fifo_info.display_name).ends_with('|'));
     assert!(!strip_str(&fifo_info.display_name).ends_with('*'));
     assert!(strip_str(&socket_info.display_name).ends_with('='));
     assert!(!strip_str(&socket_info.display_name).ends_with('*'));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_long_format_file_type_chars_for_unix_special_types() {
+    let cases = [
+        (LongFormatFileType::Fifo, 'p'),
+        (LongFormatFileType::Socket, 's'),
+        (LongFormatFileType::CharDevice, 'c'),
+        (LongFormatFileType::BlockDevice, 'b'),
+        (LongFormatFileType::Unknown, '?'),
+    ];
+
+    for (file_type, expected) in cases {
+        assert_eq!(file_type.as_char(), expected);
+    }
 }
 
 #[cfg(unix)]

--- a/tests/crate/icons.rs
+++ b/tests/crate/icons.rs
@@ -1,4 +1,7 @@
-use crate::utils::icons::{Icon, get_item_icon, has_extension};
+use crate::utils::file::LongFormatFileType;
+use crate::utils::icons::{
+    Icon, get_item_icon, has_extension, special_file_type_icon,
+};
 use std::fs;
 use std::path::Path;
 use tempfile::tempdir;
@@ -66,6 +69,22 @@ fn test_get_item_icon_handles_symlinks_and_non_utf8_extensions() {
     let metadata = fs::metadata(&full_path).unwrap();
 
     assert_eq!(get_item_icon(&metadata, &full_path), Icon::RustFile);
+}
+
+#[test]
+fn test_special_file_type_icons() {
+    let cases = [
+        (LongFormatFileType::Socket, Some(Icon::SocketFile)),
+        (LongFormatFileType::Fifo, Some(Icon::PipeFile)),
+        (LongFormatFileType::CharDevice, Some(Icon::CharDeviceFile)),
+        (LongFormatFileType::BlockDevice, Some(Icon::BlockDeviceFile)),
+        (LongFormatFileType::Regular, None),
+        (LongFormatFileType::Unknown, None),
+    ];
+
+    for (file_type, expected) in cases {
+        assert_eq!(special_file_type_icon(file_type), expected);
+    }
 }
 
 #[test]

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -123,7 +123,7 @@ fn test_build_long_format_table_colors_permissions_by_default() {
         let mut info =
             test_file_info("script.sh", None, 12, SystemTime::now());
         info.file_type = String::from("d");
-        info.mode = String::from("rwxr-x---");
+        info.mode = String::from("rwsr-tS-T");
 
         let rendered = normalized_table(build_long_format_table(
             &[info],
@@ -133,23 +133,29 @@ fn test_build_long_format_table_colors_permissions_by_default() {
         assert!(rendered.contains("\u{1b}[34md\u{1b}[0m"));
         assert!(rendered.contains("\u{1b}[32mr\u{1b}[0m"));
         assert!(rendered.contains("\u{1b}[33mw\u{1b}[0m"));
-        assert!(rendered.contains("\u{1b}[1;31mx\u{1b}[0m"));
-        assert!(rendered.contains("\u{1b}[2m-\u{1b}[0m"));
+        assert!(rendered.contains("\u{1b}[1;31ms\u{1b}[0m"));
+        assert!(rendered.contains("\u{1b}[1;31mt\u{1b}[0m"));
+        assert!(rendered.contains("\u{1b}[2mS\u{1b}[0m"));
+        assert!(rendered.contains("\u{1b}[2mT\u{1b}[0m"));
     });
 }
 
 #[test]
-fn test_build_long_format_table_colors_socket_type() {
+fn test_build_long_format_table_colors_special_file_types() {
     with_color_output_enabled(|| {
         let mut info = test_file_info("socket", None, 0, SystemTime::now());
         info.file_type = String::from("s");
+        let mut unknown =
+            test_file_info("unknown", None, 0, SystemTime::now());
+        unknown.file_type = String::from("?");
 
         let rendered = normalized_table(build_long_format_table(
-            &[info],
+            &[info, unknown],
             &fixed_time_params(),
         ));
 
         assert!(rendered.contains("\u{1b}[1;35ms\u{1b}[0m"));
+        assert!(rendered.contains("\u{1b}[2m?\u{1b}[0m"));
     });
 }
 

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -143,18 +143,29 @@ fn test_build_long_format_table_colors_permissions_by_default() {
 #[test]
 fn test_build_long_format_table_colors_special_file_types() {
     with_color_output_enabled(|| {
-        let mut info = test_file_info("socket", None, 0, SystemTime::now());
-        info.file_type = String::from("s");
+        let mut pipe = test_file_info("pipe", None, 0, SystemTime::now());
+        pipe.file_type = String::from("p");
+        let mut socket = test_file_info("socket", None, 0, SystemTime::now());
+        socket.file_type = String::from("s");
+        let mut char_device =
+            test_file_info("char", None, 0, SystemTime::now());
+        char_device.file_type = String::from("c");
+        let mut block_device =
+            test_file_info("block", None, 0, SystemTime::now());
+        block_device.file_type = String::from("b");
         let mut unknown =
             test_file_info("unknown", None, 0, SystemTime::now());
         unknown.file_type = String::from("?");
 
         let rendered = normalized_table(build_long_format_table(
-            &[info, unknown],
+            &[pipe, socket, char_device, block_device, unknown],
             &fixed_time_params(),
         ));
 
+        assert!(rendered.contains("\u{1b}[33mp\u{1b}[0m"));
         assert!(rendered.contains("\u{1b}[1;35ms\u{1b}[0m"));
+        assert!(rendered.contains("\u{1b}[1;33mc\u{1b}[0m"));
+        assert!(rendered.contains("\u{1b}[1;33mb\u{1b}[0m"));
         assert!(rendered.contains("\u{1b}[2m?\u{1b}[0m"));
     });
 }

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -139,6 +139,21 @@ fn test_build_long_format_table_colors_permissions_by_default() {
 }
 
 #[test]
+fn test_build_long_format_table_colors_socket_type() {
+    with_color_output_enabled(|| {
+        let mut info = test_file_info("socket", None, 0, SystemTime::now());
+        info.file_type = String::from("s");
+
+        let rendered = normalized_table(build_long_format_table(
+            &[info],
+            &fixed_time_params(),
+        ));
+
+        assert!(rendered.contains("\u{1b}[1;35ms\u{1b}[0m"));
+    });
+}
+
+#[test]
 fn test_build_long_format_table_omits_permission_colors_when_disabled() {
     with_color_output_enabled(|| {
         let mut info =

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -3,6 +3,7 @@ use crate::common_tests::{
     plain_permission_params, time_only_params, with_color_output_enabled,
 };
 use crate::utils::color::LongFormatColorLevel;
+use crate::utils::format::mode_to_rwx;
 use crate::utils::icons::Icon;
 use crate::utils::render::{
     build_long_format_table, render_short_format_lines,
@@ -135,6 +136,41 @@ fn test_build_long_format_table_colors_permissions_by_default() {
         assert!(rendered.contains("\u{1b}[33mw\u{1b}[0m"));
         assert!(rendered.contains("\u{1b}[1;31ms\u{1b}[0m"));
         assert!(rendered.contains("\u{1b}[1;31mt\u{1b}[0m"));
+        assert!(rendered.contains("\u{1b}[2mS\u{1b}[0m"));
+        assert!(rendered.contains("\u{1b}[2mT\u{1b}[0m"));
+    });
+}
+
+#[test]
+fn test_build_long_format_table_styles_every_mode_to_rwx_char() {
+    with_color_output_enabled(|| {
+        let emitted = [
+            mode_to_rwx(0o7777),
+            mode_to_rwx(0o4644),
+            mode_to_rwx(0o1644),
+            mode_to_rwx(0o0111),
+            mode_to_rwx(0o0000),
+        ]
+        .join("");
+        for value in ['r', 'w', 'x', '-', 's', 'S', 't', 'T'] {
+            assert!(emitted.contains(value));
+        }
+
+        let mut info =
+            test_file_info("script.sh", None, 12, SystemTime::now());
+        info.mode = emitted;
+
+        let rendered = normalized_table(build_long_format_table(
+            &[info],
+            &fixed_time_params(),
+        ));
+
+        assert!(rendered.contains("\u{1b}[32mr\u{1b}[0m"));
+        assert!(rendered.contains("\u{1b}[33mw\u{1b}[0m"));
+        assert!(rendered.contains("\u{1b}[1;31mx\u{1b}[0m"));
+        assert!(rendered.contains("\u{1b}[1;31ms\u{1b}[0m"));
+        assert!(rendered.contains("\u{1b}[1;31mt\u{1b}[0m"));
+        assert!(rendered.contains("\u{1b}[2m-\u{1b}[0m"));
         assert!(rendered.contains("\u{1b}[2mS\u{1b}[0m"));
         assert!(rendered.contains("\u{1b}[2mT\u{1b}[0m"));
     });

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -87,3 +87,14 @@ fn test_mode_to_rwx_edge_cases() {
     assert_eq!(mode_to_rwx(0o0222), "-w--w--w-");
     assert_eq!(mode_to_rwx(0o0111), "--x--x--x");
 }
+
+#[test]
+fn test_mode_to_rwx_special_bits() {
+    assert_eq!(mode_to_rwx(0o4755), "rwsr-xr-x");
+    assert_eq!(mode_to_rwx(0o4644), "rwSr--r--");
+    assert_eq!(mode_to_rwx(0o2755), "rwxr-sr-x");
+    assert_eq!(mode_to_rwx(0o2644), "rw-r-Sr--");
+    assert_eq!(mode_to_rwx(0o1755), "rwxr-xr-t");
+    assert_eq!(mode_to_rwx(0o1644), "rw-r--r-T");
+    assert_eq!(mode_to_rwx(0o7777), "rwsrwsrwt");
+}


### PR DESCRIPTION
Updates long-format Unix metadata rendering so special permission bits and special file types are displayed consistently.

Long-format permissions now render setuid, setgid, and sticky modes with s/S/t/T. Unix special file types now use standard type characters for sockets, FIFOs, character devices, and block devices, with matching name colors and Nerd Font icons where icons are enabled.

The shared file-type classifier now drives long-format type chars, name styling, icon selection, and indicator suffixes. Existing GNU-style suffix behavior is preserved for directories, symlinks, FIFOs, and sockets; executable * indicators apply only to regular executable files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for more filesystem entry types in listings, including sockets, FIFOs, character devices, and block devices.
  * Improved long-format and short-format visual indicators so these special items now show distinct colours and icons.

* **Bug Fixes**
  * Corrected file-type detection for special Unix entries, including pipe/FIFO handling.
  * Expanded permission display to better reflect special access bits such as setuid, setgid, and sticky flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->