### PR TITLE
Add permission display modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Currently, only a sub-set of the standard `ls` options are supported. These are:
 - `-F` / `--classify` - Append type indicators, including `*` for executables
 - `--no-indicators` - Disable file type indicators
 - `-l` / `--long` - Show long format listing
+- `--permissions <MODE>` - Select long-format permission display:
+  `symbolic`, `octal`, `both`, or `none`
 - `-h` / `--human-readable` - Human readable file sizes using powers of 1024
 - `--si` - Human readable file sizes using powers of 1000
 - `-D` / `--sort-dirs` - Sort directories first
@@ -153,6 +155,11 @@ Styled output is enabled automatically when writing to a terminal. Captured,
 piped, and redirected output is plain by default. You can also disable styled
 output explicitly with `--no-color`, `no_color = true` in the config file, or
 the `NO_COLOR` environment variable.
+
+Long-format output shows symbolic permissions by default. Use
+`--permissions octal` to replace them with octal permission bits,
+`--permissions both` to add octal bits after the symbolic field, or
+`--permissions none` to omit permission fields.
 
 Long-format output colors permission bits, timestamp freshness, and large file
 sizes by default. You can adjust those accents independently with

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -187,6 +187,17 @@ This option controls long-format colors for the file type character and
 permission bits. Set it to `false`, or pass `--no-permission-colors`, to render
 those fields without accent colors.
 
+### permissions
+
+- Permitted values: `symbolic`, `octal`, `both`, or `none`
+- Default value: `symbolic`
+
+This option corresponds to `--permissions` and controls long-format permission
+fields. `symbolic` shows the default file type character and symbolic
+permissions, `octal` replaces that field with the file type character and
+four-digit octal permission bits, `both` adds an octal permission cell after
+the symbolic field, and `none` omits permission fields.
+
 ### time_gradient
 
 - Permitted values: `true` or `false`
@@ -245,6 +256,7 @@ human_readable = true
 # prune_dirs = ["target", "dist"]
 no_color = true
 permission_colors = false
+permissions = "symbolic"
 time_gradient = false
 size_colors = false
 fuzzy_time = true

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -18,6 +18,8 @@ Currently, only a sub-set of the standard `ls` options are supported. These are:
 - `-F` / `--classify` - Append type indicators, including `*` for executables
 - `--no-indicators` - Disable file type indicators
 - `-l` / `--long` - Show long format listing
+- `--permissions <MODE>` - Select long-format permission display:
+  `symbolic`, `octal`, `both`, or `none`
 - `-h` / `--human-readable` - Human readable file sizes using powers of 1024
 - `--si` - Human readable file sizes using powers of 1000
 - `-R` / `--recursive` - List subdirectories recursively
@@ -94,6 +96,11 @@ Styled output is enabled automatically when writing to a terminal. Captured,
 piped, and redirected output is plain by default. You can also disable styled
 output explicitly with `--no-color`, `no_color = true` in the config file, or
 the `NO_COLOR` environment variable.
+
+Long-format output shows symbolic permissions by default. Use
+`--permissions octal` to replace them with octal permission bits,
+`--permissions both` to add octal bits after the symbolic field, or
+`--permissions none` to omit permission fields.
 
 Long-format output colors permission bits, timestamp freshness, and large file
 sizes by default. You can adjust those accents independently with

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,7 +9,7 @@ use clap::{Arg, ArgAction, ArgMatches, Command};
 use std::env;
 use std::ffi::OsString;
 
-use crate::IndicatorStyle;
+use crate::{IndicatorStyle, PermissionDisplay};
 
 const ARG_SHOW_ALL: &str = "show_all";
 const ARG_ALMOST_ALL: &str = "almost_all";
@@ -31,6 +31,7 @@ const ARG_DIRS_FIRST: &str = "dirs_first";
 const ARG_NO_ICONS: &str = "no_icons";
 const ARG_NO_COLOR: &str = "no_color";
 const ARG_NO_PERMISSION_COLORS: &str = "no_permission_colors";
+const ARG_PERMISSIONS: &str = "permissions";
 const ARG_NO_TIME_GRADIENT: &str = "no_time_gradient";
 const ARG_NO_SIZE_COLORS: &str = "no_size_colors";
 const ARG_GITIGNORE: &str = "gitignore";
