### PR TITLE
Replace long-format table renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,27 +334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,12 +378,6 @@ checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
 ]
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -549,12 +522,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-
-[[package]]
 name = "husky-rs"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,17 +567,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,12 +598,6 @@ dependencies = [
  "pest_derive",
  "serde",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -703,13 +653,12 @@ dependencies = [
  "ignore",
  "nix",
  "predicates",
- "prettytable",
  "serde",
  "strip-ansi-escapes",
  "temp-env",
  "tempfile",
  "terminal_size",
- "unicode-width 0.2.2",
+ "unicode-width",
 ]
 
 [[package]]
@@ -866,20 +815,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettytable"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46480520d1b77c9a3482d39939fcf96831537a250ec62d4fd8fbdf8e0302e781"
-dependencies = [
- "csv",
- "encode_unicode",
- "is-terminal",
- "lazy_static",
- "term",
- "unicode-width 0.1.14",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,18 +917,6 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
-
-[[package]]
-name = "ryu"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -1146,17 +1069,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
-]
-
-[[package]]
 name = "terminal_size"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,12 +1193,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ glob = "0.3.1"
 clap = { version = "4.5.37", features = ["derive"] }
 colored_text = "0.4.1"
 nix = { version = "0.31.0", features = ["user"] }
-prettytable = "0.10.0"
 terminal_size = "0.4.4"
 config = "0.15.7"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -229,44 +229,64 @@ fn size_cell(
     color_level: LongFormatColorLevel,
     base: &str,
 ) -> Cell {
-    let text = size_text(
-        text,
-        size_style_spec_for_color_level(size, params, color_level, base),
-    );
-    if base == "r" {
+    let style = size_style_for_color_level(size, params, color_level, base);
+    let text = style.format(text);
+    if style.align_right() {
         Cell::right(text)
     } else {
         Cell::new(text)
     }
 }
 
-/// Return the style spec for a size cell.
-pub(crate) fn size_style_spec_for_color_level(
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SizeCellStyle {
+    Plain,
+    PlainRight,
+    Large,
+    LargeRight,
+    Huge,
+    HugeRight,
+}
+
+impl SizeCellStyle {
+    fn align_right(self) -> bool {
+        matches!(
+            self,
+            SizeCellStyle::PlainRight
+                | SizeCellStyle::LargeRight
+                | SizeCellStyle::HugeRight
+        )
+    }
+
+    fn format(self, text: &str) -> String {
+        match self {
+            SizeCellStyle::Huge | SizeCellStyle::HugeRight => {
+                text.red().bold().to_string()
+            }
+            SizeCellStyle::Large | SizeCellStyle::LargeRight => {
+                text.yellow().to_string()
+            }
+            SizeCellStyle::Plain | SizeCellStyle::PlainRight => {
+                text.to_string()
+            }
+        }
+    }
+}
+
+/// Return the color and alignment style for a size cell.
+pub(crate) fn size_style_for_color_level(
     size: u64,
     params: &Params,
     color_level: LongFormatColorLevel,
     base: &str,
-) -> &'static str {
+) -> SizeCellStyle {
     match (params.size_colors && color_level.is_enabled(), size, base) {
-        (true, HUGE_SIZE_BYTES.., "r") => "rFrb",
-        (true, HUGE_SIZE_BYTES.., _) => "Frb",
-        (true, LARGE_SIZE_BYTES.., "r") => "rFy",
-        (true, LARGE_SIZE_BYTES.., _) => "Fy",
-        (_, _, "r") => "r",
-        _ => "",
-    }
-}
-
-fn size_text(text: &str, style_spec: &str) -> String {
-    debug_assert!(
-        matches!(style_spec, "rFrb" | "Frb" | "rFy" | "Fy" | "r" | ""),
-        "unexpected size style spec: {style_spec:?}"
-    );
-
-    match style_spec {
-        "rFrb" | "Frb" => text.red().bold().to_string(),
-        "rFy" | "Fy" => text.yellow().to_string(),
-        _ => text.to_string(),
+        (true, HUGE_SIZE_BYTES.., "r") => SizeCellStyle::HugeRight,
+        (true, HUGE_SIZE_BYTES.., _) => SizeCellStyle::Huge,
+        (true, LARGE_SIZE_BYTES.., "r") => SizeCellStyle::LargeRight,
+        (true, LARGE_SIZE_BYTES.., _) => SizeCellStyle::Large,
+        (_, _, "r") => SizeCellStyle::PlainRight,
+        _ => SizeCellStyle::Plain,
     }
 }
 
@@ -454,7 +474,7 @@ fn short_render_items(file_info: &[FileInfo]) -> Vec<ShortRenderItem<'_>> {
 fn short_render_item(info: &FileInfo) -> ShortRenderItem<'_> {
     let display_name = check_display_name(info);
     let (prefix, name) = short_cell_parts(info, &display_name);
-    let plain_width = visible_text_width(&format!("{prefix}{name}"));
+    let plain_width = visible_width(&format!("{prefix}{name}"));
 
     ShortRenderItem {
         info,
@@ -552,11 +572,9 @@ fn style_short_segment(info: &FileInfo, text: String) -> String {
     }
 }
 
-fn visible_text_width(text: &str) -> usize {
-    visible_width(text)
-}
-
 fn print_table(table: &Table) -> io::Result<()> {
+    // Long-format colors are decided before cells reach the table renderer.
+    // Keep raw ANSI escapes gated by long_format_color_level().
     let mut stdout = io::stdout();
     table.write_to(&mut stdout)?;
     stdout.flush()

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -88,7 +88,7 @@ pub(crate) fn build_long_format_table_with_name_prefixes<'a>(
             info.size,
             params,
             color_level,
-            "r",
+            true,
         ));
 
         if size_scale.is_some() {
@@ -97,7 +97,7 @@ pub(crate) fn build_long_format_table_with_name_prefixes<'a>(
                 info.size,
                 params,
                 color_level,
-                "",
+                false,
             ));
         }
 
