### PR TITLE
ci: harden GitHub Actions security

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,24 @@
+name: Set up Rust
+description: Install the stable Rust toolchain and optional components
+
+inputs:
+  components:
+    description: Space-separated rustup components to install
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install stable toolchain
+      shell: bash
+      env:
+        COMPONENTS: ${{ inputs.components }}
+      run: |
+        rustup toolchain install stable --profile minimal
+        rustup default stable
+
+        if [[ -n "$COMPONENTS" ]]; then
+          read -ra components <<< "$COMPONENTS"
+          rustup component add --toolchain stable "${components[@]}"
+        fi

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,19 @@
   "enabled": true,
   "enabledManagers": [
     "cargo",
-    "github-actions"
+    "github-actions",
+    "custom.regex"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.github\\/workflows\\/.*\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) versioning=(?<versioning>\\S+)\\s+[A-Z][A-Z0-9_]*_VERSION:\\s+\\\"(?<currentValue>[^\\\"]+)\\\""
+      ]
+    }
   ],
   "ignoreDeps": []
 }

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,11 +8,16 @@ on:
   #     - 'docs/**' # only need this to run if changes to the actual docs
   workflow_dispatch:
 
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
 jobs:
   build:
+    name: Build and deploy docs
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # Required to publish the gh-pages branch.
 
     steps:
       - name: Monitor GitHub token permissions

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Monitor GitHub token permissions
@@ -21,6 +23,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install mdBook
         run: cargo install mdbook
@@ -31,6 +35,6 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GH_PAT }}
+          github_token: ${{ github.token }}
           publish_dir: ./docs/book
           publish_branch: gh-pages

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,10 +16,11 @@ concurrency:
 
 jobs:
   build:
-    name: Build and deploy docs
+    name: Build docs
     runs-on: ubuntu-latest
     permissions:
-      contents: write # Required to publish the gh-pages branch.
+      contents: read # Required to check out the repository.
+      pages: read # Required to read the Pages site configuration.
 
     steps:
       - name: Monitor GitHub token permissions
@@ -36,12 +37,35 @@ jobs:
       - name: Install mdBook
         run: cargo install mdbook
 
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
       - name: Build the book
         run: mdbook build docs
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          github_token: ${{ github.token }}
-          publish_dir: ./docs/book
-          publish_branch: gh-pages
+          path: ./docs/book
+
+  deploy:
+    name: Deploy docs
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write # Required to create the Pages deployment.
+      id-token: write # Required to authenticate the deployment with OIDC.
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Monitor GitHub token permissions
+        if: runner.os != 'Windows'
+        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,6 +8,8 @@ on:
   #     - 'docs/**' # only need this to run if changes to the actual docs
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
   group: github-pages
   cancel-in-progress: false

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,6 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Monitor GitHub token permissions
+        if: runner.os != 'Windows'
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - name: Checkout repository
         uses: actions/checkout@v7
 
@@ -28,4 +34,3 @@ jobs:
           github_token: ${{ secrets.GH_PAT }}
           publish_dir: ./docs/book
           publish_branch: gh-pages
-

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -33,7 +33,7 @@ jobs:
         run: mdbook build docs
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@329bcc8f12caed2cefe5a5b80781499a6f3b361b # v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ github.token }}
           publish_dir: ./docs/book

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,6 +18,9 @@ jobs:
   build:
     name: Build docs
     runs-on: ubuntu-latest
+    env:
+      # renovate: datasource=crate depName=mdbook versioning=cargo
+      MDBOOK_VERSION: "0.5.4"
     permissions:
       contents: read # Required to check out the repository.
       pages: read # Required to read the Pages site configuration.
@@ -35,7 +38,7 @@ jobs:
           persist-credentials: false
 
       - name: Install mdBook
-        run: cargo install mdbook
+        run: cargo install --locked --version "$MDBOOK_VERSION" mdbook
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,12 +17,12 @@ jobs:
     steps:
       - name: Monitor GitHub token permissions
         if: runner.os != 'Windows'
