### PR TITLE
Add long-format header option

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Currently, only a sub-set of the standard `ls` options are supported. These are:
 - `-F` / `--classify` - Append type indicators, including `*` for executables
 - `--no-indicators` - Disable file type indicators
 - `-l` / `--long` - Show long format listing
+- `--header` - Show a title row in long-format output
 - `--permissions <MODE>` - Select long-format permission display:
   `symbolic`, `octal`, `both`, or `none`
 - `-h` / `--human-readable` - Human readable file sizes using powers of 1024

--- a/TODO.md
+++ b/TODO.md
@@ -53,5 +53,9 @@
 - [ ] Review `src/lib.rs` and crate/module visibility. Keep the current
       out-of-source unit test layout, but reduce the accidental public library
       API for this app crate where modules/items do not need to be exported.
+- [ ] Improve rustdoc/docstring coverage in a dedicated docs PR. Start by
+      running `RUSTDOCFLAGS='-D missing-docs' cargo doc --no-deps`; current
+      known gaps include the public `structs` module export and public
+      `Icon` enum variants.
 - [ ] Continue shifting tests toward behavior-focused checks at module seams
       (`app`, `settings`, `render`) instead of broad smoke-style coverage.

--- a/TODO.md
+++ b/TODO.md
@@ -20,8 +20,11 @@
 - [ ] Consider GNU-style `total` lines or another consistent empty-directory
       marker for long and tree output, rather than special-casing single-root
       tree output.