@@ -227,9 +227,10 @@ fn size_cell(
     size: u64,
     params: &Params,
     color_level: LongFormatColorLevel,
-    base: &str,
+    align_right: bool,
 ) -> Cell {
-    let style = size_style_for_color_level(size, params, color_level, base);
+    let style =
+        size_style_for_color_level(size, params, color_level, align_right);
     let text = style.format(text);
     if style.align_right() {
         Cell::right(text)
@@ -278,14 +279,18 @@ pub(crate) fn size_style_for_color_level(
     size: u64,
     params: &Params,
     color_level: LongFormatColorLevel,
-    base: &str,
+    align_right: bool,
 ) -> SizeCellStyle {
-    match (params.size_colors && color_level.is_enabled(), size, base) {
-        (true, HUGE_SIZE_BYTES.., "r") => SizeCellStyle::HugeRight,
+    match (
+        params.size_colors && color_level.is_enabled(),
+        size,
+        align_right,
+    ) {
+        (true, HUGE_SIZE_BYTES.., true) => SizeCellStyle::HugeRight,
         (true, HUGE_SIZE_BYTES.., _) => SizeCellStyle::Huge,
-        (true, LARGE_SIZE_BYTES.., "r") => SizeCellStyle::LargeRight,
+        (true, LARGE_SIZE_BYTES.., true) => SizeCellStyle::LargeRight,
         (true, LARGE_SIZE_BYTES.., _) => SizeCellStyle::Large,
-        (_, _, "r") => SizeCellStyle::PlainRight,
+        (_, _, true) => SizeCellStyle::PlainRight,
         _ => SizeCellStyle::Plain,
     }
 }

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -1,12 +1,10 @@
 //! Output rendering for long and short listing formats.
 //!
-//! Long format uses `prettytable` rows with optional accent colors. Short
-//! format computes terminal-width-aware columns using visible Unicode width so
-//! ANSI styling and wide glyphs do not distort layout.
+//! Long and short formats compute terminal-width-aware columns using visible
+//! Unicode width so ANSI styling and wide glyphs do not distort layout.
 
 use chrono::{DateTime, Local};
 use colored_text::{Colorize, StyledText};
-use prettytable::{Cell, Row, Table};
 use std::fmt::Write as FmtWrite;
 use std::io::{self, Write as IoWrite};
 use std::time::{Duration, SystemTime};
@@ -19,6 +17,7 @@ use crate::structs::{FileInfo, NameStyle};
 use crate::utils;
 use crate::utils::color::{LongFormatColorLevel, long_format_color_level};
 use crate::utils::file::check_display_name;
+use crate::utils::table::{Cell, Row, Table};
 use crate::utils::time::{DAY, MONTH, WEEK, YEAR};
 use crate::{Params, structs::PermissionDisplay};
 
@@ -60,11 +59,11 @@ pub(crate) fn build_long_format_table(
     )
 }
 
-fn build_long_format_table_with_name_prefixes<'a>(
+pub(crate) fn build_long_format_table_with_name_prefixes<'a>(
     file_info: impl IntoIterator<Item = (&'a FileInfo, &'a str)>,
     params: &Params,
 ) -> Table {
-    let mut table = utils::table::create_table(0);
+    let mut table = Table::new();
     let color_level = long_format_color_level(params);
 
     for (info, name_prefix) in file_info {
@@ -82,9 +81,9 @@ fn build_long_format_table_with_name_prefixes<'a>(
         let mut row_cells = Vec::with_capacity(10);
 
         append_permission_cells(&mut row_cells, info, params, color_level);
-        row_cells.push(Cell::new(&info.nlink.to_string()));
-        row_cells.push(Cell::new(&format!(" {}", info.user.cyan())));
-        row_cells.push(Cell::new(&format!("{} ", info.group.green())));
+        row_cells.push(Cell::new(info.nlink.to_string()));
+        row_cells.push(Cell::new(format!(" {}", info.user.cyan())));
+        row_cells.push(Cell::new(format!("{} ", info.group.green())));
         row_cells.push(size_cell(
             &display_size,
             info.size,
@@ -103,16 +102,17 @@ fn build_long_format_table_with_name_prefixes<'a>(
             ));
         }
 
-        row_cells.push(
-            Cell::new(&format!(
-                " {} ",
-                long_time_text(&display_time, info.mtime, params, color_level)
-            ))
-            .style_spec("r"),
-        );
+        row_cells.push(Cell::right(format!(
+            " {} ",
+            long_time_text(&display_time, info.mtime, params, color_level)
+        )));
 
-        if let Some(icon) = &info.item_icon {
-            row_cells.push(Cell::new(&format!("{} ", icon)));
+        if !params.no_icons {
+            if let Some(icon) = &info.item_icon {
+                row_cells.push(Cell::new(format!("{} ", icon)));
+            } else {
+                row_cells.push(Cell::new(""));
+            }
         }
 
         let display_name =
@@ -132,21 +132,21 @@ fn append_permission_cells(
 ) {
     match params.permissions {
         PermissionDisplay::Symbolic => {
-            row_cells.push(Cell::new(&format!(
+            row_cells.push(Cell::new(format!(
                 "{} ",
                 long_permission_text(info, params)
             )));
         }
         PermissionDisplay::Octal => {
-            row_cells.push(Cell::new(&format!(
+            row_cells.push(Cell::new(format!(
                 "{} {} ",
                 long_file_type_text(info, params),
                 long_octal_permission_text(info, params, color_level)
             )));
         }
         PermissionDisplay::Both => {
-            row_cells.push(Cell::new(&long_permission_text(info, params)));
-            row_cells.push(Cell::new(&format!(
+            row_cells.push(Cell::new(long_permission_text(info, params)));
+            row_cells.push(Cell::new(format!(
                 "{} ",
                 long_octal_permission_text(info, params, color_level)
             )));
@@ -230,15 +230,18 @@ fn size_cell(
     color_level: LongFormatColorLevel,
     base: &str,
 ) -> Cell {
-    Cell::new(text).style_spec(size_style_spec_for_color_level(
-        size,
-        params,
-        color_level,
-        base,
-    ))
+    let text = size_text(
+        text,
+        size_style_spec_for_color_level(size, params, color_level, base),
+    );
+    if base == "r" {
+        Cell::right(text)
+    } else {
+        Cell::new(text)
+    }
 }
 
-/// Return the prettytable style spec for a size cell.
+/// Return the style spec for a size cell.
 pub(crate) fn size_style_spec_for_color_level(
     size: u64,
     params: &Params,
@@ -252,6 +255,14 @@ pub(crate) fn size_style_spec_for_color_level(
         (true, LARGE_SIZE_BYTES.., _) => "Fy",
         (_, _, "r") => "r",
         _ => "",
+    }
+}
+
+fn size_text(text: &str, style_spec: &str) -> String {
+    match style_spec {
+        "rFrb" | "Frb" => text.red().bold().to_string(),
+        "rFy" | "Fy" => text.yellow().to_string(),
+        _ => text.to_string(),
     }
 }
 
@@ -543,9 +554,9 @@ fn visible_text_width(text: &str) -> usize {
 }
 
 fn print_table(table: &Table) -> io::Result<()> {
-    // Use tty-aware output so prettytable style_spec colors stay out of pipes.
-    table.print_tty(false)?;
-    io::stdout().flush()
+    let mut stdout = io::stdout();
+    table.write_to(&mut stdout)?;
+    stdout.flush()
 }
 
 fn print_short_lines(lines: &[String]) -> io::Result<()> {

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -11,13 +11,12 @@ use std::time::{Duration, SystemTime};
 
 use strip_ansi_escapes::strip_str;
 use terminal_size::{Height, Width, terminal_size};
-use unicode_width::UnicodeWidthStr;
 
 use crate::structs::{FileInfo, NameStyle};
 use crate::utils;
 use crate::utils::color::{LongFormatColorLevel, long_format_color_level};
 use crate::utils::file::check_display_name;
-use crate::utils::table::{Cell, Row, Table};
+use crate::utils::table::{Cell, Row, Table, visible_width};
 use crate::utils::time::{DAY, MONTH, WEEK, YEAR};
 use crate::{Params, structs::PermissionDisplay};
 
@@ -259,6 +258,11 @@ pub(crate) fn size_style_spec_for_color_level(
 }
 
 fn size_text(text: &str, style_spec: &str) -> String {
+    debug_assert!(
+        matches!(style_spec, "rFrb" | "Frb" | "rFy" | "Fy" | "r" | ""),
+        "unexpected size style spec: {style_spec:?}"
+    );
+
     match style_spec {
         "rFrb" | "Frb" => text.red().bold().to_string(),
         "rFy" | "Fy" => text.yellow().to_string(),
@@ -549,8 +553,7 @@ fn style_short_segment(info: &FileInfo, text: String) -> String {
 }
 
 fn visible_text_width(text: &str) -> usize {
-    let stripped = strip_str(text);
-    UnicodeWidthStr::width(stripped.as_str())
+    visible_width(text)
 }
 
 fn print_table(table: &Table) -> io::Result<()> {

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -1,15 +1,151 @@
-//! Prettytable construction helpers.
+//! Borderless table rendering with ANSI-aware cell width measurement.
 
-use prettytable::{Table, format::FormatBuilder};
+use std::fmt;
+use std::io::{self, Write};
 
-/// Create a borderless table using the spacing expected by `lsplus`.
-pub fn create_table(padding: usize) -> Table {
-    let format = FormatBuilder::new()
-        .column_separator(' ')
-        .left_border(' ')
-        .padding(0, padding)
-        .build();
-    let mut table = Table::new();
-    table.set_format(format);
-    table
+use strip_ansi_escapes::strip_str;
+use unicode_width::UnicodeWidthStr;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Alignment {
+    Left,
+    Right,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Cell {
+    text: String,
+    width: usize,
+    align: Alignment,
+}
+
+impl Cell {
+    pub(crate) fn new(text: impl Into<String>) -> Self {
+        Self::with_alignment(text, Alignment::Left)
+    }
+
+    pub(crate) fn right(text: impl Into<String>) -> Self {
+        Self::with_alignment(text, Alignment::Right)
+    }
+
+    fn with_alignment(text: impl Into<String>, align: Alignment) -> Self {
+        let text = text.into();
+        let width = visible_width(&text);
+        Self { text, width, align }
+    }
+
+    fn write_padded(
+        &self,
+        output: &mut impl Write,
+        target_width: usize,
+        skip_right_fill: bool,
+    ) -> io::Result<()> {
+        let padding = target_width.saturating_sub(self.width);
+
+        match self.align {
+            Alignment::Left => {
+                write!(output, "{}", self.text)?;
+                if !skip_right_fill {
+                    write_spaces(output, padding)?;
+                }
+            }
+            Alignment::Right => {
+                write_spaces(output, padding)?;
+                write!(output, "{}", self.text)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Row {
+    cells: Vec<Cell>,
+}
+
+impl Row {
+    pub(crate) fn new(cells: Vec<Cell>) -> Self {
+        Self { cells }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct Table {
+    rows: Vec<Row>,
+}
+
+impl Table {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn add_row(&mut self, row: Row) {
+        self.rows.push(row);
+    }
+
+    pub(crate) fn write_to(&self, output: &mut impl Write) -> io::Result<()> {
+        let widths = self.column_widths();
+        for row in &self.rows {
+            write!(output, " ")?;
+            for column in 0..widths.len() {
+                if column > 0 {
+                    write!(output, " ")?;
+                }
+
+                let skip_right_fill = column == widths.len() - 1;
+                if let Some(cell) = row.cells.get(column) {
+                    cell.write_padded(
+                        output,
+                        widths[column],
+                        skip_right_fill,
+                    )?;
+                } else if !skip_right_fill {
+                    write_spaces(output, widths[column])?;
+                }
+            }
+            writeln!(output)?;
+        }
+
+        Ok(())
+    }
+
+    fn column_widths(&self) -> Vec<usize> {
+        let column_count = self
+            .rows
+            .iter()
+            .map(|row| row.cells.len())
+            .max()
+            .unwrap_or(0);
+        let mut widths = vec![0; column_count];
+
+        for row in &self.rows {
+            for (index, cell) in row.cells.iter().enumerate() {
+                widths[index] = widths[index].max(cell.width);
+            }
+        }
+
+        widths
+    }
+}
+
+impl fmt::Display for Table {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut output = Vec::new();
+        self.write_to(&mut output).map_err(|_| fmt::Error)?;
+        let rendered = String::from_utf8(output).map_err(|_| fmt::Error)?;
+        formatter.write_str(&rendered)
+    }
+}
+
+fn visible_width(text: &str) -> usize {
+    let stripped = strip_str(text);
+    UnicodeWidthStr::width(stripped.as_str())
+}
+
+fn write_spaces(output: &mut impl Write, count: usize) -> io::Result<()> {
+    for _ in 0..count {
+        write!(output, " ")?;
+    }
+    Ok(())
 }

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -6,6 +6,8 @@ use std::io::{self, Write};
 use strip_ansi_escapes::strip_str;
 use unicode_width::UnicodeWidthStr;
 
+const SPACE_BUFFER: [u8; 64] = [b' '; 64];
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum Alignment {
     Left,
@@ -138,14 +140,17 @@ impl fmt::Display for Table {
     }
 }
 
-fn visible_width(text: &str) -> usize {
+pub(crate) fn visible_width(text: &str) -> usize {
     let stripped = strip_str(text);
     UnicodeWidthStr::width(stripped.as_str())
 }
 
 fn write_spaces(output: &mut impl Write, count: usize) -> io::Result<()> {
-    for _ in 0..count {
-        write!(output, " ")?;
+    let mut remaining = count;
+    while remaining > 0 {
+        let chunk = remaining.min(SPACE_BUFFER.len());
+        output.write_all(&SPACE_BUFFER[..chunk])?;
+        remaining -= chunk;
     }
     Ok(())
 }

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -6,7 +6,8 @@ use crate::utils::color::LongFormatColorLevel;
 use crate::utils::format::mode_to_rwx;
 use crate::utils::icons::Icon;
 use crate::utils::render::{
-    build_long_format_table, directory_header_text, render_short_format_lines,
+    build_long_format_table, build_long_format_table_with_name_prefixes,
+    directory_header_text, render_short_format_lines,
     size_style_spec_for_color_level, terminal_width_or_default,
 };
 use crate::{FileInfo, NameStyle, Params, structs::PermissionDisplay};
@@ -15,6 +16,7 @@ use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 use strip_ansi_escapes::strip_str;
 use terminal_size::{Height, Width};
+use unicode_width::UnicodeWidthStr;
 
 fn test_file_info(
     display_name: &str,
@@ -44,8 +46,13 @@ fn normalized_lines(lines: Vec<String>) -> String {
     lines.join("\n")
 }
 
-fn normalized_table(table: prettytable::Table) -> String {
+fn normalized_table(table: impl std::fmt::Display) -> String {
     table.to_string().replace("\r\n", "\n")
+}
+
+fn visible_column_start(row: &str, needle: &str) -> usize {
+    let byte_start = row.find(needle).unwrap();
+    UnicodeWidthStr::width(strip_str(&row[..byte_start]).as_str())
 }
 
 #[test]
@@ -212,6 +219,105 @@ fn test_build_long_format_table_omits_optional_units_and_icons() {
     assert!(rendered.contains("12"));
     assert!(!rendered.contains("K"));
     assert!(!rendered.contains(&Icon::RustFile.to_string()));
+}
+
+#[test]
+fn test_build_long_format_table_aligns_after_colored_symbolic_permissions() {
+    with_color_output_enabled(|| {
+        let mut first =
+            test_file_info("first.txt", None, 12, SystemTime::now());
+        first.file_type = String::from("d");
+        first.mode = String::from("rwsr-tS-T");
+        first.nlink = 1;
+
+        let mut second =
+            test_file_info("second.txt", None, 12, SystemTime::now());
+        second.file_type = String::from("-");
+        second.mode = String::from("rwxrwxrwx");
+        second.nlink = 123_456;
+
+        let rendered = normalized_table(build_long_format_table(
+            &[first, second],
+            &fixed_time_params(),
+        ));
+        let rows: Vec<_> = rendered
+            .lines()
+            .filter(|line| line.contains(".txt"))
+            .collect();
+
+        assert_eq!(rows.len(), 2);
+        assert!(rows[0].contains("\u{1b}["));
+        assert_eq!(
+            visible_column_start(rows[0], "user"),
+            visible_column_start(rows[1], "user")
+        );
+        assert_eq!(
+            visible_column_start(rows[0], "group"),
+            visible_column_start(rows[1], "group")
+        );
+    });
+}
+
+#[test]
+fn test_build_long_format_table_aligns_names_with_blank_icon_cells() {
+    let files = [
+        test_file_info("plain.txt", None, 12, SystemTime::now()),
+        test_file_info(
+            "example.rs",
+            Some(Icon::RustFile),
+            12,
+            SystemTime::now(),
+        ),
+    ];
+
+    let rendered =
+        normalized_table(build_long_format_table(&files, &Params::default()));
+    let plain_row = rendered
+        .lines()
+        .find(|line| line.contains("plain.txt"))
+        .unwrap();
+    let icon_row = rendered
+        .lines()
+        .find(|line| line.contains("example.rs"))
+        .unwrap();
+
+    assert_eq!(
+        visible_column_start(plain_row, "plain.txt"),
+        visible_column_start(icon_row, "example.rs")
+    );
+}
+
+#[test]
+fn test_build_long_format_table_with_name_prefixes_uses_same_alignment() {
+    let files = [
+        test_file_info("plain.txt", None, 12, SystemTime::now()),
+        test_file_info(
+            "example.rs",
+            Some(Icon::RustFile),
+            12,
+            SystemTime::now(),
+        ),
+    ];
+    let prefixed = [(&files[0], "|-- "), (&files[1], "`-- ")];
+
+    let rendered =
+        normalized_table(build_long_format_table_with_name_prefixes(
+            prefixed,
+            &Params::default(),
+        ));
+    let plain_row = rendered
+        .lines()
+        .find(|line| line.contains("plain.txt"))
+        .unwrap();
+    let icon_row = rendered
+        .lines()
+        .find(|line| line.contains("example.rs"))
+        .unwrap();
+
+    assert_eq!(
+        visible_column_start(plain_row, "|-- plain.txt"),
+        visible_column_start(icon_row, "`-- example.rs")
+    );
 }
 
 #[test]

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -561,19 +561,29 @@ fn test_size_style_for_color_level_colors_size_boundaries() {
     let color_level = LongFormatColorLevel::Named;
 
     assert_eq!(
-        size_style_for_color_level(1024 * 1024 - 1, &params, color_level, "r"),
+        size_style_for_color_level(
+            1024 * 1024 - 1,
+            &params,
+            color_level,
+            true
+        ),
         SizeCellStyle::PlainRight
     );
     assert_eq!(
-        size_style_for_color_level(1024 * 1024 - 1, &params, color_level, ""),
+        size_style_for_color_level(
+            1024 * 1024 - 1,
+            &params,
+            color_level,
+            false
+        ),
         SizeCellStyle::Plain
     );
     assert_eq!(
-        size_style_for_color_level(1024 * 1024, &params, color_level, "r"),
+        size_style_for_color_level(1024 * 1024, &params, color_level, true),
         SizeCellStyle::LargeRight
     );
     assert_eq!(
-        size_style_for_color_level(1024 * 1024, &params, color_level, ""),
+        size_style_for_color_level(1024 * 1024, &params, color_level, false),
         SizeCellStyle::Large
     );
     assert_eq!(
@@ -581,7 +591,7 @@ fn test_size_style_for_color_level_colors_size_boundaries() {
             1024 * 1024 * 1024,
             &params,
             color_level,
-            "r"
+            true
         ),
         SizeCellStyle::HugeRight
     );
@@ -590,7 +600,7 @@ fn test_size_style_for_color_level_colors_size_boundaries() {
             1024 * 1024 * 1024,
             &params,
             color_level,
-            ""
+            false
         ),
         SizeCellStyle::Huge
     );
@@ -605,11 +615,11 @@ fn test_size_style_for_color_level_omits_size_colors_when_disabled() {
     let color_level = LongFormatColorLevel::Named;
 
     assert_eq!(
-        size_style_for_color_level(1024 * 1024, &params, color_level, "r"),
+        size_style_for_color_level(1024 * 1024, &params, color_level, true),
         SizeCellStyle::PlainRight
     );
     assert_eq!(
-        size_style_for_color_level(1024 * 1024, &params, color_level, ""),
+        size_style_for_color_level(1024 * 1024, &params, color_level, false),
         SizeCellStyle::Plain
     );
 }
@@ -621,11 +631,11 @@ fn test_size_style_for_color_level_omits_size_colors_when_global_color_is_disabl
     let color_level = LongFormatColorLevel::None;
 
     assert_eq!(
-        size_style_for_color_level(1024 * 1024, &params, color_level, "r"),
+        size_style_for_color_level(1024 * 1024, &params, color_level, true),
         SizeCellStyle::PlainRight
     );
     assert_eq!(
-        size_style_for_color_level(1024 * 1024, &params, color_level, ""),
+        size_style_for_color_level(1024 * 1024, &params, color_level, false),
         SizeCellStyle::Plain
     );
 }

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -51,7 +51,9 @@ fn normalized_table(table: impl std::fmt::Display) -> String {
 }
 
 fn visible_column_start(row: &str, needle: &str) -> usize {
-    let byte_start = row.find(needle).unwrap();
+    let byte_start = row.find(needle).unwrap_or_else(|| {
+        panic!("needle {needle:?} not found in row {row:?}")
+    });
     UnicodeWidthStr::width(strip_str(&row[..byte_start]).as_str())
 }
 

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -6,9 +6,10 @@ use crate::utils::color::LongFormatColorLevel;
 use crate::utils::format::mode_to_rwx;
 use crate::utils::icons::Icon;
 use crate::utils::render::{
-    build_long_format_table, build_long_format_table_with_name_prefixes,
-    directory_header_text, render_short_format_lines,
-    size_style_spec_for_color_level, terminal_width_or_default,
+    SizeCellStyle, build_long_format_table,
+    build_long_format_table_with_name_prefixes, directory_header_text,
+    render_short_format_lines, size_style_for_color_level,
+    terminal_width_or_default,
 };
 use crate::{FileInfo, NameStyle, Params, structs::PermissionDisplay};
 use colored_text::{ColorMode, Colorize};
@@ -555,63 +556,48 @@ fn test_build_long_format_table_omits_size_colors_when_disabled() {
 }
 
 #[test]
-fn test_size_style_spec_colors_size_boundaries() {
+fn test_size_style_for_color_level_colors_size_boundaries() {
     let params = Params::default();
     let color_level = LongFormatColorLevel::Named;
 
     assert_eq!(
-        size_style_spec_for_color_level(
-            1024 * 1024 - 1,
-            &params,
-            color_level,
-            "r"
-        ),
-        "r"
+        size_style_for_color_level(1024 * 1024 - 1, &params, color_level, "r"),
+        SizeCellStyle::PlainRight
     );
     assert_eq!(
-        size_style_spec_for_color_level(
-            1024 * 1024 - 1,
-            &params,
-            color_level,
-            ""
-        ),
-        ""
+        size_style_for_color_level(1024 * 1024 - 1, &params, color_level, ""),
+        SizeCellStyle::Plain
     );
     assert_eq!(
-        size_style_spec_for_color_level(
-            1024 * 1024,
-            &params,
-            color_level,
-            "r"
-        ),
-        "rFy"
+        size_style_for_color_level(1024 * 1024, &params, color_level, "r"),
+        SizeCellStyle::LargeRight
     );
     assert_eq!(
-        size_style_spec_for_color_level(1024 * 1024, &params, color_level, ""),
-        "Fy"
+        size_style_for_color_level(1024 * 1024, &params, color_level, ""),
+        SizeCellStyle::Large
     );
     assert_eq!(
-        size_style_spec_for_color_level(
+        size_style_for_color_level(
             1024 * 1024 * 1024,
             &params,
             color_level,
             "r"
         ),
-        "rFrb"
+        SizeCellStyle::HugeRight
     );
     assert_eq!(
-        size_style_spec_for_color_level(
+        size_style_for_color_level(
             1024 * 1024 * 1024,
             &params,
             color_level,
             ""
         ),
-        "Frb"
+        SizeCellStyle::Huge
     );
 }
 
 #[test]
-fn test_size_style_spec_omits_size_colors_when_disabled() {
+fn test_size_style_for_color_level_omits_size_colors_when_disabled() {
     let params = Params {
         size_colors: false,
         ..Params::default()
@@ -619,37 +605,28 @@ fn test_size_style_spec_omits_size_colors_when_disabled() {
     let color_level = LongFormatColorLevel::Named;
 
     assert_eq!(
-        size_style_spec_for_color_level(
-            1024 * 1024,
-            &params,
-            color_level,
-            "r"
-        ),
-        "r"
+        size_style_for_color_level(1024 * 1024, &params, color_level, "r"),
+        SizeCellStyle::PlainRight
     );
     assert_eq!(
-        size_style_spec_for_color_level(1024 * 1024, &params, color_level, ""),
-        ""
+        size_style_for_color_level(1024 * 1024, &params, color_level, ""),
+        SizeCellStyle::Plain
     );
 }
 
 #[test]
-fn test_size_style_spec_omits_size_colors_when_global_color_is_disabled() {
+fn test_size_style_for_color_level_omits_size_colors_when_global_color_is_disabled()
+ {
     let params = Params::default();
     let color_level = LongFormatColorLevel::None;
 
     assert_eq!(
-        size_style_spec_for_color_level(
-            1024 * 1024,
-            &params,
-            color_level,
-            "r"
-        ),
-        "r"
+        size_style_for_color_level(1024 * 1024, &params, color_level, "r"),
+        SizeCellStyle::PlainRight
     );
     assert_eq!(
-        size_style_spec_for_color_level(1024 * 1024, &params, color_level, ""),
-        ""
+        size_style_for_color_level(1024 * 1024, &params, color_level, ""),
+        SizeCellStyle::Plain
     );
 }
 


### PR DESCRIPTION
Replaces the long-format prettytable dependency with a local ANSI-aware borderless table renderer.

The new renderer stores rendered cell text plus visible width, computes column widths across all rows, and pads based on terminal-visible width rather than ANSI escape byte length. This preserves per-character permission coloring while fixing alignment for symbolic permissions, mixed icon rows, and tree-style prefixed names.

This also removes `prettytable` and its unused transitive dependencies from the lockfile, and keeps size styling as a typed local enum instead of carrying prettytable-style string specs forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new in-app table rendering approach for long-format output, with improved handling of coloured text and alignment.
  * Short-format output now calculates column widths more accurately for better spacing.

* **Bug Fixes**
  * Fixed column misalignment when permissions, icons, or blank name fields are present.
  * Improved timestamp and size column alignment for more consistent terminal output.

* **Tests**
  * Expanded rendering tests to cover alignment, visible-width calculations, and colour-level size styling behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->