-        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
 
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -33,7 +33,7 @@ jobs:
         run: mdbook build docs
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@329bcc8f12caed2cefe5a5b80781499a6f3b361b # v4
         with:
           github_token: ${{ github.token }}
           publish_dir: ./docs/book

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,12 @@ jobs:
     steps:
       - name: Monitor GitHub token permissions
         if: runner.os != 'Windows'
-        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
 
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install musl tools and OpenSSL
         if: matrix.binary_target == 'x86_64-unknown-linux-musl'
@@ -72,34 +74,51 @@ jobs:
       - name: Set archive name
         id: archive
         shell: bash
+        env:
+          BINARY_TARGET: ${{ matrix.binary_target }}
+          MATRIX_OS: ${{ matrix.os }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            echo "archive_name=${{ env.BINARY_NAME }}-v${{ github.ref_name }}-${{ matrix.binary_target }}.zip" >> $GITHUB_OUTPUT
+          if [[ "$MATRIX_OS" == "windows-latest" ]]; then
+            archive_name="$BINARY_NAME-v$TAG_NAME-$BINARY_TARGET.zip"
           else
-            echo "archive_name=${{ env.BINARY_NAME }}-v${{ github.ref_name }}-${{ matrix.binary_target }}.tar.gz" >> $GITHUB_OUTPUT
+            archive_name="$BINARY_NAME-v$TAG_NAME-$BINARY_TARGET.tar.gz"
           fi
+          echo "archive_name=$archive_name" >> "$GITHUB_OUTPUT"
 
       - name: Prepare binary (Unix)
         if: matrix.os != 'windows-latest'
+        env:
+          ARCHIVE_NAME: ${{ steps.archive.outputs.archive_name }}
+          BINARY_TARGET: ${{ matrix.binary_target }}
         run: |
-          cd target/${{ matrix.binary_target }}/release
-          tar -czf ../../../${{ steps.archive.outputs.archive_name }} ${{ env.BINARY_NAME }}
+          cd "target/$BINARY_TARGET/release"
+          tar -czf "../../../$ARCHIVE_NAME" "$BINARY_NAME"
           cd -
 
       - name: Prepare binary (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
+        env:
+          ARCHIVE_NAME: ${{ steps.archive.outputs.archive_name }}
+          BINARY_TARGET: ${{ matrix.binary_target }}
         run: |
-          cd target/${{ matrix.binary_target }}/release
-          $BINARY_NAME = "${{ env.BINARY_NAME }}.exe"
-          Compress-Archive -Path $BINARY_NAME -DestinationPath ../../../${{ steps.archive.outputs.archive_name }}
+          cd "target/$env:BINARY_TARGET/release"
+          $BinaryPath = "$env:BINARY_NAME.exe"
+          Compress-Archive -Path $BinaryPath -DestinationPath "../../../$env:ARCHIVE_NAME"
           cd -
 
-      - name: Upload Release Asset
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ steps.archive.outputs.archive_name }}
-          asset_name: ${{ steps.archive.outputs.archive_name }}
-          tag: ${{ github.ref }}
-          overwrite: true
+      - name: Upload release asset
+        shell: bash
+        env:
+          ARCHIVE_NAME: ${{ steps.archive.outputs.archive_name }}
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if ! gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            gh release create "$TAG_NAME" \
+              --verify-tag \
+              --title "$TAG_NAME" \
+              --notes "" || gh release view "$TAG_NAME"
+          fi
+          gh release upload "$TAG_NAME" "$ARCHIVE_NAME" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "*"
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build ${{ matrix.binary_target }}
@@ -65,11 +69,16 @@ jobs:
           echo 'export OPENSSL_DIR=$(brew --prefix openssl@3)' >> $GITHUB_ENV
 
       - name: Install target
-        run: rustup target add ${{ matrix.binary_target }}
+        shell: bash
+        env:
+          BINARY_TARGET: ${{ matrix.binary_target }}
+        run: rustup target add "$BINARY_TARGET"
 
       - name: Build binary
