### PR TITLE
Improve test coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/TODO.md
+++ b/TODO.md
@@ -67,3 +67,6 @@
       `Icon` enum variants.
 - [ ] Continue shifting tests toward behavior-focused checks at module seams
       (`app`, `settings`, `render`) instead of broad smoke-style coverage.
+- [ ] Evaluate `rstest` for table-driven tests/fixtures and `serial_test` for
+      tests that mutate process-global state such as color mode or environment
+      variables.

--- a/TODO.md
+++ b/TODO.md
@@ -70,3 +70,6 @@
 - [ ] Evaluate `rstest` for table-driven tests/fixtures and `serial_test` for
       tests that mutate process-global state such as color mode or environment
       variables.
+- [ ] Consider deriving or implementing `Default` for `cli::Flags` so tests can
+      use struct update syntax instead of hand-rolling every flag field. Keep
+      the parsed default path behavior (`"."`) explicit in tests that need it.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -385,7 +385,7 @@ fn indicator_style_arg() -> Arg {
         .action(ArgAction::Set)
         .require_equals(true)
         .value_name("WORD")
-        .value_parser(["none", "slash", "file-type", "classify"])
+        .value_parser(clap::value_parser!(IndicatorStyle))
         .help("Append indicator with style WORD to entry names")
 }
 
@@ -554,14 +554,8 @@ fn indicator_style_from_matches(
             }
         }
         CompatMode::Gnu => matches
-            .get_one::<String>(ARG_INDICATOR_STYLE)
-            .and_then(|value| match value.as_str() {
-                "none" => Some(IndicatorStyle::None),
-                "slash" => Some(IndicatorStyle::Slash),
-                "file-type" => Some(IndicatorStyle::FileType),
-                "classify" => Some(IndicatorStyle::Classify),
-                _ => None,
-            }),
+            .get_one::<IndicatorStyle>(ARG_INDICATOR_STYLE)
+            .copied(),
     }
 }
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -16,8 +16,11 @@ const NOISY_DIR_PRESET: [&str; 5] =
 ///
 /// These map to GNU-style indicator modes and the native `--slash-dirs`,
 /// `--file-type`, `--classify`, and `--no-indicators` options.
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Default)]
+#[derive(
+    Debug, Clone, Copy, Deserialize, PartialEq, Eq, Default, ValueEnum,
+)]
 #[serde(rename_all = "kebab-case")]
+#[value(rename_all = "kebab-case")]
 pub enum IndicatorStyle {
     /// Do not append an indicator suffix.
     #[default]

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -22,14 +22,20 @@ use crate::utils;
 use crate::utils::format;
 use crate::utils::gitignore::GitignoreCache;
 
-const MODE_FILE_TYPE_MASK: u32 = nix::libc::S_IFMT;
-const MODE_FIFO: u32 = nix::libc::S_IFIFO;
-const MODE_CHAR_DEVICE: u32 = nix::libc::S_IFCHR;
-const MODE_DIRECTORY: u32 = nix::libc::S_IFDIR;
-const MODE_BLOCK_DEVICE: u32 = nix::libc::S_IFBLK;
-const MODE_REGULAR: u32 = nix::libc::S_IFREG;
-const MODE_SYMLINK: u32 = nix::libc::S_IFLNK;
-const MODE_SOCKET: u32 = nix::libc::S_IFSOCK;
+#[allow(
+    clippy::unnecessary_cast,
+    reason = "libc::mode_t is u16 on Apple targets"
+)]
+mod mode_bits {
+    pub(super) const FILE_TYPE_MASK: u32 = nix::libc::S_IFMT as u32;
+    pub(super) const FIFO: u32 = nix::libc::S_IFIFO as u32;
+    pub(super) const CHAR_DEVICE: u32 = nix::libc::S_IFCHR as u32;
+    pub(super) const DIRECTORY: u32 = nix::libc::S_IFDIR as u32;
+    pub(super) const BLOCK_DEVICE: u32 = nix::libc::S_IFBLK as u32;
+    pub(super) const REGULAR: u32 = nix::libc::S_IFREG as u32;
+    pub(super) const SYMLINK: u32 = nix::libc::S_IFLNK as u32;
+    pub(super) const SOCKET: u32 = nix::libc::S_IFSOCK as u32;
+}
 
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
@@ -73,14 +79,14 @@ impl LongFormatFileType {
 }
 
 pub(crate) fn long_format_file_type(mode: u32) -> LongFormatFileType {
-    match mode & MODE_FILE_TYPE_MASK {
-        MODE_DIRECTORY => LongFormatFileType::Directory,
-        MODE_REGULAR => LongFormatFileType::Regular,
-        MODE_SYMLINK => LongFormatFileType::Symlink,
-        MODE_SOCKET => LongFormatFileType::Socket,
-        MODE_FIFO => LongFormatFileType::Fifo,
-        MODE_CHAR_DEVICE => LongFormatFileType::CharDevice,
-        MODE_BLOCK_DEVICE => LongFormatFileType::BlockDevice,
+    match mode & mode_bits::FILE_TYPE_MASK {
+        mode_bits::DIRECTORY => LongFormatFileType::Directory,
+        mode_bits::REGULAR => LongFormatFileType::Regular,
+        mode_bits::SYMLINK => LongFormatFileType::Symlink,
+        mode_bits::SOCKET => LongFormatFileType::Socket,
+        mode_bits::FIFO => LongFormatFileType::Fifo,
+        mode_bits::CHAR_DEVICE => LongFormatFileType::CharDevice,
+        mode_bits::BLOCK_DEVICE => LongFormatFileType::BlockDevice,
         _ => LongFormatFileType::Unknown,
     }
 }

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -10,7 +10,7 @@ use nix::unistd::{Group, User};
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io;
-use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -21,6 +21,15 @@ use crate::structs::NameStyle;
 use crate::utils;
 use crate::utils::format;
 use crate::utils::gitignore::GitignoreCache;
+
+const MODE_FILE_TYPE_MASK: u32 = 0o170000;
+const MODE_FIFO: u32 = 0o010000;
+const MODE_CHAR_DEVICE: u32 = 0o020000;
+const MODE_DIRECTORY: u32 = 0o040000;
+const MODE_BLOCK_DEVICE: u32 = 0o060000;
+const MODE_REGULAR: u32 = 0o100000;
+const MODE_SYMLINK: u32 = 0o120000;
+const MODE_SOCKET: u32 = 0o140000;
 
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
@@ -63,25 +72,16 @@ impl LongFormatFileType {
     }
 }
 
