### PR TITLE
Add GNU-style size unit scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ Currently, only a sub-set of the standard `ls` options are supported. These are:
 - `-F` / `--classify` - Append type indicators, including `*` for executables
 - `--no-indicators` - Disable file type indicators
 - `-l` / `--long` - Show long format listing
-- `-h` / `--human-readable` - Human readable file sizes
+- `-h` / `--human-readable` - Human readable file sizes using powers of 1024
+- `--si` - Human readable file sizes using powers of 1000
 - `-D` / `--sort-dirs` - Sort directories first
 - `-I` / `--gitignore` - Dim entries matched by Git ignore rules
 - `-N` / `--no-color` - Disable colored and styled output

--- a/TODO.md
+++ b/TODO.md
@@ -21,6 +21,8 @@
       modes.
 - [ ] Consider separating config-loaded values from effective runtime params so
       merge behavior is more explicit than the current shared `Params` type.
+- [ ] Extend human-readable size units beyond petabytes so exabyte-scale values
+      render as `E` instead of large `P` multiples.
 - [ ] Review `src/lib.rs` and crate/module visibility. Keep the current
       out-of-source unit test layout, but reduce the accidental public library
       API for this app crate where modules/items do not need to be exported.

--- a/TODO.md
+++ b/TODO.md
@@ -16,9 +16,6 @@
 - [ ] option to list dotfiles (and folders) before non-dotfiles
 - [ ] Investigate an optional name-shortening mode for very long filenames
       that preserves extensions without changing the default wrap behavior.
-- [ ] Consider colouring special permission bits (`s`, `S`, `t`, `T`) in
-      long-format permission output, with tests for setuid, setgid, and sticky
-      modes.
 - [ ] Consider separating config-loaded values from effective runtime params so
       merge behavior is more explicit than the current shared `Params` type.
 - [ ] Extend human-readable size units beyond petabytes so exabyte-scale values

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -93,7 +93,15 @@ to `true`.
 - Default value: `false`
 
 This option corresponds to `-h` or `--human-readable` and displays
-human-readable file sizes when set to `true`.
+human-readable file sizes using powers of 1024 when set to `true`.
+
+### si
+
+- Permitted values: `true` or `false`
+- Default value: `false`
+
+This option corresponds to `--si` and displays human-readable file sizes using
+powers of 1000 when set to `true`. It also enables human-readable size output.
 
 ### no_icons
 
@@ -169,6 +177,7 @@ show_all = true
 indicator_style = "classify"
 dirs_first = true
 human_readable = true
+# si = true
 no_color = true
 permission_colors = false
 time_gradient = false

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -18,7 +18,8 @@ Currently, only a sub-set of the standard `ls` options are supported. These are:
 - `-F` / `--classify` - Append type indicators, including `*` for executables
 - `--no-indicators` - Disable file type indicators
 - `-l` / `--long` - Show long format listing
-- `-h` / `--human-readable` - Human readable file sizes
+- `-h` / `--human-readable` - Human readable file sizes using powers of 1024
+- `--si` - Human readable file sizes using powers of 1000
 - `-D` / `--sort-dirs` - Sort directories first
 - `-I` / `--gitignore` - Dim entries matched by Git ignore rules
 - `-N` / `--no-color` - Disable colored and styled output

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,7 @@ const ARG_SHOW_ALL: &str = "show_all";
 const ARG_ALMOST_ALL: &str = "almost_all";
 const ARG_LONG: &str = "long";
 const ARG_HUMAN_READABLE: &str = "human_readable";
+const ARG_SI: &str = "si";
 const ARG_PATHS: &str = "paths";
 const ARG_SLASH: &str = "slash";
 const ARG_INDICATOR_STYLE: &str = "indicator_style";
@@ -69,6 +70,8 @@ pub struct Flags {
     pub long: bool,
     /// Render human-readable file sizes in long format.
     pub human_readable: bool,
+    /// Render human-readable file sizes using powers of 1000.
+    pub si: bool,
     /// Raw path arguments collected from the CLI.
     pub paths: Vec<String>,
     /// Override the configured indicator style for this invocation.
@@ -153,6 +156,7 @@ fn build_command(mode: CompatMode) -> Command {
         .arg(almost_all_arg())
         .arg(long_arg())
         .arg(human_readable_arg())
+        .arg(si_arg())
         .arg(paths_arg())
         .arg(slash_arg(mode))
         .arg(file_type_arg(mode))
@@ -226,7 +230,14 @@ fn human_readable_arg() -> Arg {
         .short('h')
         .long("human-readable")
         .action(ArgAction::SetTrue)
-        .help("with -l, print sizes like 1K 234M 2G etc.")
+        .help("with -l, print sizes using 1024-byte units, like 1K 234M 2G")
+}
+
+fn si_arg() -> Arg {
+    Arg::new(ARG_SI)
+        .long("si")
+        .action(ArgAction::SetTrue)
+        .help("with -l, print sizes using 1000-byte units, like 1k 234M 2G")
 }
 
 fn paths_arg() -> Arg {
@@ -389,6 +400,7 @@ fn flags_from_matches(mode: CompatMode, matches: &ArgMatches) -> Flags {
         almost_all: matches.get_flag(ARG_ALMOST_ALL),
         long: matches.get_flag(ARG_LONG),
         human_readable: matches.get_flag(ARG_HUMAN_READABLE),
+        si: matches.get_flag(ARG_SI),
         paths: matches
             .get_many::<String>(ARG_PATHS)
             .map(|values| values.cloned().collect())

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 
 use crate::cli;
+use crate::utils::format::SizeScale;
 
 /// Entry-name indicator styles supported by `lsplus`.
 ///
@@ -40,6 +41,8 @@ pub struct Params {
     pub long_format: bool,
     /// Render human-readable file sizes in long format.
     pub human_readable: bool,
+    /// Use decimal powers for human-readable file sizes.
+    pub si: bool,
     /// Disable file and directory icons.
     pub no_icons: bool,
     /// Disable colored or styled output.
@@ -65,6 +68,7 @@ impl Default for Params {
             almost_all: false,
             long_format: false,
             human_readable: false,
+            si: false,
             no_icons: false,
             no_color: false,
             permission_colors: true,
@@ -85,6 +89,7 @@ pub(crate) struct RawParams {
     almost_all: bool,
     long_format: bool,
     human_readable: bool,
+    si: bool,
     no_icons: bool,
     no_color: bool,
     permission_colors: Option<bool>,
@@ -142,6 +147,7 @@ impl From<RawParams> for Params {
             almost_all: raw.almost_all,
             long_format: raw.long_format,
             human_readable: raw.human_readable,
+            si: raw.si,
             no_icons: raw.no_icons,
             no_color: raw.no_color,
             permission_colors: raw.permission_colors.unwrap_or(true),
@@ -169,7 +175,11 @@ impl Params {
             dirs_first: flags.dirs_first || config.dirs_first,
             almost_all: flags.almost_all || config.almost_all,
             long_format: flags.long || config.long_format,
-            human_readable: flags.human_readable || config.human_readable,
+            human_readable: flags.si
+                || flags.human_readable
+                || config.si
+                || config.human_readable,
+            si: flags.si || config.si,
             no_icons: flags.no_icons || config.no_icons,
             no_color: flags.no_color || config.no_color,
             permission_colors: config.permission_colors
@@ -178,6 +188,17 @@ impl Params {
             size_colors: config.size_colors && !flags.no_size_colors,
             gitignore: flags.gitignore || config.gitignore,
             fuzzy_time: flags.fuzzy_time || config.fuzzy_time,
+        }
+    }
+
+    /// Return the size scaling mode for long-format output.
+    pub fn size_scale(&self) -> Option<SizeScale> {
+        if self.si {
+            Some(SizeScale::Decimal)
+        } else if self.human_readable {
+            Some(SizeScale::Binary)
+        } else {
+            None
         }
     }
 }

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -63,7 +63,7 @@ impl SizeScale {
     }
 }
 
-/// Scale a byte count into the largest selected unit below the scale base.
+/// Scale a byte count into a human-readable value and unit.
 pub fn human_readable_format(
     size: u64,
     scale: SizeScale,
@@ -77,7 +77,17 @@ pub fn human_readable_format(
         unit_index += 1;
     }
 
+    let rounded_size = round_to_display_precision(size);
+    if rounded_size >= scale.base() && unit_index < units.len() - 1 {
+        size = rounded_size / scale.base();
+        unit_index += 1;
+    }
+
     (size, units[unit_index])
+}
+
+fn round_to_display_precision(size: f64) -> f64 {
+    (size * 10.0).round() / 10.0
 }
 
 /// Format a size for display and return the optional unit label.

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -38,30 +38,61 @@ fn special_execute_char(
     }
 }
 
-/// Scale a byte count into the largest binary unit below 1024.
-pub fn human_readable_format(size: u64) -> (f64, &'static str) {
-    const UNITS: [&str; 6] = ["B", "KB", "MB", "GB", "TB", "PB"];
+/// Unit scaling mode for human-readable file sizes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SizeScale {
+    /// Scale by powers of 1024 and use GNU-style binary suffixes.
+    Binary,
+    /// Scale by powers of 1000 and use GNU-style decimal suffixes.
+    Decimal,
+}
+
+impl SizeScale {
+    fn base(self) -> f64 {
+        match self {
+            Self::Binary => 1024.0,
+            Self::Decimal => 1000.0,
+        }
+    }
+
+    fn units(self) -> [&'static str; 6] {
+        match self {
+            Self::Binary => ["B", "K", "M", "G", "T", "P"],
+            Self::Decimal => ["B", "k", "M", "G", "T", "P"],
+        }
+    }
+}
+
+/// Scale a byte count into the largest selected unit below the scale base.
+pub fn human_readable_format(
+    size: u64,
+    scale: SizeScale,
+) -> (f64, &'static str) {
+    let units = scale.units();
     let mut size = size as f64;
     let mut unit_index = 0;
 
-    while size >= 1024.0 && unit_index < UNITS.len() - 1 {
-        size /= 1024.0;
+    while size >= scale.base() && unit_index < units.len() - 1 {
+        size /= scale.base();
         unit_index += 1;
     }
 
-    (size, UNITS[unit_index])
+    (size, units[unit_index])
 }
 
 /// Format a size for display and return the optional unit label.
-pub fn show_size(size: u64, human_readable: bool) -> (String, &'static str) {
-    if human_readable {
-        let (size, unit) = human_readable_format(size);
-        if size.fract() == 0.0 {
-            (format!("{:.0}", size), unit)
-        } else {
-            (format!("{:.1}", size), unit)
-        }
+pub fn show_size(
+    size: u64,
+    scale: Option<SizeScale>,
+) -> (String, &'static str) {
+    let Some(scale) = scale else {
+        return (size.to_string(), "");
+    };
+
+    let (size, unit) = human_readable_format(size, scale);
+    if size.fract() == 0.0 {
+        (format!("{size:.0}"), unit)
     } else {
-        (size.to_string(), "")
+        (format!("{size:.1}"), unit)
     }
 }

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -50,8 +50,9 @@ pub(crate) fn build_long_format_table(
             datetime.format("%c").to_string()
         };
 
+        let size_scale = params.size_scale();
         let (display_size, units) =
-            utils::format::show_size(info.size, params.human_readable);
+            utils::format::show_size(info.size, size_scale);
 
         let mut row_cells = Vec::with_capacity(9);
 
@@ -70,7 +71,7 @@ pub(crate) fn build_long_format_table(
             "r",
         ));
 
-        if !units.is_empty() {
+        if size_scale.is_some() {
             row_cells.push(size_cell(
                 units,
                 info.size,

--- a/tests/crate/app.rs
+++ b/tests/crate/app.rs
@@ -80,6 +80,7 @@ fn test_run_with_flags_lists_matching_entries() {
             almost_all: false,
             long: false,
             human_readable: false,
+            si: false,
             paths: vec![temp_dir.path().display().to_string()],
             indicator_style: None,
             dirs_first: false,

--- a/tests/crate/cli.rs
+++ b/tests/crate/cli.rs
@@ -10,6 +10,7 @@ fn test_default_flags() {
     assert!(!args.almost_all);
     assert!(!args.long);
     assert!(!args.human_readable);
+    assert!(!args.si);
     assert_eq!(args.indicator_style, None);
     assert!(!args.dirs_first);
     assert!(!args.no_icons);
@@ -40,6 +41,7 @@ fn test_all_flags() {
         "-A",
         "-l",
         "-h",
+        "--si",
         "-p",
         "--sort-dirs",
         "--no-icons",
@@ -54,6 +56,7 @@ fn test_all_flags() {
     assert!(args.almost_all);
     assert!(args.long);
     assert!(args.human_readable);
+    assert!(args.si);
     assert_eq!(args.indicator_style, Some(IndicatorStyle::Slash));
     assert!(args.dirs_first);
     assert!(args.no_icons);
@@ -63,6 +66,14 @@ fn test_all_flags() {
     assert!(args.no_size_colors);
     assert!(args.gitignore);
     assert!(args.fuzzy_time);
+}
+
+#[test]
+fn test_si_flag_enables_decimal_size_flag() {
+    let args = Flags::parse_from(["lsplus", "--si"]);
+
+    assert!(args.si);
+    assert!(!args.human_readable);
 }
 
 #[test]

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -255,11 +255,16 @@ fn test_build_long_format_table_colors_size_boundaries() {
         let rendered =
             normalized_table(build_long_format_table(&files, &params));
         let stripped = strip_str(&rendered);
+        let rows: Vec<_> = stripped
+            .lines()
+            .filter(|line| line.contains(".bin"))
+            .collect();
 
-        assert!(stripped.contains("1024"));
-        assert!(stripped.contains("K"));
-        assert!(stripped.contains("1 M"));
-        assert!(stripped.contains("1 G"));
+        assert_eq!(rows.len(), 3);
+        assert!(rows[0].contains("1 M"));
+        assert!(rows[1].contains("1 M"));
+        assert!(rows[2].contains("1 G"));
+        assert!(!stripped.contains("1024 K"));
     });
 }
 

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -64,7 +64,7 @@ fn test_build_long_format_table_includes_units_and_icons() {
 
     assert!(rendered.contains("example.rs"));
     assert!(rendered.contains("2"));
-    assert!(rendered.contains("KB"));
+    assert!(rendered.contains("K"));
     assert!(rendered.contains(&Icon::RustFile.to_string()));
 }
 
@@ -98,7 +98,7 @@ fn test_build_long_format_table_omits_optional_units_and_icons() {
 
     assert!(rendered.contains("plain.txt"));
     assert!(rendered.contains("12"));
-    assert!(!rendered.contains("KB"));
+    assert!(!rendered.contains("K"));
     assert!(!rendered.contains(&Icon::RustFile.to_string()));
 }
 
@@ -257,9 +257,9 @@ fn test_build_long_format_table_colors_size_boundaries() {
         let stripped = strip_str(&rendered);
 
         assert!(stripped.contains("1024"));
-        assert!(stripped.contains("KB"));
-        assert!(stripped.contains("1 MB"));
-        assert!(stripped.contains("1 GB"));
+        assert!(stripped.contains("K"));
+        assert!(stripped.contains("1 M"));
+        assert!(stripped.contains("1 G"));
     });
 }
 
@@ -298,14 +298,15 @@ fn test_build_long_format_table_aligns_colored_size_cells() {
         let plain_size_end = rows[0].find("808").unwrap() + "808".len();
         let large_size_end = rows[1].find('8').unwrap() + "8".len();
         let huge_size_end = rows[2].find("57").unwrap() + "57".len();
-        let plain_unit_start = rows[0].find("B   ").unwrap();
-        let large_unit_start = rows[1].find("MB ").unwrap();
-        let huge_unit_start = rows[2].find("GB ").unwrap();
+        let plain_unit_start = rows[0].find("B  ").unwrap();
+        let large_unit_start = rows[1].find("M ").unwrap();
+        let huge_unit_start = rows[2].find("G ").unwrap();
 
         assert_eq!(plain_size_end, large_size_end);
         assert_eq!(large_size_end, huge_size_end);
         assert_eq!(plain_unit_start, large_unit_start);
         assert_eq!(large_unit_start, huge_unit_start);
+        assert!(rows[0].contains("808 B"));
     });
 }
 
@@ -322,9 +323,9 @@ fn test_build_long_format_table_omits_size_colors_when_disabled() {
         let rendered =
             normalized_table(build_long_format_table(&[info], &params));
 
-        assert!(rendered.contains("1 MB"));
+        assert!(rendered.contains("1 M"));
         assert!(!rendered.contains("\u{1b}[33m1\u{1b}[0m"));
-        assert!(!rendered.contains("\u{1b}[33mMB\u{1b}[0m"));
+        assert!(!rendered.contains("\u{1b}[33mM\u{1b}[0m"));
     });
 }
 

--- a/tests/crate/settings.rs
+++ b/tests/crate/settings.rs
@@ -79,6 +79,7 @@ fn test_load_config_reads_boolean_settings_from_home_config() {
                 almost_all: true,
                 long_format: true,
                 human_readable: true,
+                si: false,
                 no_icons: true,
                 no_color: true,
                 permission_colors: false,

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -93,7 +93,37 @@ fn test_format_size_extreme() {
 
     let (size, unit) =
         human_readable_format(1024 * 1024 - 1, SizeScale::Binary);
-    assert_eq!(format!("{size:.1} {unit}"), "1024.0 K");
+    assert_eq!(format!("{size:.1} {unit}"), "1.0 M");
+}
+
+#[test]
+fn test_format_size_promotes_rounded_binary_boundaries() {
+    let (size, unit) = show_size(1_048_524, Some(SizeScale::Binary));
+    assert_eq!(size, "1023.9");
+    assert_eq!(unit, "K");
+
+    let (size, unit) = show_size(1_048_525, Some(SizeScale::Binary));
+    assert_eq!(size, "1");
+    assert_eq!(unit, "M");
+
+    let (size, unit) = show_size(1_073_690_624, Some(SizeScale::Binary));
+    assert_eq!(size, "1");
+    assert_eq!(unit, "G");
+}
+
+#[test]
+fn test_format_size_promotes_rounded_decimal_boundaries() {
+    let (size, unit) = show_size(999_949, Some(SizeScale::Decimal));
+    assert_eq!(size, "999.9");
+    assert_eq!(unit, "k");
+
+    let (size, unit) = show_size(999_950, Some(SizeScale::Decimal));
+    assert_eq!(size, "1");
+    assert_eq!(unit, "M");
+
+    let (size, unit) = show_size(999_950_000, Some(SizeScale::Decimal));
+    assert_eq!(size, "1");
+    assert_eq!(unit, "G");
 }
 
 #[test]

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -1,69 +1,99 @@
-use lsplus::utils::format::{human_readable_format, mode_to_rwx, show_size};
+use lsplus::utils::format::{
+    SizeScale, human_readable_format, mode_to_rwx, show_size,
+};
 
 #[test]
 fn test_format_size() {
-    let (size, unit) = human_readable_format(0);
-    assert_eq!(format!("{:.1} {}", size, unit), "0.0 B");
+    let (size, unit) = human_readable_format(0, SizeScale::Binary);
+    assert_eq!(format!("{size:.1} {unit}"), "0.0 B");
 
-    let (size, unit) = human_readable_format(1023);
-    assert_eq!(format!("{:.1} {}", size, unit), "1023.0 B");
+    let (size, unit) = human_readable_format(1023, SizeScale::Binary);
+    assert_eq!(format!("{size:.1} {unit}"), "1023.0 B");
 
-    let (size, unit) = human_readable_format(1024);
-    assert_eq!(format!("{:.1} {}", size, unit), "1.0 KB");
+    let (size, unit) = human_readable_format(1024, SizeScale::Binary);
+    assert_eq!(format!("{size:.1} {unit}"), "1.0 K");
 
-    let (size, unit) = human_readable_format(1024 * 1024);
-    assert_eq!(format!("{:.1} {}", size, unit), "1.0 MB");
+    let (size, unit) = human_readable_format(1024 * 1024, SizeScale::Binary);
+    assert_eq!(format!("{size:.1} {unit}"), "1.0 M");
 
-    let (size, unit) = human_readable_format(1024 * 1024 * 1024);
-    assert_eq!(format!("{:.1} {}", size, unit), "1.0 GB");
+    let (size, unit) =
+        human_readable_format(1024 * 1024 * 1024, SizeScale::Binary);
+    assert_eq!(format!("{size:.1} {unit}"), "1.0 G");
 
-    let (size, unit) = human_readable_format(1024 * 1024 * 1024 * 1024);
-    assert_eq!(format!("{:.1} {}", size, unit), "1.0 TB");
+    let (size, unit) =
+        human_readable_format(1024 * 1024 * 1024 * 1024, SizeScale::Binary);
+    assert_eq!(format!("{size:.1} {unit}"), "1.0 T");
 }
 
 #[test]
 fn test_format_size_partial() {
-    let (size, unit) = human_readable_format(1536);
-    assert_eq!(format!("{:.1} {}", size, unit), "1.5 KB");
+    let (size, unit) = human_readable_format(1536, SizeScale::Binary);
+    assert_eq!(format!("{size:.1} {unit}"), "1.5 K");
 
-    let (size, unit) = human_readable_format(1024 * 1024 * 3 / 2);
-    assert_eq!(format!("{:.1} {}", size, unit), "1.5 MB");
+    let (size, unit) =
+        human_readable_format(1024 * 1024 * 3 / 2, SizeScale::Binary);
+    assert_eq!(format!("{size:.1} {unit}"), "1.5 M");
 
-    let (size, unit) = human_readable_format(1024 * 1024 * 1024 * 5 / 2);
-    assert_eq!(format!("{:.1} {}", size, unit), "2.5 GB");
+    let (size, unit) =
+        human_readable_format(1024 * 1024 * 1024 * 5 / 2, SizeScale::Binary);
+    assert_eq!(format!("{size:.1} {unit}"), "2.5 G");
 
-    let (size, unit) = show_size(2560, true);
+    let (size, unit) = show_size(2560, Some(SizeScale::Binary));
     assert_eq!(size, "2.5");
-    assert_eq!(unit, "KB");
+    assert_eq!(unit, "K");
 
-    let (size, unit) = show_size(1024, true);
+    let (size, unit) = show_size(1024, Some(SizeScale::Binary));
     assert_eq!(size, "1");
-    assert_eq!(unit, "KB");
+    assert_eq!(unit, "K");
 
-    let (size, unit) = show_size(2560, false);
+    let (size, unit) = show_size(2560, None);
     assert_eq!(size, "2560");
     assert_eq!(unit, "");
 }
 
 #[test]
+fn test_format_size_decimal() {
+    let (size, unit) = human_readable_format(999, SizeScale::Decimal);
+    assert_eq!(format!("{size:.1} {unit}"), "999.0 B");
+
+    let (size, unit) = human_readable_format(1000, SizeScale::Decimal);
+    assert_eq!(format!("{size:.1} {unit}"), "1.0 k");
+
+    let (size, unit) = human_readable_format(1500, SizeScale::Decimal);
+    assert_eq!(format!("{size:.1} {unit}"), "1.5 k");
+
+    let (size, unit) = human_readable_format(1_000_000, SizeScale::Decimal);
+    assert_eq!(format!("{size:.1} {unit}"), "1.0 M");
+
+    let (size, unit) = show_size(1000, Some(SizeScale::Decimal));
+    assert_eq!(size, "1");
+    assert_eq!(unit, "k");
+}
+
+#[test]
 fn test_format_size_extreme() {
-    let (size, unit) = human_readable_format(1024 * 1024 * 1024 * 1024);
-    assert_eq!(format!("{:.1} {}", size, unit), "1.0 TB");
+    let (size, unit) =
+        human_readable_format(1024 * 1024 * 1024 * 1024, SizeScale::Binary);
+    assert_eq!(format!("{size:.1} {unit}"), "1.0 T");
 
-    let (size, unit) = human_readable_format(1024 * 1024 * 1024 * 1024 * 1024);
-    assert_eq!(format!("{:.1} {}", size, unit), "1.0 PB");
+    let (size, unit) = human_readable_format(
+        1024 * 1024 * 1024 * 1024 * 1024,
+        SizeScale::Binary,
+    );
+    assert_eq!(format!("{size:.1} {unit}"), "1.0 P");
 
-    let (size, unit) = human_readable_format(1024);
-    assert_eq!(format!("{:.1} {}", size, unit), "1.0 KB");
+    let (size, unit) = human_readable_format(1024, SizeScale::Binary);
+    assert_eq!(format!("{size:.1} {unit}"), "1.0 K");
 
-    let (size, unit) = human_readable_format(1024 * 1024);
-    assert_eq!(format!("{:.1} {}", size, unit), "1.0 MB");
+    let (size, unit) = human_readable_format(1024 * 1024, SizeScale::Binary);
+    assert_eq!(format!("{size:.1} {unit}"), "1.0 M");
 
-    let (size, unit) = human_readable_format(1023);
-    assert_eq!(format!("{:.1} {}", size, unit), "1023.0 B");
+    let (size, unit) = human_readable_format(1023, SizeScale::Binary);
+    assert_eq!(format!("{size:.1} {unit}"), "1023.0 B");
 
-    let (size, unit) = human_readable_format(1024 * 1024 - 1);
-    assert_eq!(format!("{:.1} {}", size, unit), "1024.0 KB");
+    let (size, unit) =
+        human_readable_format(1024 * 1024 - 1, SizeScale::Binary);
+    assert_eq!(format!("{size:.1} {unit}"), "1024.0 K");
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -170,9 +170,12 @@ fn test_long_format() {
     let file_path = temp_dir.path().join("size.txt");
     fs::write(&file_path, vec![b'x'; 2048]).unwrap();
 
-    let mut cmd = Command::cargo_bin("lsp").unwrap();
-    cmd.arg("-l").arg("-h").arg(&file_path);
-    let (stdout, _stderr) = run_and_capture(&mut cmd);
+    let (stdout, _stderr) =
+        temp_env::with_var("HOME", Some(temp_dir.path()), || {
+            let mut cmd = Command::cargo_bin("lsp").unwrap();
+            cmd.arg("-l").arg("-h").arg(&file_path);
+            run_and_capture(&mut cmd)
+        });
 
     assert!(stdout.contains("size.txt"));
     assert!(stdout.contains("2 K"));
@@ -184,9 +187,12 @@ fn test_long_format_si_sizes() {
     let file_path = temp_dir.path().join("size.txt");
     fs::write(&file_path, vec![b'x'; 1500]).unwrap();
 
-    let mut cmd = Command::cargo_bin("lsp").unwrap();
-    cmd.arg("-l").arg("--si").arg(&file_path);
-    let (stdout, _stderr) = run_and_capture(&mut cmd);
+    let (stdout, _stderr) =
+        temp_env::with_var("HOME", Some(temp_dir.path()), || {
+            let mut cmd = Command::cargo_bin("lsp").unwrap();
+            cmd.arg("-l").arg("--si").arg(&file_path);
+            run_and_capture(&mut cmd)
+        });
 
     assert!(stdout.contains("size.txt"));
     assert!(stdout.contains("1.5 k"));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -175,7 +175,21 @@ fn test_long_format() {
     let (stdout, _stderr) = run_and_capture(&mut cmd);
 
     assert!(stdout.contains("size.txt"));
-    assert!(stdout.contains("2 KB"));
+    assert!(stdout.contains("2 K"));
+}
+
+#[test]
+fn test_long_format_si_sizes() {
+    let temp_dir = tempdir().unwrap();
+    let file_path = temp_dir.path().join("size.txt");
+    fs::write(&file_path, vec![b'x'; 1500]).unwrap();
+
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.arg("-l").arg("--si").arg(&file_path);
+    let (stdout, _stderr) = run_and_capture(&mut cmd);
+
+    assert!(stdout.contains("size.txt"));
+    assert!(stdout.contains("1.5 k"));
 }
 
 #[test]
@@ -309,9 +323,12 @@ fn test_long_format_does_not_pad_short_rows_to_longest_filename() {
     fs::write(temp_dir.path().join(short_name), "plain").unwrap();
     fs::write(temp_dir.path().join(long_name), "long").unwrap();
 
-    let mut cmd = Command::cargo_bin("lsp").unwrap();
-    cmd.arg("-l").arg("--no-icons").arg(temp_dir.path());
-    let (stdout, _stderr) = run_and_capture(&mut cmd);
+    let (stdout, _stderr) =
+        temp_env::with_var("HOME", Some(temp_dir.path()), || {
+            let mut cmd = Command::cargo_bin("lsp").unwrap();
+            cmd.arg("-l").arg("--no-icons").arg(temp_dir.path());
+            run_and_capture(&mut cmd)
+        });
 
     let short_row = stdout
         .lines()

--- a/tests/seams.rs
+++ b/tests/seams.rs
@@ -38,6 +38,7 @@ fn test_public_run_with_flags_accepts_missing_patterns() {
         almost_all: false,
         long: false,
         human_readable: false,
+        si: false,
         paths: vec![String::from("**/definitely_missing_coverage_pattern")],
         indicator_style: None,
         dirs_first: false,

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -1,5 +1,6 @@
 use config::Config;
 use lsplus::cli::Flags;
+use lsplus::utils::format::SizeScale;
 use lsplus::{IndicatorStyle, Params};
 use std::fs;
 use tempfile::tempdir;
@@ -13,6 +14,8 @@ fn test_default_params() {
     assert!(!params.almost_all);
     assert!(!params.long_format);
     assert!(!params.human_readable);
+    assert!(!params.si);
+    assert_eq!(params.size_scale(), None);
     assert!(!params.no_icons);
     assert!(!params.no_color);
     assert!(params.permission_colors);
@@ -36,6 +39,7 @@ fn test_config_conversion() {
             almost_all = true
             long_format = true
             human_readable = true
+            si = true
             no_icons = true
             no_color = true
             permission_colors = false
@@ -63,6 +67,7 @@ fn test_config_conversion() {
             almost_all: true,
             long_format: true,
             human_readable: true,
+            si: true,
             no_icons: true,
             no_color: true,
             permission_colors: false,
@@ -121,6 +126,7 @@ fn test_params_merge_prefers_true_from_either_source() {
         almost_all: false,
         long_format: true,
         human_readable: true,
+        si: false,
         no_icons: false,
         no_color: true,
         permission_colors: true,
@@ -139,6 +145,7 @@ fn test_params_merge_prefers_true_from_either_source() {
         dirs_first: true,
         long: false,
         human_readable: false,
+        si: false,
         no_icons: true,
         no_color: false,
         no_permission_colors: true,
@@ -156,6 +163,8 @@ fn test_params_merge_prefers_true_from_either_source() {
     assert!(params.almost_all);
     assert!(params.long_format);
     assert!(params.human_readable);
+    assert!(!params.si);
+    assert_eq!(params.size_scale(), Some(SizeScale::Binary));
     assert!(params.no_icons);
     assert!(params.no_color);
     assert!(!params.permission_colors);
@@ -176,6 +185,7 @@ fn test_params_merge_keeps_false_when_both_sources_are_false() {
         dirs_first: false,
         long: false,
         human_readable: false,
+        si: false,
         no_icons: false,
         no_color: false,
         no_permission_colors: false,
@@ -188,4 +198,65 @@ fn test_params_merge_keeps_false_when_both_sources_are_false() {
     let params = Params::merge(&flags, &Params::default());
 
     assert_eq!(params, Params::default());
+}
+
+#[test]
+fn test_params_merge_si_enables_decimal_human_readable_output() {
+    let flags = Flags {
+        version: false,
+        paths: vec![],
+        show_all: false,
+        almost_all: false,
+        indicator_style: None,
+        dirs_first: false,
+        long: false,
+        human_readable: false,
+        si: true,
+        no_icons: false,
+        no_color: false,
+        no_permission_colors: false,
+        no_time_gradient: false,
+        no_size_colors: false,
+        gitignore: false,
+        fuzzy_time: false,
+    };
+
+    let params = Params::merge(&flags, &Params::default());
+
+    assert!(params.human_readable);
+    assert!(params.si);
+    assert_eq!(params.size_scale(), Some(SizeScale::Decimal));
+}
+
+#[test]
+fn test_params_merge_config_si_overrides_config_human_readable() {
+    let config = Params {
+        human_readable: true,
+        si: true,
+        ..Params::default()
+    };
+    let flags = Flags {
+        version: false,
+        paths: vec![],
+        show_all: false,
+        almost_all: false,
+        indicator_style: None,
+        dirs_first: false,
+        long: false,
+        human_readable: false,
+        si: false,
+        no_icons: false,
+        no_color: false,
+        no_permission_colors: false,
+        no_time_gradient: false,
+        no_size_colors: false,
+        gitignore: false,
+        fuzzy_time: false,
+    };
+
+    let params = Params::merge(&flags, &config);
+
+    assert!(params.human_readable);
+    assert!(params.si);
+    assert_eq!(params.size_scale(), Some(SizeScale::Decimal));
 }


### PR DESCRIPTION
Adds a decimal size mode alongside the existing human-readable long-format output.

This PR adds `--si` (cli) and `si = true` (config file) so users can choose 1000-based size scaling when they want SI-style output, while -h / --human-readable keeps 1024-based scaling. 

Docs updated to mention new switch and behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `--si` option for size display using 1000-based units (alongside existing 1024-based human-readable sizing).

* **Bug Fixes**
  * Improved human-readable size boundary handling to avoid incorrect unit promotion.
  * Updated long-format size rendering and unit labeling for more consistent output.

* **Documentation**
  * Expanded README, usage, and config documentation to clarify 1024-based vs 1000-based behaviour, including an `--si` option entry.

* **Tests**
  * Extended coverage for `--si` and updated expected rendering outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->