### PR TITLE
fix: support recursive pattern operands

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Currently, only a sub-set of the standard `ls` options are supported. These are:
   `symbolic`, `octal`, `both`, or `none`
 - `-h` / `--human-readable` - Human readable file sizes using powers of 1024
 - `--si` - Human readable file sizes using powers of 1000
+- `-R` / `--recursive` - List subdirectories recursively
 - `-D` / `--sort-dirs` - Sort directories first
 - `-I` / `--gitignore` - Dim entries matched by Git ignore rules
 - `-N` / `--no-color` - Disable colored and styled output
@@ -135,6 +136,19 @@ listing with hidden files, append a '/' to directories, and show human-readable
 file sizes.
 
 Use the `--help` option to see the full list of options.
+
+Use `-R` or `--recursive` to print GNU-style recursive directory sections.
+Quoted wildcard or filename operands filter matching entries while still
+walking subdirectories:
+
+```sh
+lsp -R '*.rs'
+lsp -R 'src/*.rs'
+```
+
+Quote or escape wildcard patterns in shells such as zsh. Otherwise the shell
+may expand or reject the pattern before `lsp` starts, which is the same
+limitation GNU `ls` has for unquoted wildcards.
 
 The indicator characters are:
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ lsp -R '*.rs'
 lsp -R 'src/*.rs'
 ```
 
+Bare filename operands such as `main.rs` search for that basename below the
+current directory. Prefixed literal paths such as `src/main.rs` remain exact
+path operands. When `--level` is used with a recursive filter, no-match
+diagnostics apply to matches visible within that depth limit.
+
 Quote or escape wildcard patterns in shells such as zsh. Otherwise the shell
 may expand or reject the pattern before `lsp` starts, which is the same
 limitation GNU `ls` has for unquoted wildcards.

--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,10 @@
 - [ ] Unify recursive and tree traversal policy behind a shared walker so
       depth limits, symlink handling, pruning, and error handling cannot drift
       between output modes.
+- [ ] Revisit recursive operand error semantics so explicit file-operand stat
+      errors can be reported without aborting later directory walks.
+- [ ] Avoid duplicate stderr for already-reported recursive traversal errors
+      while still returning a non-zero exit status.
 - [ ] Add configurable tree rendering styles, including the current compact
       root display, classic root branch graphics, and an ASCII fallback.
 - [ ] Consider GNU-style `total` lines or another consistent empty-directory

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -64,6 +64,11 @@ lsp -R '*.rs'
 lsp -R 'src/*.rs'
 ```
 
+Bare filename operands such as `main.rs` search for that basename below the
+current directory. Prefixed literal paths such as `src/main.rs` remain exact
+path operands. When `--level` is used with a recursive filter, no-match
+diagnostics apply to matches visible within that depth limit.
+
 Quote or escape wildcard patterns in shells such as zsh. Otherwise the shell
 may expand or reject the pattern before `lsp` starts, which is the same
 limitation GNU `ls` has for unquoted wildcards.

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -56,6 +56,18 @@ long-format tree output. Tree output implies `--long`, uses a default depth of
 `2`, and can be limited with `--level <N>`. `--tree` and `--recursive` are
 mutually exclusive.
 
+Quoted wildcard or filename operands filter matching entries while still
+walking subdirectories:
+
+```sh
+lsp -R '*.rs'
+lsp -R 'src/*.rs'
+```
+
+Quote or escape wildcard patterns in shells such as zsh. Otherwise the shell
+may expand or reject the pattern before `lsp` starts, which is the same
+limitation GNU `ls` has for unquoted wildcards.
+
 In both recursive and tree output, `--level <N>` counts visible entry levels
 below each operand. For example, `--level 1` shows only entries directly under
 the requested directory, while `--level 2` also shows grandchildren.

--- a/src/app.rs
+++ b/src/app.rs
@@ -468,7 +468,7 @@ fn recursive_filter_from_pattern(
         }));
     }
 
