### PR TITLE
Use colored_text terminal color detection

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,11 +24,6 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Install cargo tools
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-make,cargo-nextest,cargo-llvm-cov
-
       - name: Check formatting
         run: cargo fmt --check
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run tests
-        run: cargo make test
+        run: cargo test --all-targets --all-features
 
   audit:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /target
 .changelog_generator.toml
-.cursorrules
-.windsurfrules
+.vscode
+
 
 # AI stuff
 .codex/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -66,7 +66,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -224,9 +224,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colored_text"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a3330c8c6d190b9cfd6a2cfad78bc4c7de129fb3ed929e3fa8348d1d314a44"
+checksum = "745f8a64d62b40a725042e502af674abe0fb85726224780f1b2ff70552a4914c"
 
 [[package]]
 name = "config"
@@ -405,7 +405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -915,7 +915,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1065,7 +1065,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1075,7 +1075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1331,7 +1331,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1354,15 +1354,6 @@ name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 chrono = "0.4.41"
 glob = "0.3.1"
 clap = { version = "4.5.37", features = ["derive"] }
-colored_text = "0.4.1"
+colored_text = "0.5.1"
 nix = { version = "0.31.0", features = ["user"] }
 terminal_size = "0.4.4"
 config = "0.15.7"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,7 +1,13 @@
 [tasks.test]
 # this needs the crates 'nextest' and 'cargo-llvm-cov' installed locally
 command = "cargo"
-args = ["llvm-cov", "nextest"]
+args = [
+  "llvm-cov",
+  "nextest",
+  "--no-fail-fast",
+  "--lcov",
+  "--output-path=target/llvm-cov/coverage.lcov",
+]
 
 [tasks.test-html]
 command = "cargo"

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -219,8 +219,9 @@ age-based timestamp colors.
 Timestamp colors adapt to terminal color capability: truecolor terminals use a
 smooth age gradient and 256-color terminals use a stepped fallback to
 distinguish day, week, month, and year bands. Basic ANSI terminals use named
-yellow styling. Future-dated timestamps stay red, even with `time_gradient`
-disabled, to make clock-skewed files stand out.
+yellow styling. Terminals without color support render timestamps plainly.
+Future-dated timestamps stay red, even with `time_gradient` disabled, to make
+clock-skewed files stand out.
 
 ### size_colors
 

--- a/src/utils/color.rs
+++ b/src/utils/color.rs
@@ -30,5 +30,5 @@ pub(crate) fn long_format_color_level(params: &Params) -> ColorLevel {
         return ColorLevel::NoColor;
     }
 
-    ColorizeConfig::terminal_capabilities(RenderTarget::Stdout).color_level
+    ColorizeConfig::color_level(RenderTarget::Stdout)
 }

--- a/src/utils/color.rs
+++ b/src/utils/color.rs
@@ -1,13 +1,13 @@
-//! Terminal color-mode detection and global color configuration.
+//! Terminal color-mode detection and thread-local color configuration.
 //!
-//! Short-format names use the `colored_text` global color mode. Long-format
-//! accent colors use the same terminal capability detection.
+//! Short-format names use the `colored_text` thread-local color mode.
+//! Long-format accent colors use the same terminal capability detection.
 
 use colored_text::{ColorLevel, ColorMode, ColorizeConfig, RenderTarget};
 
 use crate::Params;
 