@@ -100,6 +101,8 @@ pub struct Flags {
     pub no_color: bool,
     /// Disable permission and file-type colors in long-format output.
     pub no_permission_colors: bool,
+    /// Override long-format permission display mode.
+    pub permissions: Option<PermissionDisplay>,
     /// Use the fixed timestamp color instead of age-based colors.
     pub no_time_gradient: bool,
     /// Disable large-size colors in long-format output.
@@ -186,6 +189,7 @@ fn build_command(mode: CompatMode) -> Command {
         .arg(no_icons_arg())
         .arg(no_color_arg(mode))
         .arg(no_permission_colors_arg())
+        .arg(permissions_arg())
         .arg(no_time_gradient_arg())
         .arg(no_size_colors_arg())
         .arg(gitignore_arg(mode))
@@ -418,6 +422,15 @@ fn no_permission_colors_arg() -> Arg {
         )
 }
 
+fn permissions_arg() -> Arg {
+    Arg::new(ARG_PERMISSIONS)
+        .long("permissions")
+        .action(ArgAction::Set)
+        .value_name("MODE")
+        .value_parser(["symbolic", "octal", "both", "none"])
+        .help("Select long-format permission display: symbolic, octal, both, or none")
+}
+
 fn no_time_gradient_arg() -> Arg {
     Arg::new(ARG_NO_TIME_GRADIENT)
         .long("no-time-gradient")
@@ -493,6 +506,15 @@ fn flags_from_matches(mode: CompatMode, matches: &ArgMatches) -> Flags {
         no_icons: matches.get_flag(ARG_NO_ICONS),
         no_color: matches.get_flag(ARG_NO_COLOR),
         no_permission_colors: matches.get_flag(ARG_NO_PERMISSION_COLORS),
+        permissions: matches.get_one::<String>(ARG_PERMISSIONS).and_then(
+            |value| match value.as_str() {
+                "symbolic" => Some(PermissionDisplay::Symbolic),
+                "octal" => Some(PermissionDisplay::Octal),
+                "both" => Some(PermissionDisplay::Both),
+                "none" => Some(PermissionDisplay::None),
+                _ => None,
+            },
+        ),
         no_time_gradient: matches.get_flag(ARG_NO_TIME_GRADIENT),
         no_size_colors: matches.get_flag(ARG_NO_SIZE_COLORS),
         gitignore: matches.get_flag(ARG_GITIGNORE),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,7 +9,7 @@ use clap::{Arg, ArgAction, ArgMatches, Command};
 use std::env;
 use std::ffi::OsString;
 
-use crate::{IndicatorStyle, PermissionDisplay};
+use crate::{IndicatorStyle, structs::PermissionDisplay};
 
 const ARG_SHOW_ALL: &str = "show_all";
 const ARG_ALMOST_ALL: &str = "almost_all";

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -427,7 +427,7 @@ fn permissions_arg() -> Arg {
         .long("permissions")
         .action(ArgAction::Set)
         .value_name("MODE")
-        .value_parser(["symbolic", "octal", "both", "none"])
+        .value_parser(clap::value_parser!(PermissionDisplay))
         .help("Select long-format permission display: symbolic, octal, both, or none")
 }
 
@@ -506,15 +506,9 @@ fn flags_from_matches(mode: CompatMode, matches: &ArgMatches) -> Flags {
         no_icons: matches.get_flag(ARG_NO_ICONS),
         no_color: matches.get_flag(ARG_NO_COLOR),
         no_permission_colors: matches.get_flag(ARG_NO_PERMISSION_COLORS),
-        permissions: matches.get_one::<String>(ARG_PERMISSIONS).and_then(
-            |value| match value.as_str() {
-                "symbolic" => Some(PermissionDisplay::Symbolic),
-                "octal" => Some(PermissionDisplay::Octal),
-                "both" => Some(PermissionDisplay::Both),
-                "none" => Some(PermissionDisplay::None),
-                _ => None,
-            },
-        ),
+        permissions: matches
+            .get_one::<PermissionDisplay>(ARG_PERMISSIONS)
+            .copied(),
         no_time_gradient: matches.get_flag(ARG_NO_TIME_GRADIENT),
         no_size_colors: matches.get_flag(ARG_NO_SIZE_COLORS),
         gitignore: matches.get_flag(ARG_GITIGNORE),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,7 @@ pub mod settings;
 pub mod structs;
 pub mod utils;
 
-pub use structs::{
-    FileInfo, IndicatorStyle, NameStyle, Params, PermissionDisplay,
-};
+pub use structs::{FileInfo, IndicatorStyle, NameStyle, Params};
 
 #[cfg(test)]
 #[path = "../tests/crate/app.rs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,9 @@ pub mod settings;
 pub mod structs;
 pub mod utils;
 
-pub use structs::{FileInfo, IndicatorStyle, NameStyle, Params};
+pub use structs::{
+    FileInfo, IndicatorStyle, NameStyle, Params, PermissionDisplay,
+};
 
 #[cfg(test)]
 #[path = "../tests/crate/app.rs"]

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,4 +1,5 @@
 use super::utils::icons::Icon;
+use clap::ValueEnum;
 use config::Config;
 use serde::Deserialize;
 use std::convert::From;
@@ -30,8 +31,11 @@ pub enum IndicatorStyle {
 }
 
 /// Long-format permission column display modes.
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Default)]
+#[derive(
+    Debug, Clone, Copy, Deserialize, PartialEq, Eq, Default, ValueEnum,
+)]
 #[serde(rename_all = "kebab-case")]