-    if path.exists() {
+    if is_display_directory(path) {
         return None;
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -44,9 +44,16 @@ struct RecursiveDirectory {
     children: Vec<PathBuf>,
 }
 
+#[derive(Clone, Copy)]
+enum RecursiveMode<'a> {
+    Normal,
+    Filter(&'a Pattern),
+}
+
 struct RecursiveFilter {
     root: PathBuf,
     pattern: Pattern,
+    operand: String,
 }
 
 enum RecursiveTarget {
@@ -173,38 +180,10 @@ fn render_recursive_listing(
     patterns: &[String],
     params: &Params,
 ) -> io::Result<()> {
-    let listing = prepare_recursive_listing(patterns, params)?;
     let mut rendered_section = false;
-
-    if !listing.file_entries.is_empty() {
-        render_listing_section(
-            &mut rendered_section,
-            &ListingSection {
-                header: None,
-                entries: listing.file_entries,
-            },
-            params,
-        )?;
-    }
-
-    let mut first_error = None;
-    for target in listing.recursive_targets {
-        let result = walk_recursive_target(target, params, &mut |section| {
-            render_listing_section(&mut rendered_section, &section, params)
-        });
-
-        if let Err(err) = result
-            && first_error.is_none()
-        {
-            first_error = Some(err);
-        }
-    }
-
-    if let Some(err) = first_error {
-        return Err(err);
-    }
-
-    Ok(())
+    for_each_recursive_listing_section(patterns, params, &mut |section| {
+        render_listing_section(&mut rendered_section, &section, params)
+    })
 }
 
 fn walk_recursive_directory(
@@ -212,27 +191,27 @@ fn walk_recursive_directory(
     params: &Params,
     fail_on_error: bool,
     visible_entry_depth: usize,
-    name_filter: Option<&Pattern>,
-    emit_empty_sections: bool,
+    mode: RecursiveMode<'_>,
     sink: &mut impl FnMut(ListingSection) -> io::Result<()>,
-) -> io::Result<()> {
+) -> io::Result<bool> {
     let mut directory = match collect_recursive_directory(
         path,
         params,
         visible_entry_depth > 1,
-        name_filter,
+        mode.name_filter(),
     ) {
         Ok(directory) => directory,
         Err(err) if fail_on_error => return Err(err),
         Err(err) => {
             report_path_error(path, &err);
-            return Ok(());
+            return Ok(false);
         }
     };
 
     directory.section.header =
         recursive_section_header(path, visible_entry_depth);
-    if emit_empty_sections || !directory.section.entries.is_empty() {
+    let mut found_match = !directory.section.entries.is_empty();
+    if mode.emit_empty_sections() || found_match {
         sink(directory.section)?;
     }
 
@@ -240,22 +219,23 @@ fn walk_recursive_directory(
         .recursive_level
         .is_some_and(|limit| visible_entry_depth >= limit)
     {
-        return Ok(());
+        return Ok(found_match);
     }
 
     for child in directory.children {
-        walk_recursive_directory(
+        if walk_recursive_directory(
             &child,
             params,
             false,
             visible_entry_depth + 1,
-            name_filter,
-            emit_empty_sections,
+            mode,
             sink,
-        )?;
+        )? {
+            found_match = true;
+        }
     }
 
-    Ok(())
+    Ok(found_match)
 }
 
 fn render_listing_section(
@@ -327,21 +307,31 @@ fn collect_recursive_listing_sections(
     patterns: &[String],
     params: &Params,
 ) -> io::Result<Vec<ListingSection>> {
-    let listing = prepare_recursive_listing(patterns, params)?;
     let mut sections = Vec::new();
+    for_each_recursive_listing_section(patterns, params, &mut |section| {
+        sections.push(section);
+        Ok(())
+    })?;
+
+    Ok(sections)
+}
+
+fn for_each_recursive_listing_section(
+    patterns: &[String],
+    params: &Params,
+    sink: &mut impl FnMut(ListingSection) -> io::Result<()>,
+) -> io::Result<()> {
+    let listing = prepare_recursive_listing(patterns, params)?;
     if !listing.file_entries.is_empty() {
-        sections.push(ListingSection {
+        sink(ListingSection {
             header: None,
             entries: listing.file_entries,
-        });
+        })?;
     }
 
     let mut first_error = None;
     for target in listing.recursive_targets {
-        let result = walk_recursive_target(target, params, &mut |section| {
-            sections.push(section);
-            Ok(())
-        });
+        let result = walk_recursive_target(target, params, sink);
 
         if let Err(err) = result
             && first_error.is_none()
@@ -354,14 +344,14 @@ fn collect_recursive_listing_sections(
         return Err(err);
     }
 
-    Ok(sections)
+    Ok(())
 }
 
 fn prepare_recursive_listing(
     patterns: &[String],
     params: &Params,
 ) -> io::Result<RecursiveListing> {
-    let targets = collect_recursive_targets(patterns)?;
+    let targets = collect_recursive_targets(patterns, params)?;
     let mut file_entries = Vec::new();
     let mut recursive_targets = Vec::new();
 
@@ -391,10 +381,16 @@ fn walk_recursive_target(
     sink: &mut impl FnMut(ListingSection) -> io::Result<()>,
 ) -> io::Result<()> {
     match target {
-        RecursiveTarget::Path(path) => {
-            walk_recursive_directory(&path, params, true, 1, None, true, sink)
-                .inspect_err(|err| report_path_error(&path, err))
-        }
+        RecursiveTarget::Path(path) => walk_recursive_directory(
+            &path,
+            params,
+            true,
+            1,
+            RecursiveMode::Normal,
+            sink,
+        )
+        .map(|_| ())
+        .inspect_err(|err| report_path_error(&path, err)),
         RecursiveTarget::Filter(filter) => {
             if !is_display_directory(&filter.root) {
                 eprintln!(
@@ -409,10 +405,17 @@ fn walk_recursive_target(
                 params,
                 true,
                 1,
-                Some(&filter.pattern),
-                false,
+                RecursiveMode::Filter(&filter.pattern),
                 sink,
             )
+            .map(|found_match| {
+                if !found_match {
+                    eprintln!(
+                        "lsplus: {}: No such file or directory",
+                        sanitize_for_terminal(&filter.operand)
+                    );
+                }
+            })
             .inspect_err(|err| report_path_error(&filter.root, err))
         }
     }
@@ -420,6 +423,7 @@ fn walk_recursive_target(
 
 fn collect_recursive_targets(
     patterns: &[String],
+    params: &Params,
 ) -> io::Result<Vec<RecursiveTarget>> {
     let mut targets = Vec::new();
 
@@ -435,7 +439,7 @@ fn collect_recursive_targets(
         }
 
         let mut operands = Vec::new();
-        append_pattern_operands(&mut operands, pattern, &Params::default())?;
+        append_pattern_operands(&mut operands, pattern, params)?;
         targets.extend(operands.into_iter().map(RecursiveTarget::Path));
     }
 
@@ -454,10 +458,12 @@ fn recursive_filter_from_pattern(
         }
 
         let file_name = path.file_name()?.to_string_lossy();
-        return Some(Pattern::new(&file_name).map(|pattern| {
+        let operand = pattern.to_owned();
+        return Some(Pattern::new(&file_name).map(|compiled_pattern| {
             RecursiveFilter {
                 root: filter_root(parent),
-                pattern,
+                pattern: compiled_pattern,
+                operand,
             }
         }));
     }
@@ -472,10 +478,27 @@ fn recursive_filter_from_pattern(
     }
 
     let file_name = path.file_name()?.to_string_lossy();
-    Some(Pattern::new(&file_name).map(|pattern| RecursiveFilter {
-        root: PathBuf::from("."),
-        pattern,
-    }))
+    let operand = pattern.to_owned();
+    Some(
+        Pattern::new(&file_name).map(|compiled_pattern| RecursiveFilter {
+            root: filter_root(parent),
+            pattern: compiled_pattern,
+            operand,
+        }),
+    )
+}
+
+impl<'a> RecursiveMode<'a> {
+    fn name_filter(self) -> Option<&'a Pattern> {
+        match self {
+            Self::Normal => None,
+            Self::Filter(pattern) => Some(pattern),
+        }
+    }
+
+    fn emit_empty_sections(self) -> bool {
+        matches!(self, Self::Normal)
+    }
 }
 
 fn filter_root(parent: &Path) -> PathBuf {

--- a/src/app.rs
+++ b/src/app.rs
@@ -413,6 +413,7 @@ fn walk_recursive_target(
                 false,
                 sink,
             )
+            .inspect_err(|err| report_path_error(&filter.root, err))
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,7 +3,7 @@
 //! This module bridges parsed CLI flags, config parameters, glob expansion,
 //! filesystem metadata collection, and the selected output renderer.
 
-use glob::glob;
+use glob::{Pattern, glob};
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -42,6 +42,21 @@ pub(crate) struct TreeEntry {
 struct RecursiveDirectory {
     section: ListingSection,
     children: Vec<PathBuf>,
+}
+
+struct RecursiveFilter {
+    root: PathBuf,
+    pattern: Pattern,
+}
+
+enum RecursiveTarget {
+    Path(PathBuf),
+    Filter(RecursiveFilter),
+}
+
+struct RecursiveListing {
+    file_entries: Vec<FileInfo>,
+    recursive_targets: Vec<RecursiveTarget>,
 }
 
 /// Run `lsplus` using parsed CLI flags and config loaded from disk.
@@ -158,25 +173,36 @@ fn render_recursive_listing(
     patterns: &[String],
     params: &Params,
 ) -> io::Result<()> {
-    let operands = collect_operands(patterns, params)?;
-    let (file_entries, directory_operands) =
-        split_file_and_directory_operands(&operands, params)?;
+    let listing = prepare_recursive_listing(patterns, params)?;
     let mut rendered_section = false;
 
-    if !file_entries.is_empty() {
+    if !listing.file_entries.is_empty() {
         render_listing_section(
             &mut rendered_section,
             &ListingSection {
                 header: None,
-                entries: file_entries,
+                entries: listing.file_entries,
             },
             params,
         )?;
     }
 
-    walk_recursive_operands(directory_operands, params, &mut |section| {
-        render_listing_section(&mut rendered_section, &section, params)
-    })?;
+    let mut first_error = None;
+    for target in listing.recursive_targets {
+        let result = walk_recursive_target(target, params, &mut |section| {
+            render_listing_section(&mut rendered_section, &section, params)
+        });
+
+        if let Err(err) = result
+            && first_error.is_none()
+        {
+            first_error = Some(err);
+        }
+    }
+
+    if let Some(err) = first_error {
+        return Err(err);
+    }
 
     Ok(())
 }
@@ -281,6 +307,10 @@ pub(crate) fn collect_listing_sections(
     patterns: &[String],
     params: &Params,
 ) -> io::Result<Vec<ListingSection>> {
+    if params.recursive {
+        return collect_recursive_listing_sections(patterns, params);
+    }
+
     let operands = collect_operands(patterns, params)?;
     build_listing_sections(&operands, params)
 }
@@ -308,6 +338,156 @@ fn collect_operands(
     }
 
     Ok(operands)
+}
+
+fn collect_recursive_listing_sections(
+    patterns: &[String],
+    params: &Params,
+) -> io::Result<Vec<ListingSection>> {
+    let listing = prepare_recursive_listing(patterns, params)?;
+    let mut sections = Vec::new();
+    if !listing.file_entries.is_empty() {
+        sections.push(ListingSection {
+            header: None,
+            entries: listing.file_entries,
+        });
+    }
+
+    let mut first_error = None;
+    for target in listing.recursive_targets {
+        let result = walk_recursive_target(target, params, &mut |section| {
+            sections.push(section);
+            Ok(())
+        });
+
+        if let Err(err) = result
+            && first_error.is_none()
+        {
+            first_error = Some(err);
+        }
+    }
+
+    if let Some(err) = first_error {
+        return Err(err);
+    }
+
+    Ok(sections)
+}
+
+fn prepare_recursive_listing(
+    patterns: &[String],
+    params: &Params,
+) -> io::Result<RecursiveListing> {
+    let targets = collect_recursive_targets(patterns)?;
+    let mut file_entries = Vec::new();
+    let mut recursive_targets = Vec::new();
+
+    for target in targets {
+        match target {
+            RecursiveTarget::Path(path) if is_display_directory(&path) => {
+                recursive_targets.push(RecursiveTarget::Path(path));
+            }
+            RecursiveTarget::Path(path) => {
+                file_entries.push(create_file_info(&path, params)?);
+            }
+            RecursiveTarget::Filter(filter) => {
+                recursive_targets.push(RecursiveTarget::Filter(filter));
+            }
+        }
+    }
+
+    Ok(RecursiveListing {
+        file_entries,
+        recursive_targets,
+    })
+}
+
+fn walk_recursive_target(
+    target: RecursiveTarget,
+    params: &Params,
+    sink: &mut impl FnMut(ListingSection) -> io::Result<()>,
+) -> io::Result<()> {
+    match target {
+        RecursiveTarget::Path(path) => {
+            walk_recursive_directory(&path, params, true, 1, sink)
+                .inspect_err(|err| report_path_error(&path, err))
+        }
+        RecursiveTarget::Filter(filter) => {
+            walk_recursive_filter(&filter, params, sink)
+        }
+    }
+}
+
+fn collect_recursive_targets(
+    patterns: &[String],
+) -> io::Result<Vec<RecursiveTarget>> {
+    let mut targets = Vec::new();
+
+    for pattern in patterns {
+        if let Some(filter) = recursive_filter_from_pattern(pattern) {
+            match filter {
+                Ok(filter) => targets.push(RecursiveTarget::Filter(filter)),
+                Err(err) => {
+                    eprintln!("lsplus: failed to read glob pattern: {}", err);
+                }
+            }
+            continue;
+        }
+
+        let mut operands = Vec::new();
+        append_pattern_operands(&mut operands, pattern, &Params::default())?;
+        targets.extend(operands.into_iter().map(RecursiveTarget::Path));
+    }
+
+    Ok(targets)
+}
+
+fn recursive_filter_from_pattern(
+    pattern: &str,
+) -> Option<Result<RecursiveFilter, glob::PatternError>> {
+    let path = Path::new(pattern);
+
+    if pattern_has_glob_chars(pattern) {
+        let parent = path.parent().unwrap_or_else(|| Path::new(""));
+        if pattern_has_glob_chars(&parent.to_string_lossy()) {
+            return None;
+        }
+
+        let file_name = path.file_name()?.to_string_lossy();
+        return Some(Pattern::new(&file_name).map(|pattern| {
+            RecursiveFilter {
+                root: filter_root(parent),
+                pattern,
+            }
+        }));
+    }
+
+    if path.exists() {
+        return None;
+    }
+
+    let parent = path.parent().unwrap_or_else(|| Path::new(""));
+    if !parent.as_os_str().is_empty() {
+        return None;
+    }
+
+    let file_name = path.file_name()?.to_string_lossy();
+    Some(Pattern::new(&file_name).map(|pattern| RecursiveFilter {
+        root: PathBuf::from("."),
+        pattern,
+    }))
+}
+
+fn filter_root(parent: &Path) -> PathBuf {
+    if parent.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        parent.to_path_buf()
+    }
+}
+
+fn pattern_has_glob_chars(pattern: &str) -> bool {
+    pattern.contains('*') || pattern.contains('?') || pattern.contains('[')
 }
 
 fn append_pattern_operands(
@@ -408,6 +588,15 @@ fn collect_recursive_directory(
     params: &Params,
     hide_dot_entries: bool,
 ) -> io::Result<RecursiveDirectory> {
+    collect_recursive_directory_entries(path, params, hide_dot_entries, None)
+}
+
+fn collect_recursive_directory_entries(
+    path: &Path,
+    params: &Params,
+    hide_dot_entries: bool,
+    name_filter: Option<&Pattern>,
+) -> io::Result<RecursiveDirectory> {
     let child_names = utils::file::collect_file_names(path, params)?;
     let mut entries = Vec::new();
     let mut children = Vec::new();
@@ -429,12 +618,14 @@ fn collect_recursive_directory(
             }
         };
 
-        entries.push(create_file_info_from_metadata_with_gitignore(
-            &child_path,
-            &metadata,
-            params,
-            &mut gitignore_cache,
-        ));
+        if name_filter.is_none_or(|pattern| pattern.matches(&child_name)) {
+            entries.push(create_file_info_from_metadata_with_gitignore(
+                &child_path,
+                &metadata,
+                params,
+                &mut gitignore_cache,
+            ));
+        }
 
         if is_traversable_child_name(&child_name)
             && metadata.is_dir()
@@ -452,6 +643,84 @@ fn collect_recursive_directory(
         },
         children,
     })
+}
+
+fn walk_recursive_filter(
+    filter: &RecursiveFilter,
+    params: &Params,
+    sink: &mut impl FnMut(ListingSection) -> io::Result<()>,
+) -> io::Result<()> {
+    if !is_display_directory(&filter.root) {
+        eprintln!(
+            "lsplus: {}: No such file or directory",
+            sanitize_for_terminal(&filter.root.to_string_lossy())
+        );
+        return Ok(());
+    }
+
+    walk_recursive_filtered_directory(&filter.root, filter, params, 1, sink)
+}
+
+fn walk_recursive_filtered_directory(
+    path: &Path,
+    filter: &RecursiveFilter,
+    params: &Params,
+    visible_entry_depth: usize,
+    sink: &mut impl FnMut(ListingSection) -> io::Result<()>,
+) -> io::Result<()> {
+    let directory = match collect_recursive_filtered_directory(
+        path,
+        filter,
+        params,
+        visible_entry_depth > 1,
+    ) {
+        Ok(directory) => directory,
+        Err(err) if visible_entry_depth == 1 => return Err(err),
+        Err(err) => {
+            report_path_error(path, &err);
+            return Ok(());
+        }
+    };
+
+    if !directory.section.entries.is_empty() {
+        sink(ListingSection {
+            header: recursive_section_header(path, visible_entry_depth),
+            entries: directory.section.entries,
+        })?;
+    }
+
+    if params
+        .recursive_level
+        .is_some_and(|limit| visible_entry_depth >= limit)
+    {
+        return Ok(());
+    }
+
+    for child in directory.children {
+        walk_recursive_filtered_directory(
+            &child,
+            filter,
+            params,
+            visible_entry_depth + 1,
+            sink,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn collect_recursive_filtered_directory(
+    path: &Path,
+    filter: &RecursiveFilter,
+    params: &Params,
+    hide_dot_entries: bool,
+) -> io::Result<RecursiveDirectory> {
+    collect_recursive_directory_entries(
+        path,
+        params,
+        hide_dot_entries,
+        Some(&filter.pattern),
+    )
 }
 
 fn build_tree_sections(

--- a/src/app.rs
+++ b/src/app.rs
@@ -207,41 +207,20 @@ fn render_recursive_listing(
     Ok(())
 }
 
-fn walk_recursive_operands(
-    directory_operands: Vec<&PathBuf>,
-    params: &Params,
-    sink: &mut impl FnMut(ListingSection) -> io::Result<()>,
-) -> io::Result<()> {
-    let mut first_error = None;
-
-    for path in directory_operands {
-        if let Err(err) = walk_recursive_directory(path, params, true, 1, sink)
-        {
-            report_path_error(path, &err);
-            if first_error.is_none() {
-                first_error = Some(err);
-            }
-        }
-    }
-
-    if let Some(err) = first_error {
-        return Err(err);
-    }
-
-    Ok(())
-}
-
 fn walk_recursive_directory(
     path: &Path,
     params: &Params,
     fail_on_error: bool,
     visible_entry_depth: usize,
+    name_filter: Option<&Pattern>,
+    emit_empty_sections: bool,
     sink: &mut impl FnMut(ListingSection) -> io::Result<()>,
 ) -> io::Result<()> {
     let mut directory = match collect_recursive_directory(
         path,
         params,
         visible_entry_depth > 1,
+        name_filter,
     ) {
         Ok(directory) => directory,
         Err(err) if fail_on_error => return Err(err),
@@ -253,7 +232,9 @@ fn walk_recursive_directory(
 
     directory.section.header =
         recursive_section_header(path, visible_entry_depth);
-    sink(directory.section)?;
+    if emit_empty_sections || !directory.section.entries.is_empty() {
+        sink(directory.section)?;
+    }
 
     if params
         .recursive_level
@@ -268,6 +249,8 @@ fn walk_recursive_directory(
             params,
             false,
             visible_entry_depth + 1,
+            name_filter,
+            emit_empty_sections,
             sink,
         )?;
     }
@@ -409,11 +392,27 @@ fn walk_recursive_target(
 ) -> io::Result<()> {
     match target {
         RecursiveTarget::Path(path) => {
-            walk_recursive_directory(&path, params, true, 1, sink)
+            walk_recursive_directory(&path, params, true, 1, None, true, sink)
                 .inspect_err(|err| report_path_error(&path, err))
         }
         RecursiveTarget::Filter(filter) => {
-            walk_recursive_filter(&filter, params, sink)
+            if !is_display_directory(&filter.root) {
+                eprintln!(
+                    "lsplus: {}: No such file or directory",
+                    sanitize_for_terminal(&filter.root.to_string_lossy())
+                );
+                return Ok(());
+            }
+
+            walk_recursive_directory(
+                &filter.root,
+                params,
+                true,
+                1,
+                Some(&filter.pattern),
+                false,
+                sink,
+            )
         }
     }
 }
@@ -536,9 +535,8 @@ fn build_listing_sections(
     let (file_entries, directory_operands) =
         split_file_and_directory_operands(operands, params)?;
 
-    let show_directory_headers = params.recursive
-        || !file_entries.is_empty()
-        || directory_operands.len() > 1;
+    let show_directory_headers =
+        !file_entries.is_empty() || directory_operands.len() > 1;
     let mut sections = Vec::new();
 
     if !file_entries.is_empty() {
@@ -548,18 +546,11 @@ fn build_listing_sections(
         });
     }
 
-    if params.recursive {
-        walk_recursive_operands(directory_operands, params, &mut |section| {
-            sections.push(section);
-            Ok(())
-        })?;
-    } else {
-        for path in directory_operands {
-            sections.push(ListingSection {
-                header: show_directory_headers.then(|| display_path(path)),
-                entries: collect_file_info(path, params)?,
-            });
-        }
+    for path in directory_operands {
+        sections.push(ListingSection {
+            header: show_directory_headers.then(|| display_path(path)),
+            entries: collect_file_info(path, params)?,
+        });
     }
 
     Ok(sections)
@@ -584,14 +575,6 @@ fn split_file_and_directory_operands<'a>(
 }
 
 fn collect_recursive_directory(
-    path: &Path,
-    params: &Params,
-    hide_dot_entries: bool,
-) -> io::Result<RecursiveDirectory> {
-    collect_recursive_directory_entries(path, params, hide_dot_entries, None)
-}
-
-fn collect_recursive_directory_entries(
     path: &Path,
     params: &Params,
     hide_dot_entries: bool,
@@ -643,84 +626,6 @@ fn collect_recursive_directory_entries(
         },
         children,
     })
-}
-
-fn walk_recursive_filter(
-    filter: &RecursiveFilter,
-    params: &Params,
-    sink: &mut impl FnMut(ListingSection) -> io::Result<()>,
-) -> io::Result<()> {
-    if !is_display_directory(&filter.root) {
-        eprintln!(
-            "lsplus: {}: No such file or directory",
-            sanitize_for_terminal(&filter.root.to_string_lossy())
-        );
-        return Ok(());
-    }
-
-    walk_recursive_filtered_directory(&filter.root, filter, params, 1, sink)
-}
-
-fn walk_recursive_filtered_directory(
-    path: &Path,
-    filter: &RecursiveFilter,
-    params: &Params,
-    visible_entry_depth: usize,
-    sink: &mut impl FnMut(ListingSection) -> io::Result<()>,
-) -> io::Result<()> {
-    let directory = match collect_recursive_filtered_directory(
-        path,
-        filter,
-        params,
-        visible_entry_depth > 1,
-    ) {
-        Ok(directory) => directory,
-        Err(err) if visible_entry_depth == 1 => return Err(err),
-        Err(err) => {
-            report_path_error(path, &err);
-            return Ok(());
-        }
-    };
-
-    if !directory.section.entries.is_empty() {
-        sink(ListingSection {
-            header: recursive_section_header(path, visible_entry_depth),
-            entries: directory.section.entries,
-        })?;
-    }
-
-    if params
-        .recursive_level
-        .is_some_and(|limit| visible_entry_depth >= limit)
-    {
-        return Ok(());
-    }
-
-    for child in directory.children {
-        walk_recursive_filtered_directory(
-            &child,
-            filter,
-            params,
-            visible_entry_depth + 1,
-            sink,
-        )?;
-    }
-
-    Ok(())
-}
-
-fn collect_recursive_filtered_directory(
-    path: &Path,
-    filter: &RecursiveFilter,
-    params: &Params,
-    hide_dot_entries: bool,
-) -> io::Result<RecursiveDirectory> {
-    collect_recursive_directory_entries(
-        path,
-        params,
-        hide_dot_entries,
-        Some(&filter.pattern),
-    )
 }
 
 fn build_tree_sections(

--- a/tests/crate/app.rs
+++ b/tests/crate/app.rs
@@ -307,6 +307,21 @@ fn test_collect_listing_sections_recursive_roots_prefixed_glob() {
 }
 
 #[test]
+fn test_collect_listing_sections_recursive_filter_no_matches_is_empty() {
+    let temp_dir = tempdir().unwrap();
+    fs::write(temp_dir.path().join("root.txt"), "root").unwrap();
+    let params = Params {
+        recursive: true,
+        ..Params::default()
+    };
+    let pattern = format!("{}/*.rs", temp_dir.path().display());
+
+    let sections = collect_listing_sections(&[pattern], &params).unwrap();
+
+    assert!(sections.is_empty());
+}
+
+#[test]
 fn test_collect_listing_sections_recursive_mixes_files_filters_and_directories()
  {
     let temp_dir = tempdir().unwrap();

--- a/tests/crate/app.rs
+++ b/tests/crate/app.rs
@@ -211,6 +211,102 @@ fn test_collect_listing_sections_recurses_with_headers() {
 }
 
 #[test]
+fn test_collect_listing_sections_recursive_filters_glob_matches() {
+    let temp_dir = tempdir().unwrap();
+    let nested = temp_dir.path().join("nested");
+    fs::create_dir(&nested).unwrap();
+    fs::write(temp_dir.path().join("root.rs"), "root").unwrap();
+    fs::write(temp_dir.path().join("root.txt"), "root").unwrap();
+    fs::write(nested.join("deep.rs"), "deep").unwrap();
+    fs::write(nested.join("deep.txt"), "deep").unwrap();
+    let params = Params {
+        recursive: true,
+        ..Params::default()
+    };
+    let pattern = format!("{}/*.rs", temp_dir.path().display());
+
+    let sections = collect_listing_sections(&[pattern], &params).unwrap();
+
+    assert_eq!(sections.len(), 2);
+    assert_eq!(
+        sections[0].header,
+        Some(temp_dir.path().display().to_string())
+    );
+    assert!(
+        sections[0]
+            .entries
+            .iter()
+            .any(|info| info.short_name == "root.rs")
+    );
+    assert!(
+        !sections[0]
+            .entries
+            .iter()
+            .any(|info| info.short_name == "root.txt")
+    );
+    assert_eq!(sections[1].header, Some(nested.display().to_string()));
+    assert!(
+        sections[1]
+            .entries
+            .iter()
+            .any(|info| info.short_name == "deep.rs")
+    );
+    assert!(
+        !sections[1]
+            .entries
+            .iter()
+            .any(|info| info.short_name == "deep.txt")
+    );
+}
+
+#[test]
+fn test_collect_listing_sections_recursive_roots_prefixed_glob() {
+    let temp_dir = tempdir().unwrap();
+    let src = temp_dir.path().join("src");
+    let utils = src.join("utils");
+    fs::create_dir_all(&utils).unwrap();
+    fs::write(temp_dir.path().join("outside.rs"), "outside").unwrap();
+    fs::write(src.join("lib.rs"), "lib").unwrap();
+    fs::write(src.join("lib.txt"), "lib").unwrap();
+    fs::write(utils.join("file.rs"), "file").unwrap();
+    let params = Params {
+        recursive: true,
+        ..Params::default()
+    };
+    let pattern = format!("{}/*.rs", src.display());
+
+    let sections = collect_listing_sections(&[pattern], &params).unwrap();
+
+    assert_eq!(sections.len(), 2);
+    assert_eq!(sections[0].header, Some(src.display().to_string()));
+    assert!(
+        sections[0]
+            .entries
+            .iter()
+            .any(|info| info.short_name == "lib.rs")
+    );
+    assert!(
+        !sections[0]
+            .entries
+            .iter()
+            .any(|info| info.short_name == "lib.txt")
+    );
+    assert_eq!(sections[1].header, Some(utils.display().to_string()));
+    assert!(
+        sections[1]
+            .entries
+            .iter()
+            .any(|info| info.short_name == "file.rs")
+    );
+    assert!(
+        !sections
+            .iter()
+            .flat_map(|section| section.entries.iter())
+            .any(|info| info.short_name == "outside.rs")
+    );
+}
+
+#[test]
 fn test_collect_listing_sections_recursive_respects_level_limit() {
     let temp_dir = tempdir().unwrap();
     let child = temp_dir.path().join("child");

--- a/tests/crate/app.rs
+++ b/tests/crate/app.rs
@@ -307,6 +307,88 @@ fn test_collect_listing_sections_recursive_roots_prefixed_glob() {
 }
 
 #[test]
+fn test_collect_listing_sections_recursive_mixes_files_filters_and_directories()
+ {
+    let temp_dir = tempdir().unwrap();
+    let top_file = temp_dir.path().join("top.txt");
+    let src = temp_dir.path().join("src");
+    let utils = src.join("utils");
+    let docs = temp_dir.path().join("docs");
+    fs::create_dir_all(&utils).unwrap();
+    fs::create_dir(&docs).unwrap();
+    fs::write(&top_file, "top").unwrap();
+    fs::write(src.join("lib.rs"), "lib").unwrap();
+    fs::write(src.join("lib.txt"), "lib").unwrap();
+    fs::write(utils.join("file.rs"), "file").unwrap();
+    fs::write(docs.join("guide.md"), "guide").unwrap();
+    let params = Params {
+        recursive: true,
+        ..Params::default()
+    };
+    let pattern = format!("{}/*.rs", src.display());
+
+    let sections = collect_listing_sections(
+        &[
+            pattern,
+            top_file.display().to_string(),
+            docs.display().to_string(),
+        ],
+        &params,
+    )
+    .unwrap();
+
+    assert_eq!(sections.len(), 4);
+    assert_eq!(sections[0].header, None);
+    assert!(
+        sections[0]
+            .entries
+            .iter()
+            .any(|info| info.short_name == "top.txt")
+    );
+    assert_eq!(sections[1].header, Some(src.display().to_string()));
+    assert!(
+        sections[1]
+            .entries
+            .iter()
+            .any(|info| info.short_name == "lib.rs")
+    );
+    assert!(
+        !sections[1]
+            .entries
+            .iter()
+            .any(|info| info.short_name == "lib.txt")
+    );
+    assert_eq!(sections[2].header, Some(utils.display().to_string()));
+    assert!(
+        sections[2]
+            .entries
+            .iter()
+            .any(|info| info.short_name == "file.rs")
+    );
+    assert_eq!(sections[3].header, Some(docs.display().to_string()));
+    assert!(
+        sections[3]
+            .entries
+            .iter()
+            .any(|info| info.short_name == "guide.md")
+    );
+}
+
+#[test]
+fn test_collect_listing_sections_recursive_missing_filter_root_is_empty() {
+    let temp_dir = tempdir().unwrap();
+    let params = Params {
+        recursive: true,
+        ..Params::default()
+    };
+    let pattern = format!("{}/missing/*.rs", temp_dir.path().display());
+
+    let sections = collect_listing_sections(&[pattern], &params).unwrap();
+
+    assert!(sections.is_empty());
+}
+
+#[test]
 fn test_collect_listing_sections_recursive_respects_level_limit() {
     let temp_dir = tempdir().unwrap();
     let child = temp_dir.path().join("child");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -387,6 +387,55 @@ fn test_recursive_current_directory_omits_root_header_and_cleans_child_headers()
 }
 
 #[test]
+fn test_recursive_quoted_glob_filters_nested_matches() {
+    let temp_dir = tempdir().unwrap();
+    let src = temp_dir.path().join("src");
+    let utils = src.join("utils");
+    fs::create_dir_all(&utils).unwrap();
+    fs::write(temp_dir.path().join("root.rs"), "root").unwrap();
+    fs::write(temp_dir.path().join("root.txt"), "root").unwrap();
+    fs::write(src.join("lib.rs"), "lib").unwrap();
+    fs::write(src.join("lib.txt"), "lib").unwrap();
+    fs::write(utils.join("file.rs"), "file").unwrap();
+
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.current_dir(temp_dir.path())
+        .arg("-R")
+        .arg("--no-icons")
+        .arg("*.rs");
+    let (stdout, _stderr) = run_and_capture(&mut cmd);
+
+    assert!(!stdout.lines().any(|line| line == ".:"));
+    assert!(stdout.lines().any(|line| line == "src:"));
+    assert!(stdout.lines().any(|line| line == "src/utils:"));
+    assert!(stdout.contains("root.rs"));
+    assert!(stdout.contains("lib.rs"));
+    assert!(stdout.contains("file.rs"));
+    assert!(!stdout.contains("root.txt"));
+    assert!(!stdout.contains("lib.txt"));
+}
+
+#[test]
+fn test_recursive_bare_filename_finds_nested_matches() {
+    let temp_dir = tempdir().unwrap();
+    let src = temp_dir.path().join("src");
+    fs::create_dir(&src).unwrap();
+    fs::write(src.join("main.rs"), "main").unwrap();
+    fs::write(src.join("lib.rs"), "lib").unwrap();
+
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.current_dir(temp_dir.path())
+        .arg("-R")
+        .arg("--no-icons")
+        .arg("main.rs");
+    let (stdout, _stderr) = run_and_capture(&mut cmd);
+
+    assert!(stdout.lines().any(|line| line == "src:"));
+    assert!(stdout.contains("main.rs"));
+    assert!(!stdout.contains("lib.rs"));
+}
+
+#[test]
 fn test_recursive_level_limits_nested_directory_headers() {
     let temp_dir = tempdir().unwrap();
     let child = temp_dir.path().join("child");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -416,6 +416,32 @@ fn test_recursive_quoted_glob_filters_nested_matches() {
 }
 
 #[test]
+fn test_recursive_prefixed_glob_filters_from_parent_directory() {
+    let temp_dir = tempdir().unwrap();
+    let src = temp_dir.path().join("src");
+    let utils = src.join("utils");
+    fs::create_dir_all(&utils).unwrap();
+    fs::write(temp_dir.path().join("outside.rs"), "outside").unwrap();
+    fs::write(src.join("lib.rs"), "lib").unwrap();
+    fs::write(src.join("lib.txt"), "lib").unwrap();
+    fs::write(utils.join("file.rs"), "file").unwrap();
+
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.current_dir(temp_dir.path())
+        .arg("-R")
+        .arg("--no-icons")
+        .arg("src/*.rs");
+    let (stdout, _stderr) = run_and_capture(&mut cmd);
+
+    assert!(stdout.lines().any(|line| line == "src:"));
+    assert!(stdout.lines().any(|line| line == "src/utils:"));
+    assert!(stdout.contains("lib.rs"));
+    assert!(stdout.contains("file.rs"));
+    assert!(!stdout.contains("outside.rs"));
+    assert!(!stdout.contains("lib.txt"));
+}
+
+#[test]
 fn test_recursive_bare_filename_finds_nested_matches() {
     let temp_dir = tempdir().unwrap();
     let src = temp_dir.path().join("src");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -462,6 +462,40 @@ fn test_recursive_bare_filename_finds_nested_matches() {
 }
 
 #[test]
+fn test_recursive_quoted_glob_no_matches_reports_diagnostic() {
+    let temp_dir = tempdir().unwrap();
+    fs::write(temp_dir.path().join("root.txt"), "root").unwrap();
+
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.current_dir(temp_dir.path())
+        .arg("-R")
+        .arg("--no-icons")
+        .arg("*.rs");
+    let (stdout, stderr) = run_and_capture(&mut cmd);
+
+    assert!(stdout.is_empty());
+    assert!(stderr.contains("lsplus: *.rs: No such file or directory"));
+}
+
+#[test]
+fn test_recursive_bare_filename_no_matches_reports_diagnostic() {
+    let temp_dir = tempdir().unwrap();
+    let src = temp_dir.path().join("src");
+    fs::create_dir(&src).unwrap();
+    fs::write(src.join("lib.rs"), "lib").unwrap();
+
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.current_dir(temp_dir.path())
+        .arg("-R")
+        .arg("--no-icons")
+        .arg("main.rs");
+    let (stdout, stderr) = run_and_capture(&mut cmd);
+
+    assert!(stdout.is_empty());
+    assert!(stderr.contains("lsplus: main.rs: No such file or directory"));
+}
+
+#[test]
 fn test_recursive_level_limits_nested_directory_headers() {
     let temp_dir = tempdir().unwrap();
     let child = temp_dir.path().join("child");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12,6 +12,19 @@ use nix::unistd::Uid;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
+#[cfg(unix)]
+struct PermissionGuard {
+    path: std::path::PathBuf,
+}
+
+#[cfg(unix)]
+impl Drop for PermissionGuard {
+    fn drop(&mut self) {
+        let _ =
+            fs::set_permissions(&self.path, fs::Permissions::from_mode(0o700));
+    }
+}
+
 fn run_and_capture(cmd: &mut Command) -> (String, String) {
     let output = cmd.output().unwrap();
     assert!(
@@ -98,19 +111,6 @@ fn test_invalid_glob_pattern_reports_lsplus_prefix() {
 #[cfg(unix)]
 #[test]
 fn test_glob_entry_error_reports_stderr_and_lists_matches() {
-    struct PermissionGuard {
-        path: std::path::PathBuf,
-    }
-
-    impl Drop for PermissionGuard {
-        fn drop(&mut self) {
-            let _ = fs::set_permissions(
-                &self.path,
-                fs::Permissions::from_mode(0o700),
-            );
-        }
-    }
-
     if Uid::effective().is_root() {
         return;
     }
@@ -628,19 +628,6 @@ fn test_recursive_prune_noisy_dirs_honors_explicit_operand() {
 #[cfg(unix)]
 #[test]
 fn test_recursive_continues_after_unreadable_directory_operand() {
-    struct PermissionGuard {
-        path: std::path::PathBuf,
-    }
-
-    impl Drop for PermissionGuard {
-        fn drop(&mut self) {
-            let _ = fs::set_permissions(
-                &self.path,
-                fs::Permissions::from_mode(0o700),
-            );
-        }
-    }
-
     if Uid::effective().is_root() {
         return;
     }
@@ -684,19 +671,6 @@ fn test_recursive_continues_after_unreadable_directory_operand() {
 #[cfg(unix)]
 #[test]
 fn test_recursive_filter_reports_unreadable_root() {
-    struct PermissionGuard {
-        path: std::path::PathBuf,
-    }
-
-    impl Drop for PermissionGuard {
-        fn drop(&mut self) {
-            let _ = fs::set_permissions(
-                &self.path,
-                fs::Permissions::from_mode(0o700),
-            );
-        }
-    }
-
     if Uid::effective().is_root() {
         return;
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -387,6 +387,29 @@ fn test_recursive_current_directory_omits_root_header_and_cleans_child_headers()
 }
 
 #[test]
+fn test_recursive_bare_directory_lists_contents() {
+    let temp_dir = tempdir().unwrap();
+    let src = temp_dir.path().join("src");
+    let utils = src.join("utils");
+    fs::create_dir_all(&utils).unwrap();
+    fs::write(src.join("lib.rs"), "lib").unwrap();
+    fs::write(utils.join("file.rs"), "file").unwrap();
+
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.current_dir(temp_dir.path())
+        .arg("-R")
+        .arg("--no-icons")
+        .arg("src");
+    let (stdout, _stderr) = run_and_capture(&mut cmd);
+
+    assert!(stdout.lines().any(|line| line == "src:"));
+    assert!(stdout.lines().any(|line| line == "src/utils:"));
+    assert!(stdout.contains("lib.rs"));
+    assert!(stdout.contains("file.rs"));
+    assert!(!stdout.trim().eq("src/"));
+}
+
+#[test]
 fn test_recursive_quoted_glob_filters_nested_matches() {
     let temp_dir = tempdir().unwrap();
     let src = temp_dir.path().join("src");
@@ -458,6 +481,29 @@ fn test_recursive_bare_filename_finds_nested_matches() {
 
     assert!(stdout.lines().any(|line| line == "src:"));
     assert!(stdout.contains("main.rs"));
+    assert!(!stdout.contains("lib.rs"));
+}
+
+#[test]
+fn test_recursive_bare_filename_in_current_directory_still_filters_recursively()
+ {
+    let temp_dir = tempdir().unwrap();
+    let src = temp_dir.path().join("src");
+    fs::create_dir(&src).unwrap();
+    fs::write(temp_dir.path().join("main.rs"), "root").unwrap();
+    fs::write(src.join("main.rs"), "nested").unwrap();
+    fs::write(src.join("lib.rs"), "lib").unwrap();
+
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    cmd.current_dir(temp_dir.path())
+        .arg("-R")
+        .arg("--no-icons")
+        .arg("main.rs");
+    let (stdout, _stderr) = run_and_capture(&mut cmd);
+
+    assert!(!stdout.lines().any(|line| line == ".:"));
+    assert!(stdout.lines().any(|line| line == "src:"));
+    assert_eq!(stdout.matches("main.rs").count(), 2);
     assert!(!stdout.contains("lib.rs"));
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -601,6 +601,50 @@ fn test_recursive_continues_after_unreadable_directory_operand() {
     assert!(stderr.contains(blocked_dir.to_string_lossy().as_ref()));
 }
 
+#[cfg(unix)]
+#[test]
+fn test_recursive_filter_reports_unreadable_root() {
+    struct PermissionGuard {
+        path: std::path::PathBuf,
+    }
+
+    impl Drop for PermissionGuard {
+        fn drop(&mut self) {
+            let _ = fs::set_permissions(
+                &self.path,
+                fs::Permissions::from_mode(0o700),
+            );
+        }
+    }
+
+    if Uid::effective().is_root() {
+        return;
+    }
+
+    let temp_dir = tempdir().unwrap();
+    let blocked_dir = temp_dir.path().join("blocked");
+    fs::create_dir(&blocked_dir).unwrap();
+    fs::set_permissions(&blocked_dir, fs::Permissions::from_mode(0o000))
+        .unwrap();
+    let _guard = PermissionGuard {
+        path: blocked_dir.clone(),
+    };
+    let pattern = format!("{}/*.rs", blocked_dir.display());
+
+    let mut cmd = Command::cargo_bin("lsp").unwrap();
+    let output = cmd
+        .arg("-R")
+        .arg("--no-icons")
+        .arg(pattern)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = strip_str(String::from_utf8_lossy(&output.stderr));
+    assert!(stderr.contains("lsplus:"));
+    assert!(stderr.contains(blocked_dir.to_string_lossy().as_ref()));
+}
+
 #[test]
 fn test_tree_level_limits_nested_descendants() {
     let temp_dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary

This fixes recursive pattern operands so quoted wildcards and bare filenames can be matched while walking subdirectories.

The root cause was that recursive mode expanded operands once, then only recursed into operands that were already directories. When the shell passed a literal pattern such as `*.rs`, `lsplus` did not apply that basename filter during traversal, so nested matches were missed.

The change keeps existing directory and file operands working as before, while adding recursive filtering for patterns such as `lsp -R '*.rs'` and `lsp -R 'src/*.rs'`. The implementation was then simplified so filtered and unfiltered recursive traversal share the same walker.

Docs now call out that shells such as zsh may expand or reject unquoted wildcards before `lsp` starts, matching GNU `ls` behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recursive listing with glob and bare-filename filtering, applying matches within the correct directory subtree.
* **Bug Fixes**
  * Improved “no matches” behaviour for recursive patterns (stdout empty when nothing matches).
  * Refined recursive error handling: clearer diagnostics for unreadable directories and recursive traversal; avoids duplicate stderr output while still exiting non-zero when appropriate.
* **Documentation**
  * Expanded usage documentation for `-R/--recursive`, including recursive operand matching rules, output formatting, and shell-quoting limitations for wildcard patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->