-pub(crate) fn long_format_file_type(
-    metadata: &fs::Metadata,
-) -> LongFormatFileType {
-    if metadata.is_dir() {
-        LongFormatFileType::Directory
-    } else if metadata.is_file() {
-        LongFormatFileType::Regular
-    } else if metadata.is_symlink() {
-        LongFormatFileType::Symlink
-    } else if metadata.file_type().is_socket() {
-        LongFormatFileType::Socket
-    } else if metadata.file_type().is_fifo() {
-        LongFormatFileType::Fifo
-    } else if metadata.file_type().is_char_device() {
-        LongFormatFileType::CharDevice
-    } else if metadata.file_type().is_block_device() {
-        LongFormatFileType::BlockDevice
-    } else {
-        LongFormatFileType::Unknown
+pub(crate) fn long_format_file_type(mode: u32) -> LongFormatFileType {
+    match mode & MODE_FILE_TYPE_MASK {
+        MODE_DIRECTORY => LongFormatFileType::Directory,
+        MODE_REGULAR => LongFormatFileType::Regular,
+        MODE_SYMLINK => LongFormatFileType::Symlink,
+        MODE_SOCKET => LongFormatFileType::Socket,
+        MODE_FIFO => LongFormatFileType::Fifo,
+        MODE_CHAR_DEVICE => LongFormatFileType::CharDevice,
+        MODE_BLOCK_DEVICE => LongFormatFileType::BlockDevice,
+        _ => LongFormatFileType::Unknown,
     }
 }
 
@@ -96,7 +96,8 @@ pub(crate) struct DirectoryEntryData {
 }
 
 fn get_file_details(metadata: &fs::Metadata) -> FileDetails {
-    let file_type = long_format_file_type(metadata).as_char().to_string();
+    let file_type =
+        long_format_file_type(metadata.mode()).as_char().to_string();
 
     let permissions = metadata.permissions();
     let mode = permissions.mode();
@@ -505,7 +506,7 @@ fn file_type_indicator_suffix(
     classify_executables: bool,
 ) -> &'static str {
     file_type_indicator_suffix_for_type(
-        long_format_file_type(metadata),
+        long_format_file_type(metadata.mode()),
         classify_executables,
         is_executable(metadata),
     )
@@ -559,7 +560,7 @@ pub(crate) fn name_style_for_file_type(
 
 fn name_style_by_metadata(metadata: &fs::Metadata) -> NameStyle {
     name_style_for_file_type(
-        long_format_file_type(metadata),
+        long_format_file_type(metadata.mode()),
         is_executable(metadata),
     )
 }

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -22,14 +22,14 @@ use crate::utils;
 use crate::utils::format;
 use crate::utils::gitignore::GitignoreCache;
 
-const MODE_FILE_TYPE_MASK: u32 = 0o170000;
-const MODE_FIFO: u32 = 0o010000;
-const MODE_CHAR_DEVICE: u32 = 0o020000;
-const MODE_DIRECTORY: u32 = 0o040000;
-const MODE_BLOCK_DEVICE: u32 = 0o060000;
-const MODE_REGULAR: u32 = 0o100000;
-const MODE_SYMLINK: u32 = 0o120000;
-const MODE_SOCKET: u32 = 0o140000;
+const MODE_FILE_TYPE_MASK: u32 = nix::libc::S_IFMT;
+const MODE_FIFO: u32 = nix::libc::S_IFIFO;
+const MODE_CHAR_DEVICE: u32 = nix::libc::S_IFCHR;
+const MODE_DIRECTORY: u32 = nix::libc::S_IFDIR;
+const MODE_BLOCK_DEVICE: u32 = nix::libc::S_IFBLK;
+const MODE_REGULAR: u32 = nix::libc::S_IFREG;
+const MODE_SYMLINK: u32 = nix::libc::S_IFLNK;
+const MODE_SOCKET: u32 = nix::libc::S_IFSOCK;
 
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -287,33 +287,16 @@ pub fn get_item_icon(metadata: &fs::Metadata, file_path: &Path) -> Icon {
         .map(|name| name.to_string_lossy())
         .unwrap_or_default();
 
-    let file_type = long_format_file_type(metadata);
-    if let Some(icon) = special_file_type_icon(file_type) {
-        return icon;
-    }
-
-    match file_type {
+    match long_format_file_type(metadata) {
         LongFormatFileType::Directory => get_folder_icon(file_name.as_ref()),
         LongFormatFileType::Symlink => Icon::Symlink,
         LongFormatFileType::Regular | LongFormatFileType::Unknown => {
             get_filename_icon(file_name.as_ref())
                 .unwrap_or_else(|| get_file_icon(file_name.as_ref()))
         }
-        LongFormatFileType::Socket
-        | LongFormatFileType::Fifo
-        | LongFormatFileType::CharDevice
-        | LongFormatFileType::BlockDevice => unreachable!(),
-    }
-}
-
-pub(crate) fn special_file_type_icon(
-    file_type: LongFormatFileType,
-) -> Option<Icon> {
-    match file_type {
-        LongFormatFileType::Socket => Some(Icon::SocketFile),
-        LongFormatFileType::Fifo => Some(Icon::PipeFile),
-        LongFormatFileType::CharDevice => Some(Icon::CharDeviceFile),
-        LongFormatFileType::BlockDevice => Some(Icon::BlockDeviceFile),
-        _ => None,
+        LongFormatFileType::Socket => Icon::SocketFile,
+        LongFormatFileType::Fifo => Icon::PipeFile,
+        LongFormatFileType::CharDevice => Icon::CharDeviceFile,
+        LongFormatFileType::BlockDevice => Icon::BlockDeviceFile,
     }
 }

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 use std::sync::OnceLock;
 use std::{fmt, fs};
@@ -287,7 +288,10 @@ pub fn get_item_icon(metadata: &fs::Metadata, file_path: &Path) -> Icon {
         .map(|name| name.to_string_lossy())
         .unwrap_or_default();
 
-    icon_for_file_type(long_format_file_type(metadata), file_name.as_ref())
+    icon_for_file_type(
+        long_format_file_type(metadata.mode()),
+        file_name.as_ref(),
+    )
 }
 
 pub(crate) fn icon_for_file_type(

--- a/src/utils/icons.rs
+++ b/src/utils/icons.rs
@@ -287,12 +287,19 @@ pub fn get_item_icon(metadata: &fs::Metadata, file_path: &Path) -> Icon {
         .map(|name| name.to_string_lossy())
         .unwrap_or_default();
 
-    match long_format_file_type(metadata) {
-        LongFormatFileType::Directory => get_folder_icon(file_name.as_ref()),
+    icon_for_file_type(long_format_file_type(metadata), file_name.as_ref())
+}
+
+pub(crate) fn icon_for_file_type(
+    file_type: LongFormatFileType,
+    file_name: &str,
+) -> Icon {
+    match file_type {
+        LongFormatFileType::Directory => get_folder_icon(file_name),
         LongFormatFileType::Symlink => Icon::Symlink,
         LongFormatFileType::Regular | LongFormatFileType::Unknown => {
-            get_filename_icon(file_name.as_ref())
-                .unwrap_or_else(|| get_file_icon(file_name.as_ref()))
+            get_filename_icon(file_name)
+                .unwrap_or_else(|| get_file_icon(file_name))
         }
         LongFormatFileType::Socket => Icon::SocketFile,
         LongFormatFileType::Fifo => Icon::PipeFile,

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -192,6 +192,10 @@ impl Table {
 
         let mut column = 0;
         for header_cell in &header.cells {
+            debug_assert!(
+                column < widths.len(),
+                "header column span exceeded computed widths"
+            );
             let span = self.column_span(column, header_cell.span, widths);
             let target_width = self.spanned_width(widths, span);
             let skip_right_fill =
@@ -295,6 +299,10 @@ impl Table {
         if let Some(header) = &self.header {
             let mut column = 0;
             for header_cell in &header.cells {
+                debug_assert!(
+                    column < widths.len(),
+                    "header column span exceeded computed widths"
+                );
                 let span = self.column_span(column, header_cell.span, &widths);
                 let target_width = self.spanned_width(&widths, span);
                 if header_cell.cell.width > target_width {
@@ -346,26 +354,7 @@ fn write_spaces(output: &mut impl Write, count: usize) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{Cell, HeaderCell, HeaderRow, Row, Table};
-    use std::io::{self, Write};
-
-    struct FailAfterFirstWrite {
-        writes: usize,
-    }
-
-    impl Write for FailAfterFirstWrite {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            if self.writes == 0 {
-                self.writes += 1;
-                Ok(buf.len())
-            } else {
-                Err(io::Error::other("write failed"))
-            }
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-    }
+    use std::io::{self, Cursor};
 
     #[test]
     fn table_header_contributes_to_widths_and_uses_column_gaps() {
@@ -479,10 +468,11 @@ mod tests {
     fn table_propagates_header_cell_write_errors() {
         let table = Table::new();
         let header = HeaderRow::new(vec![HeaderCell::new("Name")]);
-        let mut output = FailAfterFirstWrite { writes: 0 };
+        // One byte lets the leading-space write succeed, then the header cell fails.
+        let mut output = Cursor::new([0_u8; 1]);
 
         let err = table.write_header(&mut output, &header, &[4]).unwrap_err();
 
-        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert_eq!(err.kind(), io::ErrorKind::WriteZero);
     }
 }

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -192,10 +192,6 @@ impl Table {
 
         let mut column = 0;
         for header_cell in &header.cells {
-            if column >= widths.len() {
-                break;
-            }
-
             let span = self.column_span(column, header_cell.span, widths);
             let target_width = self.spanned_width(widths, span);
             let skip_right_fill =
@@ -299,10 +295,6 @@ impl Table {
         if let Some(header) = &self.header {
             let mut column = 0;
             for header_cell in &header.cells {
-                if column >= widths.len() {
-                    break;
-                }
-
                 let span = self.column_span(column, header_cell.span, &widths);
                 let target_width = self.spanned_width(&widths, span);
                 if header_cell.cell.width > target_width {

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -354,6 +354,26 @@ fn write_spaces(output: &mut impl Write, count: usize) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{Cell, HeaderCell, HeaderRow, Row, Table};
+    use std::io::{self, Write};
+
+    struct FailAfterFirstWrite {
+        writes: usize,
+    }
+
+    impl Write for FailAfterFirstWrite {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            if self.writes == 0 {
+                self.writes += 1;
+                Ok(buf.len())
+            } else {
+                Err(io::Error::other("write failed"))
+            }
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
 
     #[test]
     fn table_header_contributes_to_widths_and_uses_column_gaps() {
@@ -461,5 +481,19 @@ mod tests {
         table.add_row(Row::new(vec![Cell::new("b")]));
 
         assert_eq!(table.to_string(), " a wide end\n b      \n");
+    }
+
+    #[test]
+    fn table_propagates_header_cell_write_errors() {
+        let table = Table::new();
+        let header = HeaderRow::new(vec![HeaderCell::new("Name")]);
+        let mut output = FailAfterFirstWrite { writes: 0 };
+
+        let err = table.write_header(&mut output, &header, &[4]).unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+
+        let mut output = FailAfterFirstWrite { writes: 0 };
+        output.flush().unwrap();
     }
 }

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -484,8 +484,5 @@ mod tests {
         let err = table.write_header(&mut output, &header, &[4]).unwrap_err();
 
         assert_eq!(err.kind(), io::ErrorKind::Other);
-
-        let mut output = FailAfterFirstWrite { writes: 0 };
-        output.flush().unwrap();
     }
 }

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -431,4 +431,35 @@ mod tests {
 
         assert_eq!(table.to_string(), " Name Size\n");
     }
+
+    #[test]
+    fn table_default_matches_new_table() {
+        assert_eq!(Table::default(), Table::new());
+    }
+
+    #[test]
+    fn table_pads_missing_header_columns_before_final_column() {
+        let mut table = Table::new();
+        table.set_header(HeaderRow::new(vec![HeaderCell::new("Name")]));
+        table.add_row(Row::new(vec![
+            Cell::new("a"),
+            Cell::new("middle"),
+            Cell::new("end"),
+        ]));
+
+        assert_eq!(table.to_string(), " Name        \n a    middle end\n");
+    }
+
+    #[test]
+    fn table_pads_missing_row_cells_before_final_column() {
+        let mut table = Table::new();
+        table.add_row(Row::new(vec![
+            Cell::new("a"),
+            Cell::new("wide"),
+            Cell::new("end"),
+        ]));
+        table.add_row(Row::new(vec![Cell::new("b")]));
+
+        assert_eq!(table.to_string(), " a wide end\n b      \n");
+    }
 }

--- a/tests/crate/app.rs
+++ b/tests/crate/app.rs
@@ -1,7 +1,7 @@
 use crate::Params;
 use crate::app::{
     collect_listing_sections, collect_tree_sections, patterns_from_args,
-    run_with_flags,
+    run_with_flags, run_with_flags_and_config,
 };
 use crate::cli::Flags;
 use crate::common_tests::ColorModeGuard;
@@ -9,6 +9,34 @@ use crate::utils::color::{color_mode_for, long_format_color_level};
 use colored_text::{ColorLevel, ColorMode};
 use std::fs;
 use tempfile::tempdir;
+
+fn default_flags_with_paths(paths: Vec<String>) -> Flags {
+    Flags {
+        show_all: false,
+        almost_all: false,
+        long: false,
+        header: false,
+        human_readable: false,
+        si: false,
+        recursive: false,
+        tree: false,
+        tree_level: None,
+        prune_noisy_dirs: false,
+        prune_dirs: Vec::new(),
+        paths,
+        indicator_style: None,
+        dirs_first: false,
+        no_icons: true,
+        no_color: false,
+        no_permission_colors: false,
+        permissions: None,
+        no_time_gradient: false,
+        no_size_colors: false,
+        gitignore: false,
+        version: false,
+        fuzzy_time: false,
+    }
+}
 
 #[test]
 fn test_patterns_from_args_defaults_to_current_directory() {
@@ -106,6 +134,21 @@ fn test_run_with_flags_lists_matching_entries() {
 
         assert!(run_with_flags(flags).is_ok());
     });
+}
+
+#[test]
+fn test_run_with_flags_and_config_rejects_tree_and_recursive_merge() {
+    let flags = default_flags_with_paths(Vec::new());
+    let config = Params {
+        recursive: true,
+        tree: true,
+        ..Params::default()
+    };
+
+    let err = run_with_flags_and_config(flags, &config).unwrap_err();
+
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(err.to_string().contains("--tree and --recursive"));
 }
 
 #[test]
@@ -395,6 +438,20 @@ fn test_collect_listing_sections_recursive_missing_filter_root_is_empty() {
         ..Params::default()
     };
     let pattern = format!("{}/missing/*.rs", temp_dir.path().display());
+
+    let sections = collect_listing_sections(&[pattern], &params).unwrap();
+
+    assert!(sections.is_empty());
+}
+
+#[test]
+fn test_collect_listing_sections_recursive_invalid_filter_glob_is_empty() {
+    let temp_dir = tempdir().unwrap();
+    let params = Params {
+        recursive: true,
+        ..Params::default()
+    };
+    let pattern = format!("{}/[invalid", temp_dir.path().display());
 
     let sections = collect_listing_sections(&[pattern], &params).unwrap();
 
@@ -765,6 +822,77 @@ fn test_collect_tree_sections_keeps_prefixes_for_nested_entries() {
         nested_entry.name_prefix.contains("└──")
             || nested_entry.name_prefix.contains("├──")
     );
+}
+
+#[test]
+fn test_collect_tree_sections_keeps_vertical_prefix_for_non_last_branch() {
+    let temp_dir = tempdir().unwrap();
+    let first = temp_dir.path().join("a-first");
+    let first_branch = first.join("a-branch");
+    let first_leaf = first.join("z-leaf");
+    let second = temp_dir.path().join("b-second");
+    let second_branch = second.join("only-branch");
+    fs::create_dir_all(&first_branch).unwrap();
+    fs::create_dir_all(&second_branch).unwrap();
+    fs::write(&first_leaf, "leaf").unwrap();
+    fs::write(first_branch.join("nested.txt"), "nested").unwrap();
+    fs::write(second_branch.join("other.txt"), "other").unwrap();
+    let params = Params {
+        tree: true,
+        long_format: true,
+        no_icons: true,
+        tree_level: 3,
+        ..Params::default()
+    };
+
+    let sections = collect_tree_sections(
+        &[temp_dir.path().display().to_string()],
+        &params,
+    )
+    .unwrap();
+
+    let nested_entry = sections[0]
+        .entries
+        .iter()
+        .find(|entry| entry.info.short_name == "nested.txt")
+        .unwrap();
+    let other_entry = sections[0]
+        .entries
+        .iter()
+        .find(|entry| entry.info.short_name == "other.txt")
+        .unwrap();
+
+    assert!(nested_entry.name_prefix.starts_with("│   "));
+    assert!(other_entry.name_prefix.starts_with("    "));
+}
+
+#[test]
+fn test_collect_tree_sections_handles_file_operand_and_missing_operand() {
+    let temp_dir = tempdir().unwrap();
+    let file_path = temp_dir.path().join("shown.txt");
+    let missing_path = temp_dir.path().join("missing.txt");
+    fs::write(&file_path, "shown").unwrap();
+    let params = Params {
+        tree: true,
+        long_format: true,
+        no_icons: true,
+        ..Params::default()
+    };
+
+    let sections = collect_tree_sections(
+        &[
+            file_path.display().to_string(),
+            missing_path.display().to_string(),
+        ],
+        &params,
+    )
+    .unwrap();
+
+    assert_eq!(sections.len(), 1);
+    assert_eq!(sections[0].header, file_path.display().to_string());
+    assert_eq!(sections[0].entries.len(), 1);
+    assert_eq!(sections[0].entries[0].info.short_name, "shown.txt");
+    assert!(sections[0].entries[0].name_prefix.is_empty());
 }
 
 #[test]

--- a/tests/crate/app.rs
+++ b/tests/crate/app.rs
@@ -152,6 +152,61 @@ fn test_run_with_flags_and_config_rejects_tree_and_recursive_merge() {
 }
 
 #[test]
+fn test_run_with_flags_renders_multiple_long_directory_sections() {
+    let temp_dir = tempdir().unwrap();
+    let left = temp_dir.path().join("left");
+    let right = temp_dir.path().join("right");
+    fs::create_dir(&left).unwrap();
+    fs::create_dir(&right).unwrap();
+    fs::write(left.join("alpha.txt"), "alpha").unwrap();
+    fs::write(right.join("beta.txt"), "beta").unwrap();
+
+    let mut flags = default_flags_with_paths(vec![
+        left.display().to_string(),
+        right.display().to_string(),
+    ]);
+    flags.long = true;
+
+    assert!(run_with_flags_and_config(flags, &Params::default()).is_ok());
+}
+
+#[test]
+fn test_run_with_flags_renders_multiple_tree_sections() {
+    let temp_dir = tempdir().unwrap();
+    let left = temp_dir.path().join("left");
+    let right = temp_dir.path().join("right");
+    fs::create_dir(&left).unwrap();
+    fs::create_dir(&right).unwrap();
+    fs::write(left.join("alpha.txt"), "alpha").unwrap();
+    fs::write(right.join("beta.txt"), "beta").unwrap();
+
+    let mut flags = default_flags_with_paths(vec![
+        left.display().to_string(),
+        right.display().to_string(),
+    ]);
+    flags.tree = true;
+    flags.long = true;
+
+    assert!(run_with_flags_and_config(flags, &Params::default()).is_ok());
+}
+
+#[test]
+fn test_run_with_flags_renders_recursive_long_sections() {
+    let temp_dir = tempdir().unwrap();
+    let nested = temp_dir.path().join("nested");
+    fs::create_dir(&nested).unwrap();
+    fs::write(temp_dir.path().join("root.txt"), "root").unwrap();
+    fs::write(nested.join("deep.txt"), "deep").unwrap();
+
+    let mut flags =
+        default_flags_with_paths(vec![temp_dir.path().display().to_string()]);
+    flags.recursive = true;
+    flags.long = true;
+
+    assert!(run_with_flags_and_config(flags, &Params::default()).is_ok());
+}
+
+#[test]
 fn test_collect_listing_sections_groups_multiple_directories() {
     let temp_dir = tempdir().unwrap();
     let left = temp_dir.path().join("left");
@@ -456,6 +511,28 @@ fn test_collect_listing_sections_recursive_invalid_filter_glob_is_empty() {
     let sections = collect_listing_sections(&[pattern], &params).unwrap();
 
     assert!(sections.is_empty());
+}
+
+#[test]
+fn test_collect_listing_sections_recursive_parent_glob_uses_operand_matches() {
+    let temp_dir = tempdir().unwrap();
+    let first = temp_dir.path().join("first");
+    let second = temp_dir.path().join("second");
+    fs::create_dir(&first).unwrap();
+    fs::create_dir(&second).unwrap();
+    fs::write(first.join("alpha.rs"), "alpha").unwrap();
+    fs::write(second.join("beta.txt"), "beta").unwrap();
+    let params = Params {
+        recursive: true,
+        ..Params::default()
+    };
+    let pattern = format!("{}/*/*.rs", temp_dir.path().display());
+
+    let sections = collect_listing_sections(&[pattern], &params).unwrap();
+
+    assert_eq!(sections.len(), 1);
+    assert_eq!(sections[0].header, None);
+    assert_eq!(sections[0].entries[0].short_name, "alpha.rs");
 }
 
 #[test]

--- a/tests/crate/cli.rs
+++ b/tests/crate/cli.rs
@@ -134,6 +134,15 @@ fn test_level_zero_is_rejected() {
 }
 
 #[test]
+fn test_level_rejects_non_numeric_value() {
+    let err = Flags::try_parse_from(["lsplus", "--tree", "--level", "nope"])
+        .unwrap_err();
+
+    assert_eq!(err.kind(), ErrorKind::ValueValidation);
+    assert!(err.to_string().contains("invalid digit"));
+}
+
+#[test]
 fn test_level_help_mentions_recursive_and_tree_output() {
     let err = Flags::try_parse_from(["lsplus", "--help"]).unwrap_err();
     let help = err.to_string();

--- a/tests/crate/common.rs
+++ b/tests/crate/common.rs
@@ -12,7 +12,9 @@ pub(crate) struct ColorModeGuard {
 
 impl ColorModeGuard {
     pub(crate) fn set(mode: ColorMode) -> Self {
-        let lock = COLOR_MODE_LOCK.lock().unwrap();
+        let lock = COLOR_MODE_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let previous = ColorizeConfig::color_mode();
         ColorizeConfig::set_color_mode(mode);
         Self {

--- a/tests/crate/common.rs
+++ b/tests/crate/common.rs
@@ -1,20 +1,30 @@
 use colored_text::{ColorMode, ColorizeConfig};
+use std::sync::{Mutex, MutexGuard};
 
 use crate::Params;
 
-pub(crate) struct ColorModeGuard(ColorMode);
+static COLOR_MODE_LOCK: Mutex<()> = Mutex::new(());
+
+pub(crate) struct ColorModeGuard {
+    previous: ColorMode,
+    _lock: MutexGuard<'static, ()>,
+}
 
 impl ColorModeGuard {
     pub(crate) fn set(mode: ColorMode) -> Self {
+        let lock = COLOR_MODE_LOCK.lock().unwrap();
         let previous = ColorizeConfig::color_mode();
         ColorizeConfig::set_color_mode(mode);
-        Self(previous)
+        Self {
+            previous,
+            _lock: lock,
+        }
     }
 }
 
 impl Drop for ColorModeGuard {
     fn drop(&mut self) {
-        ColorizeConfig::set_color_mode(self.0);
+        ColorizeConfig::set_color_mode(self.previous);
     }
 }
 

--- a/tests/crate/file.rs
+++ b/tests/crate/file.rs
@@ -26,6 +26,8 @@ use tempfile::tempdir;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStringExt;
 #[cfg(unix)]
+use std::os::unix::fs::FileTypeExt;
+#[cfg(unix)]
 use std::os::unix::net::UnixListener;
 
 const BLUE_DOT: &str = "\u{1b}[34m.\u{1b}[0m";
@@ -475,6 +477,26 @@ fn test_create_file_info_colors_special_file_names() {
         assert!(!fifo_info.display_name.contains("\u{1b}[1;32m"));
         assert!(socket_info.display_name.contains("\u{1b}[1;35m"));
         assert!(!socket_info.display_name.contains("\u{1b}[1;32m"));
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn test_create_file_info_colors_char_device_names() {
+    let metadata = fs::symlink_metadata("/dev/null").unwrap();
+    if !metadata.file_type().is_char_device() {
+        return;
+    }
+
+    with_color_output_enabled(|| {
+        let info =
+            create_file_info(Path::new("/dev/null"), &Params::default())
+                .unwrap();
+
+        assert_eq!(info.file_type, "c");
+        assert_eq!(info.name_style, NameStyle::CharDevice);
+        assert_eq!(info.item_icon, Some(Icon::CharDeviceFile));
+        assert!(info.display_name.contains("\u{1b}[1;33m"));
     });
 }
 

--- a/tests/crate/file.rs
+++ b/tests/crate/file.rs
@@ -7,7 +7,7 @@ use crate::utils::file::{
     collect_visible_file_names, create_file_info,
     file_type_indicator_suffix_for_type, format_path_error,
     format_symlink_display_name_with_dim, get_groupname, get_username,
-    name_style_for_file_type, sanitize_for_terminal,
+    long_format_file_type, name_style_for_file_type, sanitize_for_terminal,
 };
 use crate::utils::icons::Icon;
 use crate::{FileInfo, IndicatorStyle, NameStyle, Params};
@@ -513,6 +513,25 @@ fn test_long_format_file_type_chars_for_unix_special_types() {
 
     for (file_type, expected) in cases {
         assert_eq!(file_type.as_char(), expected);
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn test_long_format_file_type_maps_unix_file_type_bits() {
+    let cases = [
+        (0o040755, LongFormatFileType::Directory),
+        (0o100644, LongFormatFileType::Regular),
+        (0o120777, LongFormatFileType::Symlink),
+        (0o140777, LongFormatFileType::Socket),
+        (0o010644, LongFormatFileType::Fifo),
+        (0o020644, LongFormatFileType::CharDevice),
+        (0o060644, LongFormatFileType::BlockDevice),
+        (0, LongFormatFileType::Unknown),
+    ];
+
+    for (mode, expected) in cases {
+        assert_eq!(long_format_file_type(mode), expected);
     }
 }
 

--- a/tests/crate/icons.rs
+++ b/tests/crate/icons.rs
@@ -1,4 +1,7 @@
-use crate::utils::icons::{Icon, get_item_icon, has_extension};
+use crate::utils::file::LongFormatFileType;
+use crate::utils::icons::{
+    Icon, get_item_icon, has_extension, icon_for_file_type,
+};
 use std::fs;
 use std::path::Path;
 use tempfile::tempdir;
@@ -45,6 +48,50 @@ fn test_get_item_icon_uses_known_directory_names() {
 
     assert_eq!(get_item_icon(&git_metadata, &git_dir), Icon::GitFile);
     assert_eq!(get_item_icon(&other_metadata, &other_dir), Icon::Folder);
+}
+
+#[test]
+fn test_icon_for_file_type_maps_special_file_types() {
+    assert_eq!(
+        icon_for_file_type(LongFormatFileType::Socket, "sock"),
+        Icon::SocketFile
+    );
+    assert_eq!(
+        icon_for_file_type(LongFormatFileType::Fifo, "pipe"),
+        Icon::PipeFile
+    );
+    assert_eq!(
+        icon_for_file_type(LongFormatFileType::CharDevice, "tty"),
+        Icon::CharDeviceFile
+    );
+    assert_eq!(
+        icon_for_file_type(LongFormatFileType::BlockDevice, "sda"),
+        Icon::BlockDeviceFile
+    );
+    assert_eq!(
+        icon_for_file_type(LongFormatFileType::Symlink, "link"),
+        Icon::Symlink
+    );
+}
+
+#[test]
+fn test_icon_for_file_type_maps_names_for_file_like_types() {
+    assert_eq!(
+        icon_for_file_type(LongFormatFileType::Directory, ".git"),
+        Icon::GitFile
+    );
+    assert_eq!(
+        icon_for_file_type(LongFormatFileType::Regular, ".gitignore"),
+        Icon::GitFile
+    );
+    assert_eq!(
+        icon_for_file_type(LongFormatFileType::Regular, "main.rs"),
+        Icon::RustFile
+    );
+    assert_eq!(
+        icon_for_file_type(LongFormatFileType::Unknown, "unknown.ext"),
+        Icon::GenericFile
+    );
 }
 
 #[cfg(unix)]

--- a/tests/crate/icons.rs
+++ b/tests/crate/icons.rs
@@ -1,7 +1,4 @@
-use crate::utils::file::LongFormatFileType;
-use crate::utils::icons::{
-    Icon, get_item_icon, has_extension, special_file_type_icon,
-};
+use crate::utils::icons::{Icon, get_item_icon, has_extension};
 use std::fs;
 use std::path::Path;
 use tempfile::tempdir;
@@ -69,34 +66,6 @@ fn test_get_item_icon_handles_symlinks_and_non_utf8_extensions() {
     let metadata = fs::metadata(&full_path).unwrap();
 
     assert_eq!(get_item_icon(&metadata, &full_path), Icon::RustFile);
-}
-
-#[test]
-fn test_special_file_type_icons() {
-    let cases = [
-        (LongFormatFileType::Socket, Some(Icon::SocketFile)),
-        (LongFormatFileType::Fifo, Some(Icon::PipeFile)),
-        (LongFormatFileType::CharDevice, Some(Icon::CharDeviceFile)),
-        (LongFormatFileType::BlockDevice, Some(Icon::BlockDeviceFile)),
-        (LongFormatFileType::Regular, None),
-        (LongFormatFileType::Unknown, None),
-    ];
-
-    for (file_type, expected) in cases {
-        assert_eq!(special_file_type_icon(file_type), expected);
-    }
-}
-
-#[test]
-fn test_special_file_type_icon_short_circuits_item_icon_selection() {
-    for (file_type, expected) in [
-        (LongFormatFileType::Socket, Icon::SocketFile),
-        (LongFormatFileType::Fifo, Icon::PipeFile),
-        (LongFormatFileType::CharDevice, Icon::CharDeviceFile),
-        (LongFormatFileType::BlockDevice, Icon::BlockDeviceFile),
-    ] {
-        assert_eq!(special_file_type_icon(file_type), Some(expected));
-    }
 }
 
 #[test]

--- a/tests/crate/icons.rs
+++ b/tests/crate/icons.rs
@@ -88,6 +88,18 @@ fn test_special_file_type_icons() {
 }
 
 #[test]
+fn test_special_file_type_icon_short_circuits_item_icon_selection() {
+    for (file_type, expected) in [
+        (LongFormatFileType::Socket, Icon::SocketFile),
+        (LongFormatFileType::Fifo, Icon::PipeFile),
+        (LongFormatFileType::CharDevice, Icon::CharDeviceFile),
+        (LongFormatFileType::BlockDevice, Icon::BlockDeviceFile),
+    ] {
+        assert_eq!(special_file_type_icon(file_type), Some(expected));
+    }
+}
+
+#[test]
 fn test_has_extension_rejects_empty_extension_and_dot_entries() {
     assert!(!has_extension("file.txt", ""));
     assert!(!has_extension(".", "txt"));

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -721,6 +721,27 @@ fn test_build_long_format_table_colors_special_file_types() {
 }
 
 #[test]
+fn test_build_long_format_table_colors_symlink_and_fallback_mode_chars() {
+    with_color_output_enabled(|| {
+        let mut symlink = test_file_info("link", None, 0, SystemTime::now());
+        symlink.file_type = String::from("l");
+
+        let mut fallback =
+            test_file_info("fallback", None, 0, SystemTime::now());
+        fallback.file_type = String::from("z");
+        fallback.mode = String::from("q--------");
+
+        let rendered = normalized_table(build_long_format_table(
+            &[symlink, fallback],
+            &fixed_time_params(),
+        ));
+
+        assert!(rendered.contains("\u{1b}[36ml\u{1b}[0m"));
+        assert!(rendered.contains("zq"));
+    });
+}
+
+#[test]
 fn test_build_long_format_table_omits_permission_colors_when_disabled() {
     with_color_output_enabled(|| {
         let mut info =
@@ -915,6 +936,97 @@ fn test_size_style_for_color_level_omits_size_colors_when_disabled() {
         size_style_for_color_level(1024 * 1024, &params, color_level, false),
         SizeCellStyle::Plain
     );
+}
+
+#[test]
+fn test_build_long_format_table_keeps_future_time_plain_without_color() {
+    let info = test_file_info(
+        "future.txt",
+        None,
+        12,
+        SystemTime::now()
+            .checked_add(Duration::from_secs(60 * 60))
+            .unwrap(),
+    );
+    let params = Params {
+        no_color: true,
+        ..Params::default()
+    };
+
+    let rendered = normalized_table(build_long_format_table(&[info], &params));
+
+    assert!(rendered.contains("future.txt"));
+    assert_eq!(strip_str(&rendered), rendered);
+}
+
+#[test]
+fn test_build_long_format_table_colors_time_gradient_segments() {
+    let now = SystemTime::now();
+    let files = [
+        test_file_info(
+            "days.txt",
+            None,
+            12,
+            now.checked_sub(Duration::from_secs(2 * 24 * 60 * 60))
+                .unwrap(),
+        ),
+        test_file_info(
+            "weeks.txt",
+            None,
+            12,
+            now.checked_sub(Duration::from_secs(14 * 24 * 60 * 60))
+                .unwrap(),
+        ),
+        test_file_info(
+            "months.txt",
+            None,
+            12,
+            now.checked_sub(Duration::from_secs(60 * 24 * 60 * 60))
+                .unwrap(),
+        ),
+    ];
+
+    temp_env::with_vars(
+        [("COLORTERM", Some("truecolor")), ("TERM", None::<&str>)],
+        || {
+            with_color_output_enabled(|| {
+                let rendered = normalized_table(build_long_format_table(
+                    &files,
+                    &time_only_params(),
+                ));
+
+                for name in ["days.txt", "weeks.txt", "months.txt"] {
+                    let row = rendered
+                        .lines()
+                        .find(|line| line.contains(name))
+                        .unwrap();
+                    assert!(has_ansi(row));
+                }
+            });
+        },
+    );
+}
+
+#[test]
+fn test_render_short_format_styles_special_name_types() {
+    let styles = [
+        (NameStyle::Socket, "socket", "\u{1b}[1;35msocket"),
+        (NameStyle::Fifo, "pipe", "\u{1b}[33mpipe"),
+        (NameStyle::CharDevice, "char", "\u{1b}[1;33mchar"),
+        (NameStyle::BlockDevice, "block", "\u{1b}[1;33mblock"),
+    ];
+
+    with_color_output_enabled(|| {
+        for (name_style, name, expected) in styles {
+            let mut info = test_file_info(name, None, 0, SystemTime::now());
+            info.name_style = name_style;
+
+            let rendered =
+                normalized_lines(render_short_format_lines(&[info], 80));
+
+            assert!(rendered.contains(expected));
+        }
+    });
 }
 
 #[test]

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -940,6 +940,7 @@ fn test_size_style_for_color_level_omits_size_colors_when_disabled() {
 
 #[test]
 fn test_build_long_format_table_keeps_future_time_plain_without_color() {
+    let _guard = ColorModeGuard::set(ColorMode::Never);
     let info = test_file_info(
         "future.txt",
         None,

--- a/tests/crate/settings.rs
+++ b/tests/crate/settings.rs
@@ -45,6 +45,18 @@ fn test_load_config_returns_default_when_config_is_invalid() {
 }
 
 #[test]
+fn test_load_config_returns_default_when_deserialization_fails() {
+    let temp_dir = tempdir().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("lsplus");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(config_dir.join("config.toml"), "show_all = \"yes\"\n").unwrap();
+
+    temp_env::with_var("HOME", Some(temp_dir.path()), || {
+        assert_eq!(load_config(), Params::default());
+    });
+}
+
+#[test]
 fn test_load_config_reads_boolean_settings_from_home_config() {
     let temp_dir = tempdir().unwrap();
     let config_dir = temp_dir.path().join(".config").join("lsplus");


### PR DESCRIPTION
This PR reduces the remaining test coverage gaps by adding focused coverage and simplifying branches that were unreachable or hard to exercise through real filesystem metadata.

It adds tests for CLI indicator-style parsing, app/listing branches, icon and file-type mappings, table rendering edge cases, and serializes color-mode overrides so plain `cargo test --lib` does not race on `colored_text` global state.

It also refactors small pure mappings where that makes the behavior easier to test directly: special-file icon selection now goes through a file-type helper, file-type classification uses Unix mode bits directly, and unreachable table guards were removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing and validation of `--indicator-style`, ensuring supported values are handled correctly.
  * Refined Unix file-type classification and icon/type rendering for special files (including devices, sockets, and FIFOs).
  * Improved table/list output formatting and padding for complex headers, multi-operand, and recursive views.

* **Tests**
  * Added/extended CLI, rendering, and configuration tests (including better coverage for invalid `--level` values and malformed config fallback behaviour).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->