-- [ ] Add inode, allocated block size, and optional column header support for
-      long-format output.
+- [ ] Add inode and allocated block size support for long-format output.
+- [ ] Add explicit long-format header modes, keeping plain `--header` as an
+      alias for per-section headers. Suggested modes: `section` for every
+      recursive section, `once` for the first long-format table only, and
+      `none` to disable config-enabled headers for one invocation.
 - [ ] Evaluate the Rust crate `uutils-term-grid` as a short-format layout
       alternative before expanding the current custom grid code.
 - [ ] Improve listing performance with focused architecture changes, in this

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -87,6 +87,15 @@ equivalent long option is `--group-directories-first` (replacing the original
 This option corresponds to `--long` and displays output in long format when set
 to `true`.
 
+### header
+
+- Permitted values: `true` or `false`
+- Default value: `false`
+
+This option corresponds to `--header` and adds a title row to long-format
+output when set to `true`. It only affects long-format output, so use it with
+`long_format = true` or `tree = true`.
+
 ### human_readable
 
 - Permitted values: `true` or `false`
@@ -247,6 +256,8 @@ This example sets several options. Omitted options use default values:
 show_all = true
 indicator_style = "classify"
 dirs_first = true
+long_format = true
+# header = true
 human_readable = true
 # si = true
 # recursive = true

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -18,6 +18,7 @@ Currently, only a sub-set of the standard `ls` options are supported. These are:
 - `-F` / `--classify` - Append type indicators, including `*` for executables
 - `--no-indicators` - Disable file type indicators
 - `-l` / `--long` - Show long format listing
+- `--header` - Show a title row in long-format output
 - `--permissions <MODE>` - Select long-format permission display:
   `symbolic`, `octal`, `both`, or `none`
 - `-h` / `--human-readable` - Human readable file sizes using powers of 1024
@@ -101,6 +102,10 @@ Long-format output shows symbolic permissions by default. Use
 `--permissions octal` to replace them with octal permission bits,
 `--permissions both` to add octal bits after the symbolic field, or
 `--permissions none` to omit permission fields.
+
+Use `--header` with long-format output to add a title row for the active
+columns. In the config file, set `header = true` alongside
+`long_format = true`.
 
 Long-format output colors permission bits, timestamp freshness, and large file
 sizes by default. You can adjust those accents independently with

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -104,8 +104,8 @@ Long-format output shows symbolic permissions by default. Use
 `--permissions none` to omit permission fields.
 
 Use `--header` with long-format output to add a title row for the active
-columns. In the config file, set `header = true` alongside
-`long_format = true`.
+columns. It has no effect on short output. In the config file, set
+`header = true` alongside `long_format = true` or `tree = true`.
 
 Long-format output colors permission bits, timestamp freshness, and large file
 sizes by default. You can adjust those accents independently with

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,7 @@ use crate::{IndicatorStyle, structs::PermissionDisplay};
 const ARG_SHOW_ALL: &str = "show_all";
 const ARG_ALMOST_ALL: &str = "almost_all";
 const ARG_LONG: &str = "long";
+const ARG_HEADER: &str = "header";
 const ARG_HUMAN_READABLE: &str = "human_readable";
 const ARG_SI: &str = "si";
 const ARG_RECURSIVE: &str = "recursive";
@@ -75,6 +76,8 @@ pub struct Flags {
     pub almost_all: bool,
     /// Render long-format output.
     pub long: bool,
+    /// Show a title row in long-format output.
+    pub header: bool,
     /// Render human-readable file sizes in long format.
     pub human_readable: bool,
     /// Render human-readable file sizes using powers of 1000.
@@ -174,6 +177,7 @@ fn build_command(mode: CompatMode) -> Command {
         .arg(show_all_arg())
         .arg(almost_all_arg())
         .arg(long_arg())
+        .arg(header_arg())
         .arg(human_readable_arg())
         .arg(si_arg())
         .arg(recursive_arg())
@@ -255,6 +259,13 @@ fn long_arg() -> Arg {
         .long("long")
         .action(ArgAction::SetTrue)
         .help("Display detailed information")
+}
+
+fn header_arg() -> Arg {
+    Arg::new(ARG_HEADER)
+        .long("header")
+        .action(ArgAction::SetTrue)
+        .help("Show a title row in long-format output")
 }
 
 fn human_readable_arg() -> Arg {
@@ -487,6 +498,7 @@ fn flags_from_matches(mode: CompatMode, matches: &ArgMatches) -> Flags {
         show_all: matches.get_flag(ARG_SHOW_ALL),
         almost_all: matches.get_flag(ARG_ALMOST_ALL),
         long: matches.get_flag(ARG_LONG),
+        header: matches.get_flag(ARG_HEADER),
         human_readable: matches.get_flag(ARG_HUMAN_READABLE),
         si: matches.get_flag(ARG_SI),
         recursive: matches.get_flag(ARG_RECURSIVE),

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -61,6 +61,8 @@ pub struct Params {
     pub almost_all: bool,
     /// Render long-format output.
     pub long_format: bool,
+    /// Show a title row in long-format output.
+    pub header: bool,
     /// Render human-readable file sizes in long format.
     pub human_readable: bool,
     /// Use decimal powers for human-readable file sizes.
@@ -101,6 +103,7 @@ impl Default for Params {
             dirs_first: false,
             almost_all: false,
             long_format: false,
+            header: false,
             human_readable: false,
             si: false,
             recursive: false,
@@ -128,6 +131,7 @@ pub(crate) struct RawParams {
     dirs_first: bool,
     almost_all: bool,
     long_format: bool,
+    header: bool,
     human_readable: bool,
     si: bool,
     recursive: bool,
@@ -192,6 +196,7 @@ impl From<RawParams> for Params {
             dirs_first: raw.dirs_first,
             almost_all: raw.almost_all,
             long_format: raw.long_format,
+            header: raw.header,
             human_readable: raw.human_readable,
             si: raw.si,
             recursive: raw.recursive,
@@ -233,6 +238,7 @@ impl Params {
                 || flags.tree
                 || config.long_format
                 || config.tree,
+            header: flags.header || config.header,
             human_readable: flags.si
                 || flags.human_readable
                 || config.si

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -23,6 +23,8 @@ use crate::{Params, structs::PermissionDisplay};
 const SHORT_CELL_PADDING: usize = 2;
 const LARGE_SIZE_BYTES: u64 = 1024 * 1024;
 const HUGE_SIZE_BYTES: u64 = 1024 * 1024 * 1024;
+const HEADER_SALMON_TRUECOLOR: (u8, u8, u8) = (250, 128, 114);
+const HEADER_SALMON_ANSI_256: u8 = 209;
 
 /// Render long-format rows to stdout.
 pub fn display_long_format(
@@ -64,8 +66,13 @@ pub(crate) fn build_long_format_table_with_name_prefixes<'a>(
 ) -> Table {
     let mut table = Table::new();
     let color_level = long_format_color_level(params);
+    let entries: Vec<_> = file_info.into_iter().collect();
 
-    for (info, name_prefix) in file_info {
+    if params.header && !entries.is_empty() {
+        table.add_row(long_format_header_row(params, color_level));
+    }
+
+    for (info, name_prefix) in entries {
         let display_time = if params.fuzzy_time {
             utils::fuzzy_time(info.mtime).to_string()
         } else {
@@ -121,6 +128,66 @@ pub(crate) fn build_long_format_table_with_name_prefixes<'a>(
     }
 
     table
+}
+
+fn long_format_header_row(
+    params: &Params,
+    color_level: LongFormatColorLevel,
+) -> Row {
+    let mut cells = Vec::with_capacity(10);
+
+    match params.permissions {
+        PermissionDisplay::Symbolic | PermissionDisplay::Octal => {
+            cells.push(header_cell("Permissions", color_level));
+        }
+        PermissionDisplay::Both => {
+            cells.push(header_cell("Permissions", color_level));
+            cells.push(header_cell("Octal", color_level));
+        }
+        PermissionDisplay::None => {}
+    }
+
+    cells.push(header_cell("Links", color_level));
+    cells.push(header_cell("User", color_level));
+    cells.push(header_cell("Group", color_level));
+    cells.push(header_cell("Size", color_level));
+
+    if params.size_scale().is_some() {
+        cells.push(header_cell("", color_level));
+    }
+
+    cells.push(header_cell("Date Modified", color_level));
+
+    if !params.no_icons {
+        cells.push(header_cell("", color_level));
+    }
+
+    cells.push(header_cell("Name", color_level));
+    Row::new(cells)
+}
+
+fn header_cell(text: &str, color_level: LongFormatColorLevel) -> Cell {
+    Cell::new(header_text(text, color_level))
+}
+
+fn header_text(text: &str, color_level: LongFormatColorLevel) -> String {
+    if text.is_empty() {
+        return String::new();
+    }
+
+    match color_level {
+        LongFormatColorLevel::Truecolor => format!(
+            "\x1b[4;38;2;{};{};{}m{text}\x1b[0m",
+            HEADER_SALMON_TRUECOLOR.0,
+            HEADER_SALMON_TRUECOLOR.1,
+            HEADER_SALMON_TRUECOLOR.2
+        ),
+        LongFormatColorLevel::Ansi256 => {
+            format!("\x1b[4;38;5;{HEADER_SALMON_ANSI_256}m{text}\x1b[0m")
+        }
+        LongFormatColorLevel::Named => text.red().underline().to_string(),
+        LongFormatColorLevel::None => text.to_string(),
+    }
 }
 
 fn append_permission_cells(

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -21,10 +21,49 @@ use crate::utils::time::{DAY, MONTH, WEEK, YEAR};
 use crate::{Params, structs::PermissionDisplay};
 
 const SHORT_CELL_PADDING: usize = 2;
+const LONG_TABLE_DEFAULT_GAP: usize = 2;
+const LONG_TABLE_RELATED_GAP: usize = 1;
 const LARGE_SIZE_BYTES: u64 = 1024 * 1024;
 const HUGE_SIZE_BYTES: u64 = 1024 * 1024 * 1024;
 const HEADER_SALMON_TRUECOLOR: (u8, u8, u8) = (250, 128, 114);
 const HEADER_SALMON_ANSI_256: u8 = 209;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LongColumn {
+    Permissions,
+    Octal,
+    Links,
+    User,
+    Group,
+    Size,
+    Unit,
+    Date,
+    Icon,
+    Name,
+}
+
+impl LongColumn {
+    fn header(self) -> &'static str {
+        match self {
+            LongColumn::Permissions => "Permissions",
+            LongColumn::Octal => "Octal",
+            LongColumn::Links => "Links",
+            LongColumn::User => "User",
+            LongColumn::Group => "Group",
+            LongColumn::Size => "Size",
+            LongColumn::Unit | LongColumn::Icon => "",
+            LongColumn::Date => "Date Modified",
+            LongColumn::Name => "Name",
+        }
+    }
+
+    fn header_aligns_right(self) -> bool {
+        matches!(
+            self,
+            LongColumn::Links | LongColumn::Size | LongColumn::Date
+        )
+    }
+}
 
 /// Render long-format rows to stdout.
 pub fn display_long_format(
@@ -65,109 +104,145 @@ pub(crate) fn build_long_format_table_with_name_prefixes<'a>(
     params: &Params,
 ) -> Table {
     let mut table = Table::new();
+    table.set_default_gap(LONG_TABLE_DEFAULT_GAP);
     let color_level = long_format_color_level(params);
     let entries: Vec<_> = file_info.into_iter().collect();
+    let columns = long_format_columns(params);
+    apply_long_format_gaps(&mut table, &columns);
 
     if params.header && !entries.is_empty() {
-        table.add_row(long_format_header_row(params, color_level));
+        table.set_header(long_format_header_row(&columns, color_level));
     }
 
     for (info, name_prefix) in entries {
-        let display_time = if params.fuzzy_time {
-            utils::fuzzy_time(info.mtime).to_string()
-        } else {
-            let datetime: DateTime<Local> = DateTime::from(info.mtime);
-            datetime.format("%c").to_string()
-        };
-
-        let size_scale = params.size_scale();
-        let (display_size, units) =
-            utils::format::show_size(info.size, size_scale);
-
-        let mut row_cells = Vec::with_capacity(10);
-
-        append_permission_cells(&mut row_cells, info, params, color_level);
-        row_cells.push(Cell::new(info.nlink.to_string()));
-        row_cells.push(Cell::new(format!(" {}", info.user.cyan())));
-        row_cells.push(Cell::new(format!("{} ", info.group.green())));
-        row_cells.push(size_cell(
-            &display_size,
-            info.size,
+        table.add_row(long_format_row(
+            info,
+            name_prefix,
             params,
             color_level,
-            true,
+            &columns,
         ));
-
-        if size_scale.is_some() {
-            row_cells.push(size_cell(
-                units,
-                info.size,
-                params,
-                color_level,
-                false,
-            ));
-        }
-
-        row_cells.push(Cell::right(format!(
-            " {} ",
-            long_time_text(&display_time, info.mtime, params, color_level)
-        )));
-
-        if !params.no_icons {
-            if let Some(icon) = &info.item_icon {
-                row_cells.push(Cell::new(format!("{} ", icon)));
-            } else {
-                row_cells.push(Cell::new(""));
-            }
-        }
-
-        let display_name =
-            format!("{}{}", name_prefix, check_display_name(info));
-        row_cells.push(Cell::new(&display_name));
-        table.add_row(Row::new(row_cells));
     }
 
     table
 }
 
-fn long_format_header_row(
-    params: &Params,
-    color_level: LongFormatColorLevel,
-) -> Row {
-    let mut cells = Vec::with_capacity(10);
+fn long_format_columns(params: &Params) -> Vec<LongColumn> {
+    let mut columns = Vec::with_capacity(10);
 
     match params.permissions {
         PermissionDisplay::Symbolic | PermissionDisplay::Octal => {
-            cells.push(header_cell("Permissions", color_level));
+            columns.push(LongColumn::Permissions);
         }
         PermissionDisplay::Both => {
-            cells.push(header_cell("Permissions", color_level));
-            cells.push(header_cell("Octal", color_level));
+            columns.push(LongColumn::Permissions);
+            columns.push(LongColumn::Octal);
         }
         PermissionDisplay::None => {}
     }
 
-    cells.push(header_cell("Links", color_level));
-    cells.push(header_cell("User", color_level));
-    cells.push(header_cell("Group", color_level));
-    cells.push(header_cell("Size", color_level));
+    columns.push(LongColumn::Links);
+    columns.push(LongColumn::User);
+    columns.push(LongColumn::Group);
+    columns.push(LongColumn::Size);
 
     if params.size_scale().is_some() {
-        cells.push(header_cell("", color_level));
+        columns.push(LongColumn::Unit);
     }
 
-    cells.push(header_cell("Date Modified", color_level));
+    columns.push(LongColumn::Date);
 
     if !params.no_icons {
-        cells.push(header_cell("", color_level));
+        columns.push(LongColumn::Icon);
     }
 
-    cells.push(header_cell("Name", color_level));
+    columns.push(LongColumn::Name);
+    columns
+}
+
+fn apply_long_format_gaps(table: &mut Table, columns: &[LongColumn]) {
+    for (index, pair) in columns.windows(2).enumerate() {
+        if matches!(
+            pair,
+            [LongColumn::Permissions, LongColumn::Octal]
+                | [LongColumn::User, LongColumn::Group]
+                | [LongColumn::Size, LongColumn::Unit]
+                | [LongColumn::Icon, LongColumn::Name]
+        ) {
+            table.set_column_gap(index, LONG_TABLE_RELATED_GAP);
+        }
+    }
+}
+
+fn long_format_row(
+    info: &FileInfo,
+    name_prefix: &str,
+    params: &Params,
+    color_level: LongFormatColorLevel,
+    columns: &[LongColumn],
+) -> Row {
+    let display_time = if params.fuzzy_time {
+        utils::fuzzy_time(info.mtime).to_string()
+    } else {
+        let datetime: DateTime<Local> = DateTime::from(info.mtime);
+        datetime.format("%c").to_string()
+    };
+    let size_scale = params.size_scale();
+    let (display_size, units) =
+        utils::format::show_size(info.size, size_scale);
+    let display_name = format!("{}{}", name_prefix, check_display_name(info));
+    let mut cells = Vec::with_capacity(columns.len());
+
+    for column in columns {
+        cells.push(match column {
+            LongColumn::Permissions => {
+                permission_cell(info, params, color_level)
+            }
+            LongColumn::Octal => {
+                octal_permission_cell(info, params, color_level)
+            }
+            LongColumn::Links => Cell::right(info.nlink.to_string()),
+            LongColumn::User => Cell::new(info.user.cyan().to_string()),
+            LongColumn::Group => Cell::new(info.group.green().to_string()),
+            LongColumn::Size => {
+                size_cell(&display_size, info.size, params, color_level, true)
+            }
+            LongColumn::Unit => {
+                size_cell(units, info.size, params, color_level, false)
+            }
+            LongColumn::Date => Cell::right(long_time_text(
+                &display_time,
+                info.mtime,
+                params,
+                color_level,
+            )),
+            LongColumn::Icon => icon_cell(info),
+            LongColumn::Name => Cell::new(&display_name),
+        });
+    }
+
     Row::new(cells)
 }
 
-fn header_cell(text: &str, color_level: LongFormatColorLevel) -> Cell {
-    Cell::new(header_text(text, color_level))
+fn long_format_header_row(
+    columns: &[LongColumn],
+    color_level: LongFormatColorLevel,
+) -> Row {
+    Row::new(
+        columns
+            .iter()
+            .map(|column| header_cell(*column, color_level))
+            .collect(),
+    )
+}
+
+fn header_cell(column: LongColumn, color_level: LongFormatColorLevel) -> Cell {
+    let text = header_text(column.header(), color_level);
+    if column.header_aligns_right() {
+        Cell::right(text)
+    } else {
+        Cell::new(text)
+    }
 }
 
 fn header_text(text: &str, color_level: LongFormatColorLevel) -> String {
@@ -190,35 +265,36 @@ fn header_text(text: &str, color_level: LongFormatColorLevel) -> String {
     }
 }
 
-fn append_permission_cells(
-    row_cells: &mut Vec<Cell>,
+fn permission_cell(
     info: &FileInfo,
     params: &Params,
     color_level: LongFormatColorLevel,
-) {
+) -> Cell {
     match params.permissions {
-        PermissionDisplay::Symbolic => {
-            row_cells.push(Cell::new(format!(
-                "{} ",
-                long_permission_text(info, params)
-            )));
+        PermissionDisplay::Symbolic | PermissionDisplay::Both => {
+            Cell::new(long_permission_text(info, params))
         }
-        PermissionDisplay::Octal => {
-            row_cells.push(Cell::new(format!(
-                "{} {} ",
-                long_file_type_text(info, params),
-                long_octal_permission_text(info, params, color_level)
-            )));
-        }
-        PermissionDisplay::Both => {
-            row_cells.push(Cell::new(long_permission_text(info, params)));
-            row_cells.push(Cell::new(format!(
-                "{} ",
-                long_octal_permission_text(info, params, color_level)
-            )));
-        }
-        PermissionDisplay::None => {}
+        PermissionDisplay::Octal => Cell::new(format!(
+            "{} {}",
+            long_file_type_text(info, params),
+            long_octal_permission_text(info, params, color_level)
+        )),
+        PermissionDisplay::None => Cell::new(""),
     }
+}
+
+fn octal_permission_cell(
+    info: &FileInfo,
+    params: &Params,
+    color_level: LongFormatColorLevel,
+) -> Cell {
+    Cell::new(long_octal_permission_text(info, params, color_level))
+}
+
+fn icon_cell(info: &FileInfo) -> Cell {
+    info.item_icon
+        .as_ref()
+        .map_or_else(|| Cell::new(""), |icon| Cell::new(icon.to_string()))
 }
 
 fn long_file_type_text(info: &FileInfo, params: &Params) -> String {

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -16,7 +16,9 @@ use crate::structs::{FileInfo, NameStyle};
 use crate::utils;
 use crate::utils::color::{LongFormatColorLevel, long_format_color_level};
 use crate::utils::file::check_display_name;
-use crate::utils::table::{Cell, Row, Table, visible_width};
+use crate::utils::table::{
+    Cell, HeaderCell, HeaderRow, Row, Table, visible_width,
+};
 use crate::utils::time::{DAY, MONTH, WEEK, YEAR};
 use crate::{Params, structs::PermissionDisplay};
 
@@ -227,21 +229,35 @@ fn long_format_row(
 fn long_format_header_row(
     columns: &[LongColumn],
     color_level: LongFormatColorLevel,
-) -> Row {
-    Row::new(
-        columns
-            .iter()
-            .map(|column| header_cell(*column, color_level))
-            .collect(),
-    )
+) -> HeaderRow {
+    let mut cells = Vec::with_capacity(columns.len());
+    let mut index = 0;
+
+    while index < columns.len() {
+        let column = columns[index];
+        if matches!(column, LongColumn::Size)
+            && columns.get(index + 1) == Some(&LongColumn::Unit)
+        {
+            cells.push(header_cell(column, color_level).span(2));
+            index += 2;
+        } else {
+            cells.push(header_cell(column, color_level));
+            index += 1;
+        }
+    }
+
+    HeaderRow::new(cells)
 }
 
-fn header_cell(column: LongColumn, color_level: LongFormatColorLevel) -> Cell {
+fn header_cell(
+    column: LongColumn,
+    color_level: LongFormatColorLevel,
+) -> HeaderCell {
     let text = header_text(column.header(), color_level);
     if column.header_aligns_right() {
-        Cell::right(text)
+        HeaderCell::right(text)
     } else {
-        Cell::new(text)
+        HeaderCell::new(text)
     }
 }
 

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -32,7 +32,7 @@ const HEADER_SALMON_ANSI_256: u8 = 209;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum LongColumn {
-    Permissions,
+    Permissions(PermissionColumn),
     Octal,
     Links,
     User,
@@ -44,10 +44,16 @@ enum LongColumn {
     Name,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PermissionColumn {
+    Symbolic,
+    OctalWithType,
+}
+
 impl LongColumn {
     fn header(self) -> &'static str {
         match self {
-            LongColumn::Permissions => "Permissions",
+            LongColumn::Permissions(_) => "Permissions",
             LongColumn::Octal => "Octal",
             LongColumn::Links => "Links",
             LongColumn::User => "User",
@@ -133,11 +139,16 @@ fn long_format_columns(params: &Params) -> Vec<LongColumn> {
     let mut columns = Vec::with_capacity(10);
 
     match params.permissions {
-        PermissionDisplay::Symbolic | PermissionDisplay::Octal => {
-            columns.push(LongColumn::Permissions);
+        PermissionDisplay::Symbolic => {
+            columns.push(LongColumn::Permissions(PermissionColumn::Symbolic));
+        }
+        PermissionDisplay::Octal => {
+            columns.push(LongColumn::Permissions(
+                PermissionColumn::OctalWithType,
+            ));
         }
         PermissionDisplay::Both => {
-            columns.push(LongColumn::Permissions);
+            columns.push(LongColumn::Permissions(PermissionColumn::Symbolic));
             columns.push(LongColumn::Octal);
         }
         PermissionDisplay::None => {}
@@ -166,7 +177,7 @@ fn apply_long_format_gaps(table: &mut Table, columns: &[LongColumn]) {
     for (index, pair) in columns.windows(2).enumerate() {
         if matches!(
             pair,
-            [LongColumn::Permissions, LongColumn::Octal]
+            [LongColumn::Permissions(_), LongColumn::Octal]
                 | [LongColumn::User, LongColumn::Group]
                 | [LongColumn::Size, LongColumn::Unit]
                 | [LongColumn::Icon, LongColumn::Name]
@@ -197,13 +208,13 @@ fn long_format_row(
 
     for column in columns {
         cells.push(match column {
-            LongColumn::Permissions => {
-                permission_cell(info, params, color_level)
+            LongColumn::Permissions(permission_column) => {
+                permission_cell(info, *permission_column, params, color_level)
             }
             LongColumn::Octal => {
                 octal_permission_cell(info, params, color_level)
             }
-            LongColumn::Links => Cell::right(info.nlink.to_string()),
+            LongColumn::Links => Cell::new(info.nlink.to_string()),
             LongColumn::User => Cell::new(info.user.cyan().to_string()),
             LongColumn::Group => Cell::new(info.group.green().to_string()),
             LongColumn::Size => {
@@ -283,19 +294,19 @@ fn header_text(text: &str, color_level: LongFormatColorLevel) -> String {
 
 fn permission_cell(
     info: &FileInfo,
+    column: PermissionColumn,
     params: &Params,
     color_level: LongFormatColorLevel,
 ) -> Cell {
-    match params.permissions {
-        PermissionDisplay::Symbolic | PermissionDisplay::Both => {
+    match column {
+        PermissionColumn::Symbolic => {
             Cell::new(long_permission_text(info, params))
         }
-        PermissionDisplay::Octal => Cell::new(format!(
+        PermissionColumn::OctalWithType => Cell::new(format!(
             "{} {}",
             long_file_type_text(info, params),
             long_octal_permission_text(info, params, color_level)
         )),
-        PermissionDisplay::None => Cell::new(""),
     }
 }
 

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -66,10 +66,7 @@ impl LongColumn {
     }
 
     fn header_aligns_right(self) -> bool {
-        matches!(
-            self,
-            LongColumn::Links | LongColumn::Size | LongColumn::Date
-        )
+        matches!(self, LongColumn::Size | LongColumn::Date)
     }
 }
 

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -177,7 +177,6 @@ fn apply_long_format_gaps(table: &mut Table, columns: &[LongColumn]) {
             [LongColumn::Permissions(_), LongColumn::Octal]
                 | [LongColumn::User, LongColumn::Group]
                 | [LongColumn::Size, LongColumn::Unit]
-                | [LongColumn::Icon, LongColumn::Name]
         ) {
             table.set_column_gap(index, LONG_TABLE_RELATED_GAP);
         }

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -73,8 +73,44 @@ impl Row {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct HeaderCell {
+    cell: Cell,
+    span: usize,
+}
+
+impl HeaderCell {
+    pub(crate) fn new(text: impl Into<String>) -> Self {
+        Self::from_cell(Cell::new(text))
+    }
+
+    pub(crate) fn right(text: impl Into<String>) -> Self {
+        Self::from_cell(Cell::right(text))
+    }
+
+    pub(crate) fn span(mut self, span: usize) -> Self {
+        self.span = span.max(1);
+        self
+    }
+
+    fn from_cell(cell: Cell) -> Self {
+        Self { cell, span: 1 }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct HeaderRow {
+    cells: Vec<HeaderCell>,
+}
+
+impl HeaderRow {
+    pub(crate) fn new(cells: Vec<HeaderCell>) -> Self {
+        Self { cells }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct Table {
-    header: Option<Row>,
+    header: Option<HeaderRow>,
     rows: Vec<Row>,
     default_gap: usize,
     column_gaps: Vec<usize>,
@@ -90,7 +126,7 @@ impl Table {
         }
     }
 
-    pub(crate) fn set_header(&mut self, header: Row) {
+    pub(crate) fn set_header(&mut self, header: HeaderRow) {
         self.header = Some(header);
     }
 
@@ -112,13 +148,55 @@ impl Table {
     pub(crate) fn write_to(&self, output: &mut impl Write) -> io::Result<()> {
         let widths = self.column_widths();
         if let Some(header) = &self.header {
-            self.write_row(output, header, &widths)?;
+            self.write_header(output, header, &widths)?;
         }
 
         for row in &self.rows {
             self.write_row(output, row, &widths)?;
         }
 
+        Ok(())
+    }
+
+    fn write_header(
+        &self,
+        output: &mut impl Write,
+        header: &HeaderRow,
+        widths: &[usize],
+    ) -> io::Result<()> {
+        write!(output, " ")?;
+
+        let mut column = 0;
+        for header_cell in &header.cells {
+            if column >= widths.len() {
+                break;
+            }
+
+            let span = header_cell.span.min(widths.len() - column);
+            let target_width = self.spanned_width(widths, column, span);
+            let skip_right_fill = column + span >= widths.len();
+            header_cell.cell.write_padded(
+                output,
+                target_width,
+                skip_right_fill,
+            )?;
+
+            column += span;
+            if column < widths.len() {
+                write_spaces(output, self.gap_after(column - 1))?;
+            }
+        }
+
+        while column < widths.len() {
+            let skip_right_fill = column == widths.len() - 1;
+            if !skip_right_fill {
+                write_spaces(output, widths[column])?;
+                write_spaces(output, self.gap_after(column))?;
+            }
+            column += 1;
+        }
+
+        writeln!(output)?;
         Ok(())
     }
 
@@ -152,6 +230,20 @@ impl Table {
             .unwrap_or(self.default_gap)
     }
 
+    fn spanned_width(
+        &self,
+        widths: &[usize],
+        start: usize,
+        span: usize,
+    ) -> usize {
+        let end = start + span;
+        let content_width = widths[start..end].iter().sum::<usize>();
+        let gap_width = (start..end.saturating_sub(1))
+            .map(|column| self.gap_after(column))
+            .sum::<usize>();
+        content_width + gap_width
+    }
+
     fn column_widths(&self) -> Vec<usize> {
         let column_count = self
             .rows_for_widths()
@@ -166,11 +258,26 @@ impl Table {
             }
         }
 
+        if let Some(header) = &self.header {
+            let mut column = 0;
+            for header_cell in &header.cells {
+                if column >= widths.len() {
+                    break;
+                }
+
+                if header_cell.span == 1 {
+                    widths[column] =
+                        widths[column].max(header_cell.cell.width);
+                }
+                column += header_cell.span;
+            }
+        }
+
         widths
     }
 
     fn rows_for_widths(&self) -> impl Iterator<Item = &Row> {
-        self.header.iter().chain(self.rows.iter())
+        self.rows.iter()
     }
 }
 
@@ -206,16 +313,16 @@ fn write_spaces(output: &mut impl Write, count: usize) -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cell, Row, Table};
+    use super::{Cell, HeaderCell, HeaderRow, Row, Table};
 
     #[test]
     fn table_header_contributes_to_widths_and_uses_column_gaps() {
         let mut table = Table::new();
         table.set_default_gap(2);
         table.set_column_gap(0, 1);
-        table.set_header(Row::new(vec![
-            Cell::new("Long Header"),
-            Cell::new("Next"),
+        table.set_header(HeaderRow::new(vec![
+            HeaderCell::new("Long Header"),
+            HeaderCell::new("Next"),
         ]));
         table.add_row(Row::new(vec![Cell::new("x"), Cell::new("y")]));
 
@@ -229,5 +336,23 @@ mod tests {
         table.add_row(Row::new(vec![Cell::new("b"), Cell::new("longer")]));
 
         assert_eq!(table.to_string(), " a short\n b longer\n");
+    }
+
+    #[test]
+    fn table_header_cell_can_span_existing_columns() {
+        let mut table = Table::new();
+        table.set_default_gap(2);
+        table.set_column_gap(0, 1);
+        table.set_header(HeaderRow::new(vec![
+            HeaderCell::right("Size").span(2),
+            HeaderCell::new("Name"),
+        ]));
+        table.add_row(Row::new(vec![
+            Cell::right("4"),
+            Cell::new("K"),
+            Cell::new("file"),
+        ]));
+
+        assert_eq!(table.to_string(), " Size  Name\n 4 K  file\n");
     }
 }

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -120,6 +120,26 @@ pub(crate) struct Table {
     column_gaps: Vec<usize>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ColumnSpan {
+    start: usize,
+    len: usize,
+}
+
+impl ColumnSpan {
+    fn end(self) -> usize {
+        self.start + self.len
+    }
+
+    fn last_column(self) -> usize {
+        self.end() - 1
+    }
+
+    fn contains_final_column(self, widths: &[usize]) -> bool {
+        self.end() >= widths.len()
+    }
+}
+
 impl Table {
     pub(crate) fn new() -> Self {
         Self {
@@ -176,16 +196,17 @@ impl Table {
                 break;
             }
 
-            let span = header_cell.span.min(widths.len() - column);
-            let target_width = self.spanned_width(widths, column, span);
-            let skip_right_fill = span == 1 && column + span >= widths.len();
+            let span = self.column_span(column, header_cell.span, widths);
+            let target_width = self.spanned_width(widths, span);
+            let skip_right_fill =
+                span.len == 1 && span.contains_final_column(widths);
             header_cell.cell.write_padded(
                 output,
                 target_width,
                 skip_right_fill,
             )?;
 
-            column += span;
+            column = span.end();
             if column < widths.len() {
                 write_spaces(output, self.gap_after(column - 1))?;
             }
@@ -234,15 +255,22 @@ impl Table {
             .unwrap_or(self.default_gap)
     }
 
-    fn spanned_width(
+    fn column_span(
         &self,
-        widths: &[usize],
         start: usize,
-        span: usize,
-    ) -> usize {
-        let end = start + span;
-        let content_width = widths[start..end].iter().sum::<usize>();
-        let gap_width = (start..end.saturating_sub(1))
+        requested_len: usize,
+        widths: &[usize],
+    ) -> ColumnSpan {
+        ColumnSpan {
+            start,
+            len: requested_len.min(widths.len() - start),
+        }
+    }
+
+    fn spanned_width(&self, widths: &[usize], span: ColumnSpan) -> usize {
+        let content_width =
+            widths[span.start..span.end()].iter().sum::<usize>();
+        let gap_width = (span.start..span.last_column())
             .map(|column| self.gap_after(column))
             .sum::<usize>();
         content_width + gap_width
@@ -274,14 +302,17 @@ impl Table {
                     break;
                 }
 
-                let span = header_cell.span.min(widths.len() - column);
-                let target_width = self.spanned_width(&widths, column, span);
+                let span = self.column_span(column, header_cell.span, &widths);
+                let target_width = self.spanned_width(&widths, span);
                 if header_cell.cell.width > target_width {
                     let overflow = header_cell.cell.width - target_width;
-                    let last_column = column + span - 1;
-                    widths[last_column] += overflow;
+                    let overflow_column = match header_cell.cell.align {
+                        Alignment::Left => span.start,
+                        Alignment::Right => span.last_column(),
+                    };
+                    widths[overflow_column] += overflow;
                 }
-                column += span;
+                column = span.end();
             }
         }
 
@@ -366,6 +397,22 @@ mod tests {
         ]));
 
         assert_eq!(table.to_string(), " Size  Name\n 4 K   file\n");
+    }
+
+    #[test]
+    fn table_left_aligned_spanned_header_expands_first_column() {
+        let mut table = Table::new();
+        table.set_header(HeaderRow::new(vec![
+            HeaderCell::new("Label").span(2),
+            HeaderCell::new("Name"),
+        ]));
+        table.add_row(Row::new(vec![
+            Cell::new("x"),
+            Cell::new("y"),
+            Cell::new("file"),
+        ]));
+
+        assert_eq!(table.to_string(), " Label Name\n x   y file\n");
     }
 
     #[test]

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -106,6 +106,10 @@ impl HeaderRow {
     pub(crate) fn new(cells: Vec<HeaderCell>) -> Self {
         Self { cells }
     }
+
+    fn column_count(&self) -> usize {
+        self.cells.iter().map(|cell| cell.span).sum()
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -174,7 +178,7 @@ impl Table {
 
             let span = header_cell.span.min(widths.len() - column);
             let target_width = self.spanned_width(widths, column, span);
-            let skip_right_fill = column + span >= widths.len();
+            let skip_right_fill = span == 1 && column + span >= widths.len();
             header_cell.cell.write_padded(
                 output,
                 target_width,
@@ -245,11 +249,16 @@ impl Table {
     }
 
     fn column_widths(&self) -> Vec<usize> {
-        let column_count = self
+        let row_column_count = self
             .rows_for_widths()
             .map(|row| row.cells.len())
             .max()
             .unwrap_or(0);
+        let header_column_count = self
+            .header
+            .as_ref()
+            .map_or(0, |header| header.column_count());
+        let column_count = row_column_count.max(header_column_count);
         let mut widths = vec![0; column_count];
 
         for row in self.rows_for_widths() {
@@ -265,11 +274,14 @@ impl Table {
                     break;
                 }
 
-                if header_cell.span == 1 {
-                    widths[column] =
-                        widths[column].max(header_cell.cell.width);
+                let span = header_cell.span.min(widths.len() - column);
+                let target_width = self.spanned_width(&widths, column, span);
+                if header_cell.cell.width > target_width {
+                    let overflow = header_cell.cell.width - target_width;
+                    let last_column = column + span - 1;
+                    widths[last_column] += overflow;
                 }
-                column += header_cell.span;
+                column += span;
             }
         }
 
@@ -353,6 +365,26 @@ mod tests {
             Cell::new("file"),
         ]));
 
-        assert_eq!(table.to_string(), " Size  Name\n 4 K  file\n");
+        assert_eq!(table.to_string(), " Size  Name\n 4 K   file\n");
+    }
+
+    #[test]
+    fn table_header_cell_spanning_final_columns_keeps_interior_padding() {
+        let mut table = Table::new();
+        table.set_header(HeaderRow::new(vec![HeaderCell::new("Hi").span(2)]));
+        table.add_row(Row::new(vec![Cell::new("x"), Cell::new("y")]));
+
+        assert_eq!(table.to_string(), " Hi \n x y\n");
+    }
+
+    #[test]
+    fn table_header_only_output_keeps_header_content() {
+        let mut table = Table::new();
+        table.set_header(HeaderRow::new(vec![
+            HeaderCell::new("Name"),
+            HeaderCell::right("Size"),
+        ]));
+
+        assert_eq!(table.to_string(), " Name Size\n");
     }
 }

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -72,62 +72,111 @@ impl Row {
     }
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct Table {
+    header: Option<Row>,
     rows: Vec<Row>,
+    default_gap: usize,
+    column_gaps: Vec<usize>,
 }
 
 impl Table {
     pub(crate) fn new() -> Self {
-        Self::default()
+        Self {
+            header: None,
+            rows: Vec::new(),
+            default_gap: 1,
+            column_gaps: Vec::new(),
+        }
+    }
+
+    pub(crate) fn set_header(&mut self, header: Row) {
+        self.header = Some(header);
     }
 
     pub(crate) fn add_row(&mut self, row: Row) {
         self.rows.push(row);
     }
 
+    pub(crate) fn set_default_gap(&mut self, gap: usize) {
+        self.default_gap = gap;
+    }
+
+    pub(crate) fn set_column_gap(&mut self, column: usize, gap: usize) {
+        if self.column_gaps.len() <= column {
+            self.column_gaps.resize(column + 1, self.default_gap);
+        }
+        self.column_gaps[column] = gap;
+    }
+
     pub(crate) fn write_to(&self, output: &mut impl Write) -> io::Result<()> {
         let widths = self.column_widths();
-        for row in &self.rows {
-            write!(output, " ")?;
-            for column in 0..widths.len() {
-                if column > 0 {
-                    write!(output, " ")?;
-                }
+        if let Some(header) = &self.header {
+            self.write_row(output, header, &widths)?;
+        }
 
-                let skip_right_fill = column == widths.len() - 1;
-                if let Some(cell) = row.cells.get(column) {
-                    cell.write_padded(
-                        output,
-                        widths[column],
-                        skip_right_fill,
-                    )?;
-                } else if !skip_right_fill {
-                    write_spaces(output, widths[column])?;
-                }
-            }
-            writeln!(output)?;
+        for row in &self.rows {
+            self.write_row(output, row, &widths)?;
         }
 
         Ok(())
     }
 
+    fn write_row(
+        &self,
+        output: &mut impl Write,
+        row: &Row,
+        widths: &[usize],
+    ) -> io::Result<()> {
+        write!(output, " ")?;
+        for column in 0..widths.len() {
+            let skip_right_fill = column == widths.len() - 1;
+            if let Some(cell) = row.cells.get(column) {
+                cell.write_padded(output, widths[column], skip_right_fill)?;
+            } else if !skip_right_fill {
+                write_spaces(output, widths[column])?;
+            }
+
+            if !skip_right_fill {
+                write_spaces(output, self.gap_after(column))?;
+            }
+        }
+        writeln!(output)?;
+        Ok(())
+    }
+
+    fn gap_after(&self, column: usize) -> usize {
+        self.column_gaps
+            .get(column)
+            .copied()
+            .unwrap_or(self.default_gap)
+    }
+
     fn column_widths(&self) -> Vec<usize> {
         let column_count = self
-            .rows
-            .iter()
+            .rows_for_widths()
             .map(|row| row.cells.len())
             .max()
             .unwrap_or(0);
         let mut widths = vec![0; column_count];
 
-        for row in &self.rows {
+        for row in self.rows_for_widths() {
             for (index, cell) in row.cells.iter().enumerate() {
                 widths[index] = widths[index].max(cell.width);
             }
         }
 
         widths
+    }
+
+    fn rows_for_widths(&self) -> impl Iterator<Item = &Row> {
+        self.header.iter().chain(self.rows.iter())
+    }
+}
+
+impl Default for Table {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -153,4 +202,32 @@ fn write_spaces(output: &mut impl Write, count: usize) -> io::Result<()> {
         remaining -= chunk;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Cell, Row, Table};
+
+    #[test]
+    fn table_header_contributes_to_widths_and_uses_column_gaps() {
+        let mut table = Table::new();
+        table.set_default_gap(2);
+        table.set_column_gap(0, 1);
+        table.set_header(Row::new(vec![
+            Cell::new("Long Header"),
+            Cell::new("Next"),
+        ]));
+        table.add_row(Row::new(vec![Cell::new("x"), Cell::new("y")]));
+
+        assert_eq!(table.to_string(), " Long Header Next\n x           y\n");
+    }
+
+    #[test]
+    fn table_does_not_pad_final_left_aligned_column() {
+        let mut table = Table::new();
+        table.add_row(Row::new(vec![Cell::new("a"), Cell::new("short")]));
+        table.add_row(Row::new(vec![Cell::new("b"), Cell::new("longer")]));
+
+        assert_eq!(table.to_string(), " a short\n b longer\n");
+    }
 }

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -278,7 +278,8 @@ impl Table {
 
     fn column_widths(&self) -> Vec<usize> {
         let row_column_count = self
-            .rows_for_widths()
+            .rows
+            .iter()
             .map(|row| row.cells.len())
             .max()
             .unwrap_or(0);
@@ -289,7 +290,7 @@ impl Table {
         let column_count = row_column_count.max(header_column_count);
         let mut widths = vec![0; column_count];
 
-        for row in self.rows_for_widths() {
+        for row in &self.rows {
             for (index, cell) in row.cells.iter().enumerate() {
                 widths[index] = widths[index].max(cell.width);
             }
@@ -317,10 +318,6 @@ impl Table {
         }
 
         widths
-    }
-
-    fn rows_for_widths(&self) -> impl Iterator<Item = &Row> {
-        self.rows.iter()
     }
 }
 

--- a/tests/crate/app.rs
+++ b/tests/crate/app.rs
@@ -84,6 +84,7 @@ fn test_run_with_flags_lists_matching_entries() {
             show_all: false,
             almost_all: false,
             long: false,
+            header: false,
             human_readable: false,
             si: false,
             recursive: false,

--- a/tests/crate/cli.rs
+++ b/tests/crate/cli.rs
@@ -10,6 +10,7 @@ fn test_default_flags() {
     assert!(!args.show_all);
     assert!(!args.almost_all);
     assert!(!args.long);
+    assert!(!args.header);
     assert!(!args.human_readable);
     assert!(!args.si);
     assert!(!args.recursive);
@@ -47,6 +48,7 @@ fn test_all_flags() {
         "-a",
         "-A",
         "-l",
+        "--header",
         "-h",
         "--si",
         "-R",
@@ -70,6 +72,7 @@ fn test_all_flags() {
     assert!(args.show_all);
     assert!(args.almost_all);
     assert!(args.long);
+    assert!(args.header);
     assert!(args.human_readable);
     assert!(args.si);
     assert!(args.recursive);
@@ -98,6 +101,13 @@ fn test_tree_flags() {
 
     assert!(args.tree);
     assert_eq!(args.tree_level, Some(3));
+}
+
+#[test]
+fn test_header_flag() {
+    let args = Flags::parse_from(["lsplus", "--header"]);
+
+    assert!(args.header);
 }
 
 #[test]
@@ -223,6 +233,15 @@ fn test_parse_from_mode_accepts_recursive_and_tree_options() {
                 .unwrap();
         assert!(tree.tree);
         assert_eq!(tree.tree_level, Some(3));
+    }
+}
+
+#[test]
+fn test_parse_from_mode_accepts_header_option() {
+    for mode in [CompatMode::Native, CompatMode::Gnu] {
+        let args = try_parse_from_mode(mode, ["lsplus", "--header"]).unwrap();
+
+        assert!(args.header);
     }
 }
 

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -572,10 +572,15 @@ fn test_build_long_format_table_aligns_names_with_blank_icon_cells() {
         .lines()
         .find(|line| line.contains("example.rs"))
         .unwrap();
+    let icon = Icon::RustFile.to_string();
 
     assert_eq!(
         visible_column_start(plain_row, "plain.txt"),
         visible_column_start(icon_row, "example.rs")
+    );
+    assert_eq!(
+        visible_column_start(icon_row, "example.rs"),
+        visible_column_end(icon_row, &icon) + 2
     );
 }
 

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -241,6 +241,27 @@ fn test_build_long_format_table_omits_header_by_default() {
 }
 
 #[test]
+fn test_build_long_format_table_preserves_left_aligned_links_without_header() {
+    let mut first = test_file_info("one.txt", None, 12, SystemTime::now());
+    first.nlink = 1;
+    let mut second = test_file_info("many.txt", None, 12, SystemTime::now());
+    second.nlink = 123_456;
+    let params = Params {
+        no_icons: true,
+        ..plain_permission_params()
+    };
+
+    let rendered =
+        normalized_table(build_long_format_table(&[first, second], &params));
+    let rows: Vec<_> = rendered.lines().collect();
+
+    assert_eq!(
+        visible_column_start(rows[0], "1"),
+        visible_column_start(rows[1], "123456")
+    );
+}
+
+#[test]
 fn test_build_long_format_table_adds_header_before_rows() {
     let info = test_file_info("plain.txt", None, 12, SystemTime::now());
     let params = Params {

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -395,6 +395,7 @@ fn test_build_long_format_table_header_uses_column_alignment() {
     let params = Params {
         fuzzy_time: true,
         header: true,
+        human_readable: true,
         no_icons: true,
         ..plain_permission_params()
     };
@@ -413,6 +414,10 @@ fn test_build_long_format_table_header_uses_column_alignment() {
     assert_eq!(
         visible_column_start(rows[0], "Name"),
         visible_column_start(rows[1], "plain.txt")
+    );
+    assert_eq!(
+        visible_column_end(rows[0], "Size"),
+        visible_column_end(rows[1], "12 B")
     );
     assert_eq!(
         visible_column_end(rows[0], "Date Modified"),

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -225,6 +225,221 @@ fn test_build_long_format_table_omits_optional_units_and_icons() {
 }
 
 #[test]
+fn test_build_long_format_table_omits_header_by_default() {
+    let info = test_file_info("plain.txt", None, 12, SystemTime::now());
+
+    let rendered =
+        normalized_table(build_long_format_table(&[info], &Params::default()));
+
+    assert!(!rendered.contains("Permissions"));
+    assert!(!rendered.contains("Date Modified"));
+}
+
+#[test]
+fn test_build_long_format_table_adds_header_before_rows() {
+    let info = test_file_info("plain.txt", None, 12, SystemTime::now());
+    let params = Params {
+        header: true,
+        no_icons: true,
+        ..Params::default()
+    };
+
+    let rendered = normalized_table(build_long_format_table(&[info], &params));
+    let stripped = strip_str(&rendered);
+    let rows: Vec<_> = stripped.lines().collect();
+
+    assert!(rows[0].contains("Permissions"));
+    assert!(rows[0].contains("Links"));
+    assert!(rows[0].contains("Date Modified"));
+    assert!(rows[0].contains("Name"));
+    assert!(rows[1].contains("plain.txt"));
+}
+
+#[test]
+fn test_build_long_format_table_header_matches_optional_columns() {
+    let info = test_file_info(
+        "example.rs",
+        Some(Icon::RustFile),
+        2 * 1024,
+        SystemTime::now(),
+    );
+    let params = Params {
+        header: true,
+        human_readable: true,
+        permissions: PermissionDisplay::Both,
+        ..Params::default()
+    };
+
+    let rendered = normalized_table(build_long_format_table(&[info], &params));
+    let header = strip_str(&rendered).lines().next().unwrap().to_string();
+
+    assert!(header.contains("Permissions"));
+    assert!(header.contains("Octal"));
+    assert!(header.contains("Links"));
+    assert!(header.contains("User"));
+    assert!(header.contains("Group"));
+    assert!(header.contains("Size"));
+    assert!(header.contains("Date Modified"));
+    assert!(header.contains("Name"));
+    assert!(!header.contains("Unit"));
+}
+
+#[test]
+fn test_build_long_format_table_header_omits_disabled_columns() {
+    let info = test_file_info("plain.txt", None, 12, SystemTime::now());
+    let params = Params {
+        header: true,
+        no_icons: true,
+        permissions: PermissionDisplay::None,
+        ..Params::default()
+    };
+
+    let rendered = normalized_table(build_long_format_table(&[info], &params));
+    let header = strip_str(&rendered).lines().next().unwrap().to_string();
+
+    assert!(!header.contains("Permissions"));
+    assert!(!header.contains("Octal"));
+    assert!(!header.contains("Unit"));
+    assert!(header.contains("Links"));
+    assert!(header.contains("Name"));
+}
+
+#[test]
+fn test_build_long_format_table_omits_header_for_empty_rows() {
+    let params = Params {
+        header: true,
+        ..Params::default()
+    };
+
+    let rendered = normalized_table(build_long_format_table(&[], &params));
+
+    assert!(!rendered.contains("Permissions"));
+    assert!(!rendered.contains("Name"));
+}
+
+#[test]
+fn test_build_long_format_table_header_aligns_with_colored_rows() {
+    temp_env::with_vars(
+        [("COLORTERM", Some("truecolor")), ("TERM", None::<&str>)],
+        || {
+            with_color_output_enabled(|| {
+                let mut first =
+                    test_file_info("first.txt", None, 12, SystemTime::now());
+                first.file_type = String::from("d");
+                first.mode = String::from("rwsr-tS-T");
+                first.nlink = 1;
+
+                let mut second = test_file_info(
+                    "second.txt",
+                    Some(Icon::RustFile),
+                    12,
+                    SystemTime::now(),
+                );
+                second.file_type = String::from("-");
+                second.mode = String::from("rwxrwxrwx");
+                second.nlink = 123_456;
+
+                let params = Params {
+                    header: true,
+                    human_readable: true,
+                    ..fixed_time_params()
+                };
+                let rendered = normalized_table(build_long_format_table(
+                    &[first, second],
+                    &params,
+                ));
+                let rows: Vec<_> = rendered.lines().collect();
+
+                assert!(rows[0].contains("Permissions"));
+                assert!(rows[1].contains("\u{1b}["));
+                assert!(
+                    visible_column_start(rows[0], "User")
+                        < visible_column_start(rows[0], "Group")
+                );
+                assert!(
+                    visible_column_start(rows[0], "Group")
+                        < visible_column_start(rows[0], "Name")
+                );
+                assert_eq!(
+                    visible_column_start(rows[1], "user"),
+                    visible_column_start(rows[2], "user")
+                );
+                assert_eq!(
+                    visible_column_start(rows[1], "group"),
+                    visible_column_start(rows[2], "group")
+                );
+                assert_eq!(
+                    visible_column_start(rows[1], "first.txt"),
+                    visible_column_start(rows[2], "second.txt")
+                );
+            });
+        },
+    );
+}
+
+#[test]
+fn test_build_long_format_table_colors_header_when_enabled() {
+    for (env, expected) in [
+        (
+            [("COLORTERM", Some("truecolor")), ("TERM", None::<&str>)],
+            "\u{1b}[4;38;2;250;128;114mPermissions\u{1b}[0m",
+        ),
+        (
+            [
+                ("COLORTERM", None::<&str>),
+                ("TERM", Some("xterm-256color")),
+            ],
+            "\u{1b}[4;38;5;209mPermissions\u{1b}[0m",
+        ),
+        (
+            [("COLORTERM", None::<&str>), ("TERM", Some("xterm"))],
+            "\u{1b}[4;31mPermissions\u{1b}[0m",
+        ),
+    ] {
+        temp_env::with_vars(env, || {
+            with_color_output_enabled(|| {
+                let info =
+                    test_file_info("plain.txt", None, 12, SystemTime::now());
+                let params = Params {
+                    header: true,
+                    no_icons: true,
+                    ..fixed_time_params()
+                };
+
+                let rendered = normalized_table(build_long_format_table(
+                    &[info],
+                    &params,
+                ));
+
+                assert!(rendered.contains(expected));
+            });
+        });
+    }
+}
+
+#[test]
+fn test_build_long_format_table_keeps_header_plain_when_color_disabled() {
+    with_color_output_enabled(|| {
+        let info = test_file_info("plain.txt", None, 12, SystemTime::now());
+        let params = Params {
+            header: true,
+            no_color: true,
+            no_icons: true,
+            ..Params::default()
+        };
+
+        let rendered =
+            normalized_table(build_long_format_table(&[info], &params));
+        let header = rendered
+            .lines()
+            .find(|line| line.contains("Permissions"))
+            .unwrap();
+
+        assert_eq!(strip_str(header), header);
+    });
+}
+
+#[test]
 fn test_build_long_format_table_aligns_after_colored_symbolic_permissions() {
     with_color_output_enabled(|| {
         let mut first =

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -58,6 +58,11 @@ fn visible_column_start(row: &str, needle: &str) -> usize {
     UnicodeWidthStr::width(strip_str(&row[..byte_start]).as_str())
 }
 
+fn visible_column_end(row: &str, needle: &str) -> usize {
+    visible_column_start(row, needle)
+        + UnicodeWidthStr::width(strip_str(needle).as_str())
+}
+
 #[test]
 fn test_build_long_format_table_shows_symbolic_permissions_by_default() {
     let mut info = test_file_info("plain.txt", None, 12, SystemTime::now());
@@ -374,6 +379,44 @@ fn test_build_long_format_table_header_aligns_with_colored_rows() {
                 );
             });
         },
+    );
+}
+
+#[test]
+fn test_build_long_format_table_header_uses_column_alignment() {
+    let info = test_file_info(
+        "plain.txt",
+        None,
+        12,
+        SystemTime::now()
+            .checked_sub(Duration::from_secs(2 * 60 * 60))
+            .unwrap(),
+    );
+    let params = Params {
+        fuzzy_time: true,
+        header: true,
+        no_icons: true,
+        ..plain_permission_params()
+    };
+
+    let rendered = normalized_table(build_long_format_table(&[info], &params));
+    let rows: Vec<_> = rendered.lines().collect();
+
+    assert_eq!(
+        visible_column_start(rows[0], "User"),
+        visible_column_start(rows[1], "user")
+    );
+    assert_eq!(
+        visible_column_start(rows[0], "Group"),
+        visible_column_start(rows[1], "group")
+    );
+    assert_eq!(
+        visible_column_start(rows[0], "Name"),
+        visible_column_start(rows[1], "plain.txt")
+    );
+    assert_eq!(
+        visible_column_end(rows[0], "Date Modified"),
+        visible_column_end(rows[1], "2 hours ago")
     );
 }
 

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -405,7 +405,7 @@ fn test_build_long_format_table_header_aligns_with_colored_rows() {
 
 #[test]
 fn test_build_long_format_table_header_uses_column_alignment() {
-    let info = test_file_info(
+    let mut info = test_file_info(
         "plain.txt",
         None,
         12,
@@ -413,6 +413,7 @@ fn test_build_long_format_table_header_uses_column_alignment() {
             .checked_sub(Duration::from_secs(2 * 60 * 60))
             .unwrap(),
     );
+    info.nlink = 123_456;
     let params = Params {
         fuzzy_time: true,
         header: true,
@@ -424,6 +425,10 @@ fn test_build_long_format_table_header_uses_column_alignment() {
     let rendered = normalized_table(build_long_format_table(&[info], &params));
     let rows: Vec<_> = rendered.lines().collect();
 
+    assert_eq!(
+        visible_column_start(rows[0], "Links"),
+        visible_column_start(rows[1], "123456")
+    );
     assert_eq!(
         visible_column_start(rows[0], "User"),
         visible_column_start(rows[1], "user")

--- a/tests/crate/settings.rs
+++ b/tests/crate/settings.rs
@@ -57,6 +57,7 @@ fn test_load_config_reads_boolean_settings_from_home_config() {
             dirs_first = true
             almost_all = true
             long_format = true
+            header = true
             human_readable = true
             no_icons = true
             no_color = true
@@ -80,6 +81,7 @@ fn test_load_config_reads_boolean_settings_from_home_config() {
                 dirs_first: true,
                 almost_all: true,
                 long_format: true,
+                header: true,
                 human_readable: true,
                 si: false,
                 recursive: false,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -181,6 +181,52 @@ fn test_long_format() {
 }
 
 #[test]
+fn test_long_format_header_flag() {
+    let temp_dir = tempdir().unwrap();
+    let file_path = temp_dir.path().join("header.txt");
+    fs::write(&file_path, "header").unwrap();
+
+    let mut cmd = command_with_home(temp_dir.path());
+    cmd.arg("-l")
+        .arg("--header")
+        .arg("--no-icons")
+        .arg(&file_path);
+    let (stdout, _stderr) = run_and_capture(&mut cmd);
+    let rows: Vec<_> = stdout.lines().collect();
+
+    assert!(rows[0].contains("Permissions"));
+    assert!(rows[0].contains("Links"));
+    assert!(rows[0].contains("Date Modified"));
+    assert!(rows[0].contains("Name"));
+    assert!(!rows[0].contains("Unit"));
+    assert!(rows[1].contains("header.txt"));
+}
+
+#[test]
+fn test_long_format_header_from_config() {
+    let temp_dir = tempdir().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("lsplus");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(
+        config_dir.join("config.toml"),
+        "long_format = true\nheader = true\nno_icons = true\n",
+    )
+    .unwrap();
+    let file_path = temp_dir.path().join("configured.txt");
+    fs::write(&file_path, "configured").unwrap();
+
+    let mut cmd = command_with_home(temp_dir.path());
+    cmd.arg(&file_path);
+    let (stdout, _stderr) = run_and_capture(&mut cmd);
+    let rows: Vec<_> = stdout.lines().collect();
+
+    assert!(rows[0].contains("Permissions"));
+    assert!(rows[0].contains("Date Modified"));
+    assert!(rows[0].contains("Name"));
+    assert!(rows[1].contains("configured.txt"));
+}
+
+#[test]
 fn test_long_format_si_sizes() {
     let temp_dir = tempdir().unwrap();
     let file_path = temp_dir.path().join("size.txt");

--- a/tests/seams.rs
+++ b/tests/seams.rs
@@ -37,6 +37,7 @@ fn test_public_run_with_flags_accepts_missing_patterns() {
         show_all: false,
         almost_all: false,
         long: false,
+        header: false,
         human_readable: false,
         si: false,
         recursive: false,

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -294,6 +294,48 @@ fn test_params_merge_keeps_false_when_both_sources_are_false() {
 }
 
 #[test]
+fn test_params_merge_header_prefers_true_from_either_source() {
+    let flags = Flags {
+        version: false,
+        paths: vec![],
+        show_all: false,
+        almost_all: false,
+        indicator_style: None,
+        dirs_first: false,
+        long: false,
+        header: false,
+        human_readable: false,
+        si: false,
+        recursive: false,
+        tree: false,
+        tree_level: None,
+        prune_noisy_dirs: false,
+        prune_dirs: Vec::new(),
+        no_icons: false,
+        no_color: false,
+        no_permission_colors: false,
+        permissions: None,
+        no_time_gradient: false,
+        no_size_colors: false,
+        gitignore: false,
+        fuzzy_time: false,
+    };
+    let config = Params {
+        header: true,
+        ..Params::default()
+    };
+
+    assert!(Params::merge(&flags, &config).header);
+
+    let flags = Flags {
+        header: true,
+        ..flags
+    };
+
+    assert!(Params::merge(&flags, &Params::default()).header);
+}
+
+#[test]
 fn test_params_merge_uses_config_permissions_until_cli_overrides() {
     let config = Params {
         permissions: PermissionDisplay::Octal,

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -21,6 +21,7 @@ fn test_default_params() {
     assert_eq!(params.recursive_level, None);
     assert!(params.prune_dirs.is_empty());
     assert_eq!(params.size_scale(), None);
+    assert!(!params.header);
     assert!(!params.no_icons);
     assert!(!params.no_color);
     assert!(params.permission_colors);
@@ -44,6 +45,7 @@ fn test_config_conversion() {
             dirs_first = true
             almost_all = true
             long_format = true
+            header = true
             human_readable = true
             si = true
             recursive = true
@@ -78,6 +80,7 @@ fn test_config_conversion() {
             dirs_first: true,
             almost_all: true,
             long_format: true,
+            header: true,
             human_readable: true,
             si: true,
             recursive: true,
@@ -169,6 +172,7 @@ fn test_params_merge_prefers_true_from_either_source() {
         dirs_first: false,
         almost_all: false,
         long_format: true,
+        header: true,
         human_readable: true,
         si: false,
         recursive: true,
@@ -201,6 +205,7 @@ fn test_params_merge_prefers_true_from_either_source() {
         indicator_style: Some(IndicatorStyle::Classify),
         dirs_first: true,
         long: false,
+        header: true,
         human_readable: false,
         si: false,
         recursive: false,
@@ -225,6 +230,7 @@ fn test_params_merge_prefers_true_from_either_source() {
     assert!(params.dirs_first);
     assert!(params.almost_all);
     assert!(params.long_format);
+    assert!(params.header);
     assert!(params.human_readable);
     assert!(!params.si);
     assert!(params.recursive);
@@ -264,6 +270,7 @@ fn test_params_merge_keeps_false_when_both_sources_are_false() {
         indicator_style: None,
         dirs_first: false,
         long: false,
+        header: false,
         human_readable: false,
         si: false,
         recursive: false,
@@ -300,6 +307,7 @@ fn test_params_merge_uses_config_permissions_until_cli_overrides() {
         indicator_style: None,
         dirs_first: false,
         long: false,
+        header: false,
         human_readable: false,
         si: false,
         recursive: false,
@@ -340,6 +348,7 @@ fn test_params_merge_si_enables_decimal_human_readable_output() {
         indicator_style: None,
         dirs_first: false,
         long: false,
+        header: false,
         human_readable: false,
         si: true,
         recursive: false,
@@ -379,6 +388,7 @@ fn test_params_merge_config_si_overrides_config_human_readable() {
         indicator_style: None,
         dirs_first: false,
         long: false,
+        header: false,
         human_readable: false,
         si: false,
         recursive: false,
@@ -417,6 +427,7 @@ fn test_params_merge_cli_prune_dirs_append_config_prune_dirs() {
         indicator_style: None,
         dirs_first: false,
         long: false,
+        header: false,
         human_readable: false,
         si: false,
         recursive: false,
@@ -462,6 +473,7 @@ fn test_params_merge_deduplicates_prune_preset() {
         indicator_style: None,
         dirs_first: false,
         long: false,
+        header: false,
         human_readable: false,
         si: false,
         recursive: false,


### PR DESCRIPTION
## Summary

Adds an opt-in `--header` / `header = true` option for long-format output. The title row follows the active long-format columns, including permission display mode, human-readable size units, icon visibility, and tree output through the shared long-table builder.

The table renderer now owns header rows and column spacing, so long-format cell values no longer carry layout padding in their text. Related columns use tighter gaps while the table keeps ANSI-aware width calculations across both header and body rows.

Local checks completed: `rtk cargo fmt --check`, `rtk cargo clippy --all-targets --all-features -- -D warnings`, `rtk cargo make test`, and `rtk mdbook build docs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `--header` option for long-format output to display a title row.
  * Added configuration support via `header = true` (works when long-format output is enabled).
  * Long-format headers are now rendered more consistently, with improved column alignment/spacing and correct styling for both colored and non-colored output.
* **Documentation**
  * Updated the README and usage/config docs to describe the new `--header` option and `header` configuration.
* **Tests**
  * Expanded CLI, rendering, and integration coverage for long-format header behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->