### PR TITLE
ci: finalize GitHub Actions hardening

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -26,12 +26,6 @@ jobs:
       pages: read # Required to read the Pages site configuration.
 
     steps:
-      - name: Monitor GitHub token permissions
-        if: runner.os != 'Windows'
-        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -63,12 +57,6 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - name: Monitor GitHub token permissions
-        if: runner.os != 'Windows'
-        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,14 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   build:
     name: Build ${{ matrix.binary_target }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write # Required to create releases and upload assets.
     env:
       BINARY_NAME: lsp
     strategy:
@@ -31,12 +35,6 @@ jobs:
             binary_target: aarch64-apple-darwin
 
     steps:
-      - name: Monitor GitHub token permissions
-        if: runner.os != 'Windows'
-        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,12 +24,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Monitor GitHub token permissions
-        if: runner.os != 'Windows'
-        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -76,12 +70,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Monitor GitHub token permissions
-        if: runner.os != 'Windows'
-        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -102,12 +90,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Monitor GitHub token permissions
-        if: runner.os != 'Windows'
-        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,12 +21,6 @@ jobs:
       security-events: write # Required to upload SARIF results.
 
     steps:
-      - name: Monitor GitHub token permissions
-        if: runner.os != 'Windows'
-        uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -36,5 +30,5 @@ jobs:
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
           version: 1.26.1
-          persona: regular
+          persona: pedantic
           online-audits: true

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -29,7 +29,7 @@ args = ["deny", "check"]
 [tasks.zizmor]
 description = "Audit GitHub Actions workflows"
 command = "zizmor"
-args = ["--persona=regular", "."]
+args = ["--persona=pedantic", "."]
 
 [tasks.format]
 description = "Check Rust formatting"

--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,6 @@
 
 - [ ] migrate docs from `mdbook` to `zensical`
 - [ ] complete code coverage - 83 lines uncovered at last run
-- [ ] add `zizmor` linting to the GitHub actions - both local and as an action
-      itself. Use `https://github.com/GitHubSecurityLab/actions-permission` to
-      help.
-- [ ] after hardening the release workflow permissions, switch both local and
-      CI `zizmor` runs to the `pedantic` persona
 - [ ] add colorization for different file types, folders and symlinks. Make it
       customizable and theme-able. Make it default but allow an option to
       disable it (or vice-versa). Files that have a known extension should all


### PR DESCRIPTION
Locks the release matrix to the explicit contents: write permission required to create releases and upload assets.

Removes the completed permission-monitor instrumentation from all workflows, eliminating its GraphQL, Node runtime, and optional-variable warnings. Local and CI zizmor now use the pedantic persona, and the completed security TODOs are removed.

Pedantic zizmor reports no findings, and the Rust formatting, Clippy, and test gates pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Tightened permissions for automated release workflows, granting only the access required to publish releases.
  - Removed redundant token-permission monitoring steps from automated workflows.

- **Quality Assurance**
  - Updated workflow security analysis to use a stricter inspection mode.
  - Applied the same stricter checks to local workflow-audit tasks, improving detection of potential configuration issues.

- **Maintenance**
  - Removed completed workflow-hardening tasks from the project checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->