-        run: |
-          cargo build --release --target ${{ matrix.binary_target }}
+        shell: bash
+        env:
+          BINARY_TARGET: ${{ matrix.binary_target }}
+        run: cargo build --release --target "$BINARY_TARGET"
 
       - name: Set archive name
         id: archive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,12 @@ jobs:
             binary_target: aarch64-apple-darwin
 
     steps:
+      - name: Monitor GitHub token permissions
+        if: runner.os != 'Windows'
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - name: Checkout repository
         uses: actions/checkout@v7
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,17 +22,18 @@ jobs:
     steps:
       - name: Monitor GitHub token permissions
         if: runner.os != 'Windows'
-        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Check formatting
@@ -50,17 +51,18 @@ jobs:
     steps:
       - name: Monitor GitHub token permissions
         if: runner.os != 'Windows'
-        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Check formatting
@@ -78,19 +80,21 @@ jobs:
     steps:
       - name: Monitor GitHub token permissions
         if: runner.os != 'Windows'
-        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
 
       - name: Install cargo tools
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@2ca9b94c269419b7b0c711c09d0b21c4e1d51145 # v2
         with:
           tool: cargo-make,cargo-audit
 
@@ -103,19 +107,21 @@ jobs:
     steps:
       - name: Monitor GitHub token permissions
         if: runner.os != 'Windows'
-        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
 
       - name: Install cargo tools
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@2ca9b94c269419b7b0c711c09d0b21c4e1d51145 # v2
         with:
           tool: cargo-make,cargo-deny
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,9 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -24,6 +27,8 @@ jobs:
           config: ${{ vars.PERMISSIONS_CONFIG }}
 
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -50,6 +55,8 @@ jobs:
           config: ${{ vars.PERMISSIONS_CONFIG }}
 
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -76,6 +83,8 @@ jobs:
           config: ${{ vars.PERMISSIONS_CONFIG }}
 
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -99,6 +108,8 @@ jobs:
           config: ${{ vars.PERMISSIONS_CONFIG }}
 
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Monitor GitHub token permissions
+        if: runner.os != 'Windows'
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
@@ -37,6 +43,12 @@ jobs:
     runs-on: windows-latest
 
     steps:
+      - name: Monitor GitHub token permissions
+        if: runner.os != 'Windows'
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
@@ -57,6 +69,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Monitor GitHub token permissions
+        if: runner.os != 'Windows'
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
@@ -74,6 +92,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Monitor GitHub token permissions
+        if: runner.os != 'Windows'
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,10 +35,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
-          components: rustfmt, clippy
+          components: rustfmt clippy
 
       - name: Check formatting
         run: cargo fmt --check
@@ -65,10 +64,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
-          components: rustfmt, clippy
+          components: rustfmt clippy
 
       - name: Check formatting
         run: cargo fmt --check
@@ -95,9 +93,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
-        with:
-          toolchain: stable
+        uses: ./.github/actions/setup-rust
 
       - name: Install cargo tools
         uses: taiki-e/install-action@2ca9b94c269419b7b0c711c09d0b21c4e1d51145 # v2
@@ -123,9 +119,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
-        with:
-          toolchain: stable
+        uses: ./.github/actions/setup-rust
 
       - name: Install cargo tools
         uses: taiki-e/install-action@2ca9b94c269419b7b0c711c09d0b21c4e1d51145 # v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,12 +53,6 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - name: Monitor GitHub token permissions
-        if: runner.os != 'Windows'
-        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,8 +9,7 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,10 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 env:
@@ -16,6 +20,7 @@ env:
 
 jobs:
   unix:
+    name: Unix tests
     runs-on: ubuntu-latest
 
     steps:
@@ -45,6 +50,7 @@ jobs:
         run: cargo test --all-targets --all-features
 
   windows:
+    name: Windows tests
     runs-on: windows-latest
 
     steps:
@@ -74,6 +80,7 @@ jobs:
         run: cargo test --all-targets --all-features
 
   audit:
+    name: Dependency audit
     runs-on: ubuntu-latest
 
     steps:
@@ -101,6 +108,7 @@ jobs:
         run: cargo make audit
 
   deny:
+    name: Dependency policy
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -7,13 +7,18 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
   zizmor:
+    name: Run zizmor security analysis
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
+      security-events: write # Required to upload SARIF results.
 
     steps:
       - name: Monitor GitHub token permissions

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,35 @@
+name: GitHub Actions Security
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Monitor GitHub token permissions
+        if: runner.os != 'Windows'
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          version: 1.26.1
+          persona: regular
+          online-audits: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Monitor GitHub token permissions
         if: runner.os != 'Windows'
-        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -26,6 +26,11 @@ args = ["audit"]
 command = "cargo"
 args = ["deny", "check"]
 
+[tasks.zizmor]
+description = "Audit GitHub Actions workflows"
+command = "zizmor"
+args = ["--persona=regular", "."]
+
 [tasks.format]
 description = "Check Rust formatting"
 command = "cargo"

--- a/README.md
+++ b/README.md
@@ -372,9 +372,10 @@ cargo install --locked --version 1.26.1 zizmor
 ```
 
 Audit the GitHub Actions workflows locally with `cargo make zizmor`. The
-command runs offline by default; set a supported GitHub token environment
-variable to enable online audits. Keep the installed zizmor version aligned
-with the version configured in the GitHub Actions security workflow.
+command runs offline by default; set `GH_TOKEN`, `GITHUB_TOKEN`, or
+`ZIZMOR_GITHUB_TOKEN` to enable online audits. Keep the installed zizmor
+version aligned with the version configured in the GitHub Actions security
+workflow.
 
 The coverage aliases, `cargo make test` and `cargo make test-html`, also
 require:

--- a/README.md
+++ b/README.md
@@ -368,7 +368,13 @@ For task aliases and dependency checks, install:
 cargo install cargo-make
 cargo install cargo-audit
 cargo install cargo-deny
+cargo install --locked --version 1.26.1 zizmor
 ```
+
+Audit the GitHub Actions workflows locally with `cargo make zizmor`. The
+command runs offline by default; set a supported GitHub token environment
+variable to enable online audits. Keep the installed zizmor version aligned
+with the version configured in the GitHub Actions security workflow.
 
 The coverage aliases, `cargo make test` and `cargo make test-html`, also
 require:

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,8 @@
 - [ ] add `zizmor` linting to the GitHub actions - both local and as an action
       itself. Use `https://github.com/GitHubSecurityLab/actions-permission` to
       help.
+- [ ] after hardening the release workflow permissions, switch both local and
+      CI `zizmor` runs to the `pedantic` persona
 - [ ] add colorization for different file types, folders and symlinks. Make it
       customizable and theme-able. Make it default but allow an option to
       disable it (or vice-versa). Files that have a known extension should all


### PR DESCRIPTION
Adds runtime permission monitoring and zizmor analysis for the repository's
GitHub Actions workflows.

The workflows now use explicit least-privilege permissions outside the release
job, disable checkout credential persistence, replace the Pages PAT with the
repository token, avoid release-script template injection, and pin retained
actions to full commit SHAs. The release upload uses the runner-provided GitHub
CLI while preserving release creation and asset replacement behavior.

Local development gains a `cargo make zizmor` task, while CI publishes
regular-persona findings to code scanning through SARIF. The temporary
permissions Monitor remains enabled so its job summaries can inform the final
release permission declaration after the next real tagged release; Windows
monitoring is skipped because the action does not support Windows runners.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated security audits for GitHub Actions workflows (CI and local).
  * Added a reusable Rust setup action with optional component installation.
* **Improvements**
  * Strengthened workflow security with tighter permissions and run concurrency controls.
  * Modernised GitHub Pages publishing and updated release packaging/upload approach.
  * Improved CI tooling setup by pinning actions and avoiding persisted credentials.
* **Documentation**
  * Updated development docs and tasks for running workflow audits locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->