-/// Return the global color mode implied by runtime parameters.
+/// Return the color mode implied by runtime parameters.
 pub(crate) fn color_mode_for(params: &Params) -> ColorMode {
     if params.no_color {
         ColorMode::Never
@@ -16,7 +16,7 @@ pub(crate) fn color_mode_for(params: &Params) -> ColorMode {
     }
 }
 
-/// Apply the runtime color setting to the process-wide coloring backend.
+/// Apply the runtime color setting to the current thread.
 pub(crate) fn configure_color_output(params: &Params) {
     ColorizeConfig::set_color_mode(color_mode_for(params));
 }
@@ -24,7 +24,8 @@ pub(crate) fn configure_color_output(params: &Params) {
 /// Detect the color capability for long-format accents.
 ///
 /// `params.no_color` is kept as an explicit guard so direct calls remain safe
-/// even before the process-wide color configuration has been applied.
+/// even before the thread-local color configuration has been applied on the
+/// calling thread.
 pub(crate) fn long_format_color_level(params: &Params) -> ColorLevel {
     if params.no_color {
         return ColorLevel::NoColor;

--- a/src/utils/color.rs
+++ b/src/utils/color.rs
@@ -1,12 +1,9 @@
 //! Terminal color-mode detection and global color configuration.
 //!
 //! Short-format names use the `colored_text` global color mode. Long-format
-//! accent colors also need a capability level so table style specs and
-//! timestamp gradients can choose named, ANSI 256, or truecolor output.
+//! accent colors use the same terminal capability detection.
 
-use colored_text::{ColorMode, ColorizeConfig};
-use std::env;
-use std::io::{self, IsTerminal};
+use colored_text::{ColorLevel, ColorMode, ColorizeConfig, RenderTarget};
 
 use crate::Params;
 
@@ -24,73 +21,14 @@ pub(crate) fn configure_color_output(params: &Params) {
     ColorizeConfig::set_color_mode(color_mode_for(params));
 }
 
-/// Terminal color capability for long-format accent rendering.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum LongFormatColorLevel {
-    /// Do not emit long-format accent colors.
-    None,
-    /// Use named ANSI colors only.
-    Named,
-    /// Use ANSI 256-color escape sequences.
-    Ansi256,
-    /// Use RGB truecolor escape sequences.
-    Truecolor,
-}
-
-impl LongFormatColorLevel {
-    /// Return true when long-format accents may emit color.
-    pub(crate) fn is_enabled(self) -> bool {
-        self != Self::None
-    }
-}
-
 /// Detect the color capability for long-format accents.
 ///
-/// This respects `--no-color`, `NO_COLOR`, the configured `colored_text` mode,
-/// stdout terminal detection, and common `COLORTERM`/`TERM` capability names.
-pub(crate) fn long_format_color_level(
-    params: &Params,
-) -> LongFormatColorLevel {
-    if !color_output_enabled(params) {
-        return LongFormatColorLevel::None;
-    }
-
-    if env_contains_truecolor("COLORTERM") || env_contains_truecolor("TERM") {
-        LongFormatColorLevel::Truecolor
-    } else if env_contains_256color("COLORTERM")
-        || env_contains_256color("TERM")
-    {
-        LongFormatColorLevel::Ansi256
-    } else {
-        LongFormatColorLevel::Named
-    }
-}
-
-fn color_output_enabled(params: &Params) -> bool {
+/// `params.no_color` is kept as an explicit guard so direct calls remain safe
+/// even before the process-wide color configuration has been applied.
+pub(crate) fn long_format_color_level(params: &Params) -> ColorLevel {
     if params.no_color {
-        return false;
+        return ColorLevel::NoColor;
     }
 
-    match ColorizeConfig::color_mode() {
-        ColorMode::Never => false,
-        ColorMode::Always => env::var_os("NO_COLOR").is_none(),
-        ColorMode::Auto => {
-            env::var_os("NO_COLOR").is_none() && io::stdout().is_terminal()
-        }
-    }
-}
-
-fn env_contains_truecolor(name: &str) -> bool {
-    env::var(name)
-        .map(|value| {
-            let value = value.to_ascii_lowercase();
-            value.contains("truecolor") || value.contains("24bit")
-        })
-        .unwrap_or(false)
-}
-
-fn env_contains_256color(name: &str) -> bool {
-    env::var(name)
-        .map(|value| value.to_ascii_lowercase().contains("256color"))
-        .unwrap_or(false)
+    ColorizeConfig::terminal_capabilities(RenderTarget::Stdout).color_level
 }

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -341,15 +341,16 @@ fn long_octal_permission_text(
     color_level: ColorLevel,
 ) -> String {
     let text = utils::format::mode_to_octal(info.mode_bits);
-    if !params.permission_colors {
+    if !params.permission_colors || color_level == ColorLevel::NoColor {
         return text;
     }
 
-    match color_level {
-        ColorLevel::TrueColor => text.rgb(238, 204, 92).to_string(),
-        ColorLevel::Ansi256 => text.ansi256(221).to_string(),
-        ColorLevel::Ansi16 => text.yellow().dim().to_string(),
-        ColorLevel::NoColor => text,
+    if color_level == ColorLevel::TrueColor {
+        text.rgb(238, 204, 92).to_string()
+    } else if color_level == ColorLevel::Ansi256 {
+        text.ansi256(221).to_string()
+    } else {
+        text.yellow().dim().to_string()
     }
 }
 

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -271,12 +271,14 @@ fn header_text(text: &str, color_level: ColorLevel) -> String {
     }
 
     match color_level {
-        ColorLevel::TrueColor => format!(
-            "\x1b[4;38;2;{};{};{}m{text}\x1b[0m",
-            HEADER_SALMON_TRUECOLOR.0,
-            HEADER_SALMON_TRUECOLOR.1,
-            HEADER_SALMON_TRUECOLOR.2
-        ),
+        ColorLevel::TrueColor => text
+            .rgb(
+                HEADER_SALMON_TRUECOLOR.0,
+                HEADER_SALMON_TRUECOLOR.1,
+                HEADER_SALMON_TRUECOLOR.2,
+            )
+            .underline()
+            .to_string(),
         ColorLevel::Ansi256 => {
             text.ansi256(HEADER_SALMON_ANSI_256).underline().to_string()
         }

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -4,7 +4,7 @@
 //! Unicode width so ANSI styling and wide glyphs do not distort layout.
 
 use chrono::{DateTime, Local};
-use colored_text::{Colorize, StyledText};
+use colored_text::{ColorLevel, Colorize, StyledText};
 use std::fmt::Write as FmtWrite;
 use std::io::{self, Write as IoWrite};
 use std::time::{Duration, SystemTime};
@@ -14,7 +14,7 @@ use terminal_size::{Height, Width, terminal_size};
 
 use crate::structs::{FileInfo, NameStyle};
 use crate::utils;
-use crate::utils::color::{LongFormatColorLevel, long_format_color_level};
+use crate::utils::color::long_format_color_level;
 use crate::utils::file::check_display_name;
 use crate::utils::table::{
     Cell, HeaderCell, HeaderRow, Row, Table, visible_width,
@@ -187,7 +187,7 @@ fn long_format_row(
     info: &FileInfo,
     name_prefix: &str,
     params: &Params,
-    color_level: LongFormatColorLevel,
+    color_level: ColorLevel,
     columns: &[LongColumn],
 ) -> Row {
     let display_time = if params.fuzzy_time {
@@ -235,7 +235,7 @@ fn long_format_row(
 
 fn long_format_header_row(
     columns: &[LongColumn],
-    color_level: LongFormatColorLevel,
+    color_level: ColorLevel,
 ) -> HeaderRow {
     let mut cells = Vec::with_capacity(columns.len());
     let mut index = 0;
@@ -256,10 +256,7 @@ fn long_format_header_row(
     HeaderRow::new(cells)
 }
 
-fn header_cell(
-    column: LongColumn,
-    color_level: LongFormatColorLevel,
-) -> HeaderCell {
+fn header_cell(column: LongColumn, color_level: ColorLevel) -> HeaderCell {
     let text = header_text(column.header(), color_level);
     if column.header_aligns_right() {
         HeaderCell::right(text)
@@ -268,23 +265,23 @@ fn header_cell(
     }
 }
 
-fn header_text(text: &str, color_level: LongFormatColorLevel) -> String {
+fn header_text(text: &str, color_level: ColorLevel) -> String {
     if text.is_empty() {
         return String::new();
     }
 
     match color_level {
-        LongFormatColorLevel::Truecolor => format!(
+        ColorLevel::TrueColor => format!(
             "\x1b[4;38;2;{};{};{}m{text}\x1b[0m",
             HEADER_SALMON_TRUECOLOR.0,
             HEADER_SALMON_TRUECOLOR.1,
             HEADER_SALMON_TRUECOLOR.2
         ),
-        LongFormatColorLevel::Ansi256 => {
-            format!("\x1b[4;38;5;{HEADER_SALMON_ANSI_256}m{text}\x1b[0m")
+        ColorLevel::Ansi256 => {
+            text.ansi256(HEADER_SALMON_ANSI_256).underline().to_string()
         }
-        LongFormatColorLevel::Named => text.red().underline().to_string(),
-        LongFormatColorLevel::None => text.to_string(),
+        ColorLevel::Ansi16 => text.red().underline().to_string(),
+        ColorLevel::NoColor => text.to_string(),
     }
 }
 
@@ -292,15 +289,15 @@ fn permission_cell(
     info: &FileInfo,
     column: PermissionColumn,
     params: &Params,
-    color_level: LongFormatColorLevel,
+    color_level: ColorLevel,
 ) -> Cell {
     match column {
         PermissionColumn::Symbolic => {
-            Cell::new(long_permission_text(info, params))
+            Cell::new(long_permission_text(info, params, color_level))
         }
         PermissionColumn::OctalWithType => Cell::new(format!(
             "{} {}",
-            long_file_type_text(info, params),
+            long_file_type_text(info, params, color_level),
             long_octal_permission_text(info, params, color_level)
         )),
     }
@@ -309,7 +306,7 @@ fn permission_cell(
 fn octal_permission_cell(
     info: &FileInfo,
     params: &Params,
-    color_level: LongFormatColorLevel,
+    color_level: ColorLevel,
 ) -> Cell {
     Cell::new(long_octal_permission_text(info, params, color_level))
 }
@@ -320,8 +317,12 @@ fn icon_cell(info: &FileInfo) -> Cell {
         .map_or_else(|| Cell::new(""), |icon| Cell::new(icon.to_string()))
 }
 
-fn long_file_type_text(info: &FileInfo, params: &Params) -> String {
-    if !params.permission_colors {
+fn long_file_type_text(
+    info: &FileInfo,
+    params: &Params,
+    color_level: ColorLevel,
+) -> String {
+    if !params.permission_colors || color_level == ColorLevel::NoColor {
         return info.file_type.clone();
     }
 
@@ -335,7 +336,7 @@ fn long_file_type_text(info: &FileInfo, params: &Params) -> String {
 fn long_octal_permission_text(
     info: &FileInfo,
     params: &Params,
-    color_level: LongFormatColorLevel,
+    color_level: ColorLevel,
 ) -> String {
     let text = utils::format::mode_to_octal(info.mode_bits);
     if !params.permission_colors {
@@ -343,21 +344,23 @@ fn long_octal_permission_text(
     }
 
     match color_level {
-        LongFormatColorLevel::Truecolor => text.rgb(238, 204, 92).to_string(),
-        LongFormatColorLevel::Ansi256 => {
-            format!("\x1b[38;5;221m{text}\x1b[0m")
-        }
-        LongFormatColorLevel::Named => text.yellow().dim().to_string(),
-        LongFormatColorLevel::None => text,
+        ColorLevel::TrueColor => text.rgb(238, 204, 92).to_string(),
+        ColorLevel::Ansi256 => text.ansi256(221).to_string(),
+        ColorLevel::Ansi16 => text.yellow().dim().to_string(),
+        ColorLevel::NoColor => text,
     }
 }
 
-fn long_permission_text(info: &FileInfo, params: &Params) -> String {
-    if !params.permission_colors {
+fn long_permission_text(
+    info: &FileInfo,
+    params: &Params,
+    color_level: ColorLevel,
+) -> String {
+    if !params.permission_colors || color_level == ColorLevel::NoColor {
         return format!("{}{}", info.file_type, info.mode);
     }
 
-    let mut output = long_file_type_text(info, params);
+    let mut output = long_file_type_text(info, params, color_level);
     output.reserve(info.mode.len());
     for value in info.mode.chars() {
         write_permission_char(&mut output, value);
@@ -392,7 +395,7 @@ fn size_cell(
     text: &str,
     size: u64,
     params: &Params,
-    color_level: LongFormatColorLevel,
+    color_level: ColorLevel,
     align_right: bool,
 ) -> Cell {
     let style =
@@ -444,11 +447,11 @@ impl SizeCellStyle {
 pub(crate) fn size_style_for_color_level(
     size: u64,
     params: &Params,
-    color_level: LongFormatColorLevel,
+    color_level: ColorLevel,
     align_right: bool,
 ) -> SizeCellStyle {
     match (
-        params.size_colors && color_level.is_enabled(),
+        params.size_colors && color_level != ColorLevel::NoColor,
         size,
         align_right,
     ) {
@@ -466,14 +469,14 @@ fn long_time_text(
     text: &str,
     mtime: SystemTime,
     params: &Params,
-    color_level: LongFormatColorLevel,
+    color_level: ColorLevel,
 ) -> String {
     let age = match SystemTime::now().duration_since(mtime) {
         Ok(age) => age,
         Err(_) => return future_time_text(text, color_level),
     };
 
-    if color_level == LongFormatColorLevel::None {
+    if color_level == ColorLevel::NoColor {
         return text.to_string();
     }
 
@@ -481,24 +484,22 @@ fn long_time_text(
         return text.yellow().to_string();
     }
 
-    if color_level == LongFormatColorLevel::Truecolor {
+    if color_level == ColorLevel::TrueColor {
         return truecolor_time_text(text, age);
     }
-    if color_level == LongFormatColorLevel::Ansi256 {
+    if color_level == ColorLevel::Ansi256 {
         return ansi_256_time_text(text, age);
     }
 
     named_time_text(text, age)
 }
 
-fn future_time_text(text: &str, color_level: LongFormatColorLevel) -> String {
+fn future_time_text(text: &str, color_level: ColorLevel) -> String {
     match color_level {
-        LongFormatColorLevel::Truecolor => text.rgb(220, 80, 70).to_string(),
-        LongFormatColorLevel::Ansi256 => {
-            format!("\x1b[1;38;5;203m{text}\x1b[0m")
-        }
-        LongFormatColorLevel::Named => text.red().bold().to_string(),
-        LongFormatColorLevel::None => text.to_string(),
+        ColorLevel::TrueColor => text.rgb(220, 80, 70).to_string(),
+        ColorLevel::Ansi256 => text.ansi256(203).bold().to_string(),
+        ColorLevel::Ansi16 => text.red().bold().to_string(),
+        ColorLevel::NoColor => text.to_string(),
     }
 }
 
@@ -533,9 +534,9 @@ fn ansi_256_time_text(text: &str, age: Duration) -> String {
     };
 
     if bold {
-        format!("\x1b[1;38;5;{color}m{text}\x1b[0m")
+        text.ansi256(color).bold().to_string()
     } else {
-        format!("\x1b[38;5;{color}m{text}\x1b[0m")
+        text.ansi256(color).to_string()
     }
 }
 

--- a/tests/crate/app.rs
+++ b/tests/crate/app.rs
@@ -974,7 +974,10 @@ fn test_long_format_color_level_uses_none_when_color_is_disabled() {
             ColorLevel::NoColor
         );
     });
+}
 
+#[test]
+fn test_long_format_color_level_detects_terminal_capability() {
     temp_env::with_vars(
         [
             ("COLORTERM", None::<&str>),
@@ -990,10 +993,7 @@ fn test_long_format_color_level_uses_none_when_color_is_disabled() {
             );
         },
     );
-}
 
-#[test]
-fn test_long_format_color_level_detects_terminal_capability() {
     temp_env::with_vars(
         [
             ("COLORTERM", Some("truecolor")),

--- a/tests/crate/app.rs
+++ b/tests/crate/app.rs
@@ -5,10 +5,8 @@ use crate::app::{
 };
 use crate::cli::Flags;
 use crate::common_tests::ColorModeGuard;
-use crate::utils::color::{
-    LongFormatColorLevel, color_mode_for, long_format_color_level,
-};
-use colored_text::ColorMode;
+use crate::utils::color::{color_mode_for, long_format_color_level};
+use colored_text::{ColorLevel, ColorMode};
 use std::fs;
 use tempfile::tempdir;
 
@@ -956,10 +954,7 @@ fn test_long_format_color_level_uses_none_when_color_is_disabled() {
             ..Params::default()
         };
 
-        assert_eq!(
-            long_format_color_level(&params),
-            LongFormatColorLevel::None
-        );
+        assert_eq!(long_format_color_level(&params), ColorLevel::NoColor);
     });
 
     temp_env::with_var("NO_COLOR", None::<&str>, || {
@@ -967,7 +962,7 @@ fn test_long_format_color_level_uses_none_when_color_is_disabled() {
 
         assert_eq!(
             long_format_color_level(&Params::default()),
-            LongFormatColorLevel::None
+            ColorLevel::NoColor
         );
     });
 
@@ -976,9 +971,25 @@ fn test_long_format_color_level_uses_none_when_color_is_disabled() {
 
         assert_eq!(
             long_format_color_level(&Params::default()),
-            LongFormatColorLevel::None
+            ColorLevel::NoColor
         );
     });
+
+    temp_env::with_vars(
+        [
+            ("COLORTERM", None::<&str>),
+            ("NO_COLOR", None::<&str>),
+            ("TERM", Some("dumb")),
+        ],
+        || {
+            let _guard = ColorModeGuard::set(ColorMode::Always);
+
+            assert_eq!(
+                long_format_color_level(&Params::default()),
+                ColorLevel::NoColor
+            );
+        },
+    );
 }
 
 #[test]
@@ -994,7 +1005,7 @@ fn test_long_format_color_level_detects_terminal_capability() {
 
             assert_eq!(
                 long_format_color_level(&Params::default()),
-                LongFormatColorLevel::Truecolor
+                ColorLevel::TrueColor
             );
         },
     );
@@ -1010,7 +1021,7 @@ fn test_long_format_color_level_detects_terminal_capability() {
 
             assert_eq!(
                 long_format_color_level(&Params::default()),
-                LongFormatColorLevel::Ansi256
+                ColorLevel::Ansi256
             );
         },
     );
@@ -1026,7 +1037,23 @@ fn test_long_format_color_level_detects_terminal_capability() {
 
             assert_eq!(
                 long_format_color_level(&Params::default()),
-                LongFormatColorLevel::Named
+                ColorLevel::Ansi16
+            );
+        },
+    );
+
+    temp_env::with_vars(
+        [
+            ("COLORTERM", None::<&str>),
+            ("NO_COLOR", None::<&str>),
+            ("TERM", None::<&str>),
+        ],
+        || {
+            let _guard = ColorModeGuard::set(ColorMode::Always);
+
+            assert_eq!(
+                long_format_color_level(&Params::default()),
+                ColorLevel::Ansi16
             );
         },
     );

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -2,7 +2,6 @@ use crate::common_tests::{
     ColorModeGuard, accentless_params, fixed_time_params, has_ansi,
     plain_permission_params, time_only_params, with_color_output_enabled,
 };
-use crate::utils::color::LongFormatColorLevel;
 use crate::utils::format::mode_to_rwx;
 use crate::utils::icons::Icon;
 use crate::utils::render::{
@@ -12,7 +11,7 @@ use crate::utils::render::{
     terminal_width_or_default,
 };
 use crate::{FileInfo, NameStyle, Params, structs::PermissionDisplay};
-use colored_text::{ColorMode, Colorize};
+use colored_text::{ColorLevel, ColorMode, Colorize};
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 use strip_ansi_escapes::strip_str;
@@ -852,7 +851,7 @@ fn test_build_long_format_table_omits_size_colors_when_disabled() {
 #[test]
 fn test_size_style_for_color_level_colors_size_boundaries() {
     let params = Params::default();
-    let color_level = LongFormatColorLevel::Named;
+    let color_level = ColorLevel::Ansi16;
 
     assert_eq!(
         size_style_for_color_level(
@@ -906,7 +905,7 @@ fn test_size_style_for_color_level_omits_size_colors_when_disabled() {
         size_colors: false,
         ..Params::default()
     };
-    let color_level = LongFormatColorLevel::Named;
+    let color_level = ColorLevel::Ansi16;
 
     assert_eq!(
         size_style_for_color_level(1024 * 1024, &params, color_level, true),
@@ -922,7 +921,7 @@ fn test_size_style_for_color_level_omits_size_colors_when_disabled() {
 fn test_size_style_for_color_level_omits_size_colors_when_global_color_is_disabled()
  {
     let params = Params::default();
-    let color_level = LongFormatColorLevel::None;
+    let color_level = ColorLevel::NoColor;
 
     assert_eq!(
         size_style_for_color_level(1024 * 1024, &params, color_level, true),


### PR DESCRIPTION
Summary

- Update colored_text to 0.5.1.
- Replace lsplus local long-format color capability detector with colored_text ColorLevel terminal capability detection.
- Keep long-format accent rendering aligned across no-color, ANSI 16, ANSI 256, and truecolor terminals.
- Add focused coverage for color-disable precedence and documented timestamp color fallback behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved colour output behaviour in long-format views, especially in terminals with limited colour support or when colour is disabled.
  * Kept timestamp highlighting consistent for future-dated entries.

* **Documentation**
  * Clarified how timestamp colouring behaves across different terminal capabilities.

* **Chores**
  * Updated testing and coverage tooling, refreshed ignore rules, and bumped a dependency for maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->