+#[value(rename_all = "kebab-case")]
 pub enum PermissionDisplay {
     /// Show the existing file-type character plus symbolic permissions.
     #[default]

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -29,6 +29,21 @@ pub enum IndicatorStyle {
     Classify,
 }
 
+/// Long-format permission column display modes.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum PermissionDisplay {
+    /// Show the existing file-type character plus symbolic permissions.
+    #[default]
+    Symbolic,
+    /// Show the file-type character plus octal permission bits.
+    Octal,
+    /// Show symbolic permissions and a separate octal permission cell.
+    Both,
+    /// Hide permission cells entirely.
+    None,
+}
+
 /// Runtime options after CLI flags and config defaults have been merged.
 #[derive(Debug, PartialEq)]
 pub struct Params {
@@ -62,6 +77,8 @@ pub struct Params {
     pub no_color: bool,
     /// Color file type and permission bits in long-format output.
     pub permission_colors: bool,
+    /// Select which permission fields to show in long-format output.
+    pub permissions: PermissionDisplay,
     /// Color timestamps by age in long-format output.
     pub time_gradient: bool,
     /// Color large sizes in long-format output.
@@ -90,6 +107,7 @@ impl Default for Params {
             no_icons: false,
             no_color: false,
             permission_colors: true,
+            permissions: PermissionDisplay::Symbolic,
             time_gradient: true,
             size_colors: true,
             gitignore: false,
@@ -116,6 +134,7 @@ pub(crate) struct RawParams {
     no_icons: bool,
     no_color: bool,
     permission_colors: Option<bool>,
+    permissions: PermissionDisplay,
     time_gradient: Option<bool>,
     size_colors: Option<bool>,
     gitignore: bool,
@@ -182,6 +201,7 @@ impl From<RawParams> for Params {
             no_icons: raw.no_icons,
             no_color: raw.no_color,
             permission_colors: raw.permission_colors.unwrap_or(true),
+            permissions: raw.permissions,
             time_gradient: raw.time_gradient.unwrap_or(true),
             size_colors: raw.size_colors.unwrap_or(true),
             gitignore: raw.gitignore,
@@ -223,6 +243,7 @@ impl Params {
             no_color: flags.no_color || config.no_color,
             permission_colors: config.permission_colors
                 && !flags.no_permission_colors,
+            permissions: flags.permissions.unwrap_or(config.permissions),
             time_gradient: config.time_gradient && !flags.no_time_gradient,
             size_colors: config.size_colors && !flags.no_size_colors,
             gitignore: flags.gitignore || config.gitignore,
@@ -294,6 +315,9 @@ pub struct FileInfo {
     /// Unix-style permission string, possibly including `s`, `S`, `t`, or
     /// `T` special-bit overlays.
     pub mode: String,
+    /// Unix permission bits masked to the displayable permission and special
+    /// bit range.
+    pub mode_bits: u32,
     /// Link count from filesystem metadata.
     pub nlink: u64,
     /// Owner name, or numeric user ID when lookup fails.

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -28,6 +28,7 @@ use std::os::unix::ffi::OsStrExt;
 struct FileDetails {
     file_type: String,
     mode: String,
+    mode_bits: u32,
     nlink: u64,
     size: u64,
     mtime: SystemTime,
@@ -112,6 +113,7 @@ fn get_file_details(metadata: &fs::Metadata) -> FileDetails {
     FileDetails {
         file_type,
         mode: rwx_mode,
+        mode_bits: mode & 0o7777,
         nlink,
         size,
         mtime,
@@ -377,6 +379,7 @@ pub(crate) fn create_file_info_from_metadata_with_gitignore(
     FileInfo {
         file_type: details.file_type,
         mode: details.mode,
+        mode_bits: details.mode_bits,
         nlink: details.nlink,
         user: details.user,
         group: details.group,

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -19,6 +19,11 @@ pub fn mode_to_rwx(mode: u32) -> String {
     rwx
 }
 
+/// Format Unix permission and special bits as four octal digits.
+pub fn mode_to_octal(mode: u32) -> String {
+    format!("{:04o}", mode & 0o7777)
+}
+
 fn permission_char(mode: u32, bit: u32, value: char) -> char {
     if mode & bit != 0 { value } else { '-' }
 }

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -20,7 +20,7 @@ use crate::utils;
 use crate::utils::color::{LongFormatColorLevel, long_format_color_level};
 use crate::utils::file::check_display_name;
 use crate::utils::time::{DAY, MONTH, WEEK, YEAR};
-use crate::{Params, PermissionDisplay};
+use crate::{Params, structs::PermissionDisplay};
 
 const SHORT_CELL_PADDING: usize = 2;
 const LARGE_SIZE_BYTES: u64 = 1024 * 1024;

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -15,12 +15,12 @@ use strip_ansi_escapes::strip_str;
 use terminal_size::{Height, Width, terminal_size};
 use unicode_width::UnicodeWidthStr;
 
-use crate::Params;
 use crate::structs::{FileInfo, NameStyle};
 use crate::utils;
 use crate::utils::color::{LongFormatColorLevel, long_format_color_level};
 use crate::utils::file::check_display_name;
 use crate::utils::time::{DAY, MONTH, WEEK, YEAR};
+use crate::{Params, PermissionDisplay};
 
 const SHORT_CELL_PADDING: usize = 2;
 const LARGE_SIZE_BYTES: u64 = 1024 * 1024;
@@ -79,12 +79,9 @@ fn build_long_format_table_with_name_prefixes<'a>(
         let (display_size, units) =
             utils::format::show_size(info.size, size_scale);
 
-        let mut row_cells = Vec::with_capacity(9);
+        let mut row_cells = Vec::with_capacity(10);
 
-        row_cells.push(Cell::new(&format!(
-            "{} ",
-            long_permission_text(info, params)
-        )));
+        append_permission_cells(&mut row_cells, info, params, color_level);
         row_cells.push(Cell::new(&info.nlink.to_string()));
         row_cells.push(Cell::new(&format!(" {}", info.user.cyan())));
         row_cells.push(Cell::new(&format!("{} ", info.group.green())));
@@ -125,6 +122,69 @@ fn build_long_format_table_with_name_prefixes<'a>(
     }
 
     table
+}
+
+fn append_permission_cells(
+    row_cells: &mut Vec<Cell>,
+    info: &FileInfo,
+    params: &Params,
+    color_level: LongFormatColorLevel,
+) {
+    match params.permissions {
+        PermissionDisplay::Symbolic => {
+            row_cells.push(Cell::new(&format!(
+                "{} ",
+                long_permission_text(info, params)
+            )));
+        }
+        PermissionDisplay::Octal => {
+            row_cells.push(Cell::new(&format!(
+                "{} {} ",
+                long_file_type_text(info, params),
+                long_octal_permission_text(info, params, color_level)
+            )));
+        }
+        PermissionDisplay::Both => {
+            row_cells.push(Cell::new(&long_permission_text(info, params)));
+            row_cells.push(Cell::new(&format!(
+                "{} ",
+                long_octal_permission_text(info, params, color_level)
+            )));
+        }
+        PermissionDisplay::None => {}
+    }
+}
+
+fn long_file_type_text(info: &FileInfo, params: &Params) -> String {
+    if !params.permission_colors {
+        return info.file_type.clone();
+    }
+
+    let mut output = String::with_capacity(info.file_type.len());
+    for value in info.file_type.chars() {
+        write_file_type_char(&mut output, value);
+    }
+    output
+}
+
+fn long_octal_permission_text(
+    info: &FileInfo,
+    params: &Params,
+    color_level: LongFormatColorLevel,
+) -> String {
+    let text = utils::format::mode_to_octal(info.mode_bits);
+    if !params.permission_colors {
+        return text;
+    }
+
+    match color_level {
+        LongFormatColorLevel::Truecolor => text.rgb(238, 204, 92).to_string(),
+        LongFormatColorLevel::Ansi256 => {
+            format!("\x1b[38;5;221m{text}\x1b[0m")
+        }
+        LongFormatColorLevel::Named => text.yellow().dim().to_string(),
+        LongFormatColorLevel::None => text,
+    }
 }
 
 fn long_permission_text(info: &FileInfo, params: &Params) -> String {

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -192,11 +192,8 @@ fn long_permission_text(info: &FileInfo, params: &Params) -> String {
         return format!("{}{}", info.file_type, info.mode);
     }
 
-    let mut output =
-        String::with_capacity(info.file_type.len() + info.mode.len());
-    for value in info.file_type.chars() {
-        write_file_type_char(&mut output, value);
-    }
+    let mut output = long_file_type_text(info, params);
+    output.reserve(info.mode.len());
     for value in info.mode.chars() {
         write_permission_char(&mut output, value);
     }

--- a/tests/crate/app.rs
+++ b/tests/crate/app.rs
@@ -97,6 +97,7 @@ fn test_run_with_flags_lists_matching_entries() {
             no_icons: true,
             no_color: false,
             no_permission_colors: false,
+            permissions: None,
             no_time_gradient: false,
             no_size_colors: false,
             gitignore: false,

--- a/tests/crate/cli.rs
+++ b/tests/crate/cli.rs
@@ -1,7 +1,7 @@
 use crate::cli::{
     CompatMode, Flags, format_version_info, try_parse_from_mode, version_info,
 };
-use crate::{IndicatorStyle, PermissionDisplay};
+use crate::{IndicatorStyle, structs::PermissionDisplay};
 use clap::error::ErrorKind;
 
 #[test]

--- a/tests/crate/cli.rs
+++ b/tests/crate/cli.rs
@@ -1,7 +1,7 @@
-use crate::IndicatorStyle;
 use crate::cli::{
     CompatMode, Flags, format_version_info, try_parse_from_mode, version_info,
 };
+use crate::{IndicatorStyle, PermissionDisplay};
 use clap::error::ErrorKind;
 
 #[test]
@@ -22,6 +22,7 @@ fn test_default_flags() {
     assert!(!args.no_icons);
     assert!(!args.no_color);
     assert!(!args.no_permission_colors);
+    assert_eq!(args.permissions, None);
     assert!(!args.no_time_gradient);
     assert!(!args.no_size_colors);
     assert!(!args.gitignore);
@@ -54,6 +55,8 @@ fn test_all_flags() {
         "--no-icons",
         "--no-color",
         "--no-permission-colors",
+        "--permissions",
+        "both",
         "--no-time-gradient",
         "--no-size-colors",
         "--gitignore",
@@ -77,6 +80,7 @@ fn test_all_flags() {
     assert!(args.no_icons);
     assert!(args.no_color);
     assert!(args.no_permission_colors);
+    assert_eq!(args.permissions, Some(PermissionDisplay::Both));
     assert!(args.no_time_gradient);
     assert!(args.no_size_colors);
     assert!(args.gitignore);
@@ -263,6 +267,35 @@ fn test_parse_from_mode_accepts_long_format_accent_disable_flags() {
         assert!(args.no_permission_colors);
         assert!(args.no_time_gradient);
         assert!(args.no_size_colors);
+    }
+}
+
+#[test]
+fn test_parse_from_mode_accepts_permission_display_modes() {
+    for mode in [CompatMode::Native, CompatMode::Gnu] {
+        for (value, expected) in [
+            ("symbolic", PermissionDisplay::Symbolic),
+            ("octal", PermissionDisplay::Octal),
+            ("both", PermissionDisplay::Both),
+            ("none", PermissionDisplay::None),
+        ] {
+            let args =
+                try_parse_from_mode(mode, ["lsplus", "--permissions", value])
+                    .unwrap();
+
+            assert_eq!(args.permissions, Some(expected));
+        }
+    }
+}
+
+#[test]
+fn test_parse_from_mode_rejects_invalid_permission_display_mode() {
+    for mode in [CompatMode::Native, CompatMode::Gnu] {
+        let err =
+            try_parse_from_mode(mode, ["lsplus", "--permissions", "wide"])
+                .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::InvalidValue);
     }
 }
 

--- a/tests/crate/file.rs
+++ b/tests/crate/file.rs
@@ -35,6 +35,7 @@ fn basic_info(display_name: &str, full_path: PathBuf) -> FileInfo {
     FileInfo {
         file_type: String::from("directory"),
         mode: String::from("drwxr-xr-x"),
+        mode_bits: 0o755,
         nlink: 1,
         user: String::from("user"),
         group: String::from("group"),

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -9,7 +9,7 @@ use crate::utils::render::{
     build_long_format_table, directory_header_text, render_short_format_lines,
     size_style_spec_for_color_level, terminal_width_or_default,
 };
-use crate::{FileInfo, NameStyle, Params};
+use crate::{FileInfo, NameStyle, Params, PermissionDisplay};
 use colored_text::{ColorMode, Colorize};
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
@@ -25,6 +25,7 @@ fn test_file_info(
     FileInfo {
         file_type: String::from("-"),
         mode: String::from("rw-r--r--"),
+        mode_bits: 0o644,
         nlink: 1,
         user: String::from("user"),
         group: String::from("group"),
@@ -45,6 +46,117 @@ fn normalized_lines(lines: Vec<String>) -> String {
 
 fn normalized_table(table: prettytable::Table) -> String {
     table.to_string().replace("\r\n", "\n")
+}
+
+#[test]
+fn test_build_long_format_table_shows_symbolic_permissions_by_default() {
+    let mut info = test_file_info("plain.txt", None, 12, SystemTime::now());
+    info.file_type = String::from("-");
+    info.mode = String::from("rw-r--r--");
+    info.mode_bits = 0o644;
+
+    let rendered = normalized_table(build_long_format_table(
+        &[info],
+        &plain_permission_params(),
+    ));
+
+    assert!(rendered.contains("-rw-r--r--"));
+    assert!(!rendered.contains("0644"));
+}
+
+#[test]
+fn test_build_long_format_table_replaces_symbolic_permissions_with_octal() {
+    let mut info = test_file_info("script.sh", None, 12, SystemTime::now());
+    info.file_type = String::from("-");
+    info.mode = String::from("rwxr-xr-x");
+    info.mode_bits = 0o4755;
+    let params = Params {
+        permissions: PermissionDisplay::Octal,
+        ..plain_permission_params()
+    };
+
+    let rendered = normalized_table(build_long_format_table(&[info], &params));
+    let stripped = strip_str(&rendered);
+
+    assert!(stripped.contains("- 4755  1"));
+    assert!(!rendered.contains("-rwxr-xr-x"));
+}
+
+#[test]
+fn test_build_long_format_table_shows_symbolic_and_octal_permissions() {
+    let mut info = test_file_info("sticky", None, 12, SystemTime::now());
+    info.file_type = String::from("d");
+    info.mode = String::from("rwxrwxrwt");
+    info.mode_bits = 0o1777;
+    let params = Params {
+        permissions: PermissionDisplay::Both,
+        ..plain_permission_params()
+    };
+
+    let rendered = normalized_table(build_long_format_table(&[info], &params));
+    let stripped = strip_str(&rendered);
+
+    assert!(stripped.contains("drwxrwxrwt 1777  1"));
+}
+
+#[test]
+fn test_build_long_format_table_colors_octal_permissions_subtly() {
+    for (env, expected) in [
+        (
+            [("COLORTERM", Some("truecolor")), ("TERM", None::<&str>)],
+            "\u{1b}[38;2;238;204;92m0755\u{1b}[0m",
+        ),
+        (
+            [
+                ("COLORTERM", None::<&str>),
+                ("TERM", Some("xterm-256color")),
+            ],
+            "\u{1b}[38;5;221m0755\u{1b}[0m",
+        ),
+        (
+            [("COLORTERM", None::<&str>), ("TERM", Some("xterm"))],
+            "\u{1b}[2;33m0755\u{1b}[0m",
+        ),
+    ] {
+        temp_env::with_vars(env, || {
+            with_color_output_enabled(|| {
+                let mut info =
+                    test_file_info("script.sh", None, 12, SystemTime::now());
+                info.file_type = String::from("-");
+                info.mode_bits = 0o755;
+                let params = Params {
+                    permissions: PermissionDisplay::Octal,
+                    ..fixed_time_params()
+                };
+
+                let rendered = normalized_table(build_long_format_table(
+                    &[info],
+                    &params,
+                ));
+
+                assert!(rendered.contains(expected));
+                assert!(rendered.contains("\u{1b}[2m-\u{1b}[0m"));
+            });
+        });
+    }
+}
+
+#[test]
+fn test_build_long_format_table_omits_permissions() {
+    let mut info = test_file_info("private", None, 12, SystemTime::now());
+    info.file_type = String::from("-");
+    info.mode = String::from("---------");
+    info.mode_bits = 0;
+    let params = Params {
+        permissions: PermissionDisplay::None,
+        ..plain_permission_params()
+    };
+
+    let rendered = normalized_table(build_long_format_table(&[info], &params));
+
+    assert!(rendered.contains("private"));
+    assert!(!rendered.contains("---------"));
+    assert!(!rendered.contains("0000"));
 }
 
 #[test]

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -9,7 +9,7 @@ use crate::utils::render::{
     build_long_format_table, directory_header_text, render_short_format_lines,
     size_style_spec_for_color_level, terminal_width_or_default,
 };
-use crate::{FileInfo, NameStyle, Params, PermissionDisplay};
+use crate::{FileInfo, NameStyle, Params, structs::PermissionDisplay};
 use colored_text::{ColorMode, Colorize};
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};

--- a/tests/crate/settings.rs
+++ b/tests/crate/settings.rs
@@ -3,7 +3,7 @@ use crate::settings::{
     StartupConfig, config_path_from_home, load_config, load_config_from_path,
     load_startup_config_from,
 };
-use crate::{IndicatorStyle, Params, PermissionDisplay};
+use crate::{IndicatorStyle, Params, structs::PermissionDisplay};
 use std::fs;
 use std::path::PathBuf;
 use tempfile::tempdir;

--- a/tests/crate/settings.rs
+++ b/tests/crate/settings.rs
@@ -3,7 +3,7 @@ use crate::settings::{
     StartupConfig, config_path_from_home, load_config, load_config_from_path,
     load_startup_config_from,
 };
-use crate::{IndicatorStyle, Params};
+use crate::{IndicatorStyle, Params, PermissionDisplay};
 use std::fs;
 use std::path::PathBuf;
 use tempfile::tempdir;
@@ -98,6 +98,7 @@ fn test_load_config_reads_boolean_settings_from_home_config() {
                 no_icons: true,
                 no_color: true,
                 permission_colors: false,
+                permissions: PermissionDisplay::Symbolic,
                 time_gradient: false,
                 size_colors: false,
                 gitignore: true,

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -1,5 +1,5 @@
 use lsplus::utils::format::{
-    SizeScale, human_readable_format, mode_to_rwx, show_size,
+    SizeScale, human_readable_format, mode_to_octal, mode_to_rwx, show_size,
 };
 
 #[test]
@@ -157,4 +157,14 @@ fn test_mode_to_rwx_special_bits() {
     assert_eq!(mode_to_rwx(0o1755), "rwxr-xr-t");
     assert_eq!(mode_to_rwx(0o1644), "rw-r--r-T");
     assert_eq!(mode_to_rwx(0o7777), "rwsrwsrwt");
+}
+
+#[test]
+fn test_mode_to_octal_masks_permission_bits() {
+    assert_eq!(mode_to_octal(0o100644), "0644");
+    assert_eq!(mode_to_octal(0o100755), "0755");
+    assert_eq!(mode_to_octal(0o0000), "0000");
+    assert_eq!(mode_to_octal(0o104755), "4755");
+    assert_eq!(mode_to_octal(0o041777), "1777");
+    assert_eq!(mode_to_octal(0o107777), "7777");
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -204,6 +204,12 @@ fn test_long_format_permission_display_modes() {
     fs::set_permissions(&file_path, fs::Permissions::from_mode(0o755))
         .unwrap();
 
+    let mut symbolic = command_with_home(home_dir.path());
+    symbolic.arg("-l").arg("--no-icons").arg(&file_path);
+    let (stdout, _stderr) = run_and_capture(&mut symbolic);
+    assert!(stdout.contains("-rwxr-xr-x"));
+    assert!(!stdout.contains("0755"));
+
     let mut octal = command_with_home(home_dir.path());
     octal
         .arg("-l")
@@ -214,6 +220,15 @@ fn test_long_format_permission_display_modes() {
     let (stdout, _stderr) = run_and_capture(&mut octal);
     assert!(stdout.contains("- 0755"));
     assert!(!stdout.contains("-rwxr-xr-x"));
+
+    let mut both = command_with_home(home_dir.path());
+    both.arg("-l")
+        .arg("--no-icons")
+        .arg("--permissions")
+        .arg("both")
+        .arg(&file_path);
+    let (stdout, _stderr) = run_and_capture(&mut both);
+    assert!(stdout.contains("-rwxr-xr-x 0755"));
 
     let mut none = command_with_home(home_dir.path());
     none.arg("-l")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -194,6 +194,39 @@ fn test_long_format_si_sizes() {
     assert!(stdout.contains("1.5 k"));
 }
 
+#[cfg(unix)]
+#[test]
+fn test_long_format_permission_display_modes() {
+    let home_dir = tempdir().unwrap();
+    let temp_dir = tempdir().unwrap();
+    let file_path = temp_dir.path().join("script.sh");
+    fs::write(&file_path, "#!/bin/sh\n").unwrap();
+    fs::set_permissions(&file_path, fs::Permissions::from_mode(0o755))
+        .unwrap();
+
+    let mut octal = command_with_home(home_dir.path());
+    octal
+        .arg("-l")
+        .arg("--no-icons")
+        .arg("--permissions")
+        .arg("octal")
+        .arg(&file_path);
+    let (stdout, _stderr) = run_and_capture(&mut octal);
+    assert!(stdout.contains("- 0755"));
+    assert!(!stdout.contains("-rwxr-xr-x"));
+
+    let mut none = command_with_home(home_dir.path());
+    none.arg("-l")
+        .arg("--no-icons")
+        .arg("--permissions")
+        .arg("none")
+        .arg(&file_path);
+    let (stdout, _stderr) = run_and_capture(&mut none);
+    assert!(stdout.contains("script.sh"));
+    assert!(!stdout.contains("- 0755"));
+    assert!(!stdout.contains("-rwxr-xr-x"));
+}
+
 #[test]
 fn test_multiple_paths() {
     let temp_dir = tempdir().unwrap();

--- a/tests/seams.rs
+++ b/tests/seams.rs
@@ -50,6 +50,7 @@ fn test_public_run_with_flags_accepts_missing_patterns() {
         no_icons: false,
         no_color: false,
         no_permission_colors: false,
+        permissions: None,
         no_time_gradient: false,
         no_size_colors: false,
         gitignore: false,

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -1,7 +1,7 @@
 use config::Config;
 use lsplus::cli::Flags;
 use lsplus::utils::format::SizeScale;
-use lsplus::{IndicatorStyle, Params};
+use lsplus::{IndicatorStyle, Params, PermissionDisplay};
 use std::fs;
 use tempfile::tempdir;
 
@@ -24,6 +24,7 @@ fn test_default_params() {
     assert!(!params.no_icons);
     assert!(!params.no_color);
     assert!(params.permission_colors);
+    assert_eq!(params.permissions, PermissionDisplay::Symbolic);
     assert!(params.time_gradient);
     assert!(params.size_colors);
     assert!(!params.gitignore);
@@ -53,6 +54,7 @@ fn test_config_conversion() {
             no_icons = true
             no_color = true
             permission_colors = false
+            permissions = "octal"
             time_gradient = false
             size_colors = false
             gitignore = true
@@ -94,6 +96,7 @@ fn test_config_conversion() {
             no_icons: true,
             no_color: true,
             permission_colors: false,
+            permissions: PermissionDisplay::Octal,
             time_gradient: false,
             size_colors: false,
             gitignore: true,
@@ -183,6 +186,7 @@ fn test_params_merge_prefers_true_from_either_source() {
         no_icons: false,
         no_color: true,
         permission_colors: true,
+        permissions: PermissionDisplay::Octal,
         time_gradient: false,
         size_colors: true,
         gitignore: true,
@@ -207,6 +211,7 @@ fn test_params_merge_prefers_true_from_either_source() {
         no_icons: true,
         no_color: false,
         no_permission_colors: true,
+        permissions: Some(PermissionDisplay::Both),
         no_time_gradient: false,
         no_size_colors: true,
         gitignore: false,
@@ -242,6 +247,7 @@ fn test_params_merge_prefers_true_from_either_source() {
     assert!(params.no_icons);
     assert!(params.no_color);
     assert!(!params.permission_colors);
+    assert_eq!(params.permissions, PermissionDisplay::Both);
     assert!(!params.time_gradient);
     assert!(!params.size_colors);
     assert!(params.gitignore);
@@ -268,6 +274,7 @@ fn test_params_merge_keeps_false_when_both_sources_are_false() {
         no_icons: false,
         no_color: false,
         no_permission_colors: false,
+        permissions: None,
         no_time_gradient: false,
         no_size_colors: false,
         gitignore: false,
@@ -277,6 +284,50 @@ fn test_params_merge_keeps_false_when_both_sources_are_false() {
     let params = Params::merge(&flags, &Params::default());
 
     assert_eq!(params, Params::default());
+}
+
+#[test]
+fn test_params_merge_uses_config_permissions_until_cli_overrides() {
+    let config = Params {
+        permissions: PermissionDisplay::Octal,
+        ..Params::default()
+    };
+    let flags = Flags {
+        version: false,
+        paths: vec![],
+        show_all: false,
+        almost_all: false,
+        indicator_style: None,
+        dirs_first: false,
+        long: false,
+        human_readable: false,
+        si: false,
+        recursive: false,
+        tree: false,
+        tree_level: None,
+        prune_noisy_dirs: false,
+        prune_dirs: Vec::new(),
+        no_icons: false,
+        no_color: false,
+        no_permission_colors: false,
+        permissions: None,
+        no_time_gradient: false,
+        no_size_colors: false,
+        gitignore: false,
+        fuzzy_time: false,
+    };
+
+    let params = Params::merge(&flags, &config);
+
+    assert_eq!(params.permissions, PermissionDisplay::Octal);
+
+    let flags = Flags {
+        permissions: Some(PermissionDisplay::None),
+        ..flags
+    };
+    let params = Params::merge(&flags, &config);
+
+    assert_eq!(params.permissions, PermissionDisplay::None);
 }
 
 #[test]
@@ -299,6 +350,7 @@ fn test_params_merge_si_enables_decimal_human_readable_output() {
         no_icons: false,
         no_color: false,
         no_permission_colors: false,
+        permissions: None,
         no_time_gradient: false,
         no_size_colors: false,
         gitignore: false,
@@ -337,6 +389,7 @@ fn test_params_merge_config_si_overrides_config_human_readable() {
         no_icons: false,
         no_color: false,
         no_permission_colors: false,
+        permissions: None,
         no_time_gradient: false,
         no_size_colors: false,
         gitignore: false,
@@ -374,6 +427,7 @@ fn test_params_merge_cli_prune_dirs_append_config_prune_dirs() {
         no_icons: false,
         no_color: false,
         no_permission_colors: false,
+        permissions: None,
         no_time_gradient: false,
         no_size_colors: false,
         gitignore: false,
@@ -418,6 +472,7 @@ fn test_params_merge_deduplicates_prune_preset() {
         no_icons: false,
         no_color: false,
         no_permission_colors: false,
+        permissions: None,
         no_time_gradient: false,
         no_size_colors: false,
         gitignore: false,

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -1,7 +1,7 @@
 use config::Config;
 use lsplus::cli::Flags;
 use lsplus::utils::format::SizeScale;
-use lsplus::{IndicatorStyle, Params, PermissionDisplay};
+use lsplus::{IndicatorStyle, Params, structs::PermissionDisplay};
 use std::fs;
 use tempfile::tempdir;
 


### PR DESCRIPTION
Adds a long-format permissions option with symbolic, octal, both, and none modes. Includes config support, octal rendering and coloring, tests, README notes, and mdBook usage/config documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `--permissions` option for long-format output, letting you choose symbolic, octal, both, or no permissions display.
  * Added support for setting the same permission display mode in configuration files.

* **Bug Fixes**
  * Long-format listings now show permission details consistently with the selected display mode.
  * Octal permission values are now rendered in a standard four-digit format.

* **Documentation**
  * Updated usage and configuration docs to describe the new permission display options and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->