### PR TITLE
Add across short-format output

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -2,9 +2,5 @@
 
 Currently known bugs with this project:
 
-- Very little/no error handling
-- if more than one path is provided they should have a gap between them, and a
-header for each.
-- wild-cards for the path are not supported and will cause the program to crash.
 - when sorting, dot files should come before non-dot files with the same sorting
 ie `.changelog` should come before `changelog` etc.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Currently, only a sub-set of the standard `ls` options are supported. These are:
 - `--no-indicators` - Disable file type indicators
 - `-l` / `--long` - Show long format listing
 - `-C` / `--format=vertical` - Force short output into vertical columns
+- `-x` / `--format=across` - Force short output into columns filled across
 - `--header` - Show a title row in long-format output
 - `--permissions <MODE>` - Select long-format permission display:
   `symbolic`, `octal`, `both`, or `none`
@@ -158,8 +159,9 @@ Use the `--help` option to see the full list of options.
 Short output fills variable-width columns from top to bottom when stdout is a
 terminal. Redirected short output prints one entry per line. Use `-C` or
 `--format=vertical` to keep the vertical grid when redirecting output. The
-grid uses spaces between columns so icons, colors, and Unicode names stay
-aligned across terminals.
+`-x` and `--format=across` options instead fill each row from left to right and
+also keep the grid when redirecting output. Grids use spaces between columns
+so icons, colors, and Unicode names stay aligned across terminals.
 
 Use `-R` or `--recursive` to print GNU-style recursive directory sections.
 Quoted wildcard or filename operands filter matching entries while still

--- a/TODO.md
+++ b/TODO.md
@@ -30,11 +30,11 @@
       alias for per-section headers. Suggested modes: `section` for every
       recursive section, `once` for the first long-format table only, and
       `none` to disable config-enabled headers for one invocation.
-- [ ] Add GNU `-x` / `--format=across` short output with variable-width columns
+- [x] Add GNU `-x` / `--format=across` short output with variable-width columns
       filled from left to right, using the shared `uutils-term-grid` renderer.
 - [ ] Evaluate GNU last-option-wins precedence for competing format selectors
-      (`-l`, `-C`, and `--format`) in GNU compatibility mode. If adopted, add
-      order-sensitive tests and define the interaction with `--tree`.
+      (`-l`, `-C`, `-x`, and `--format`) in GNU compatibility mode. If adopted,
+      add order-sensitive tests and define the interaction with `--tree`.
 - [ ] Improve listing performance with focused architecture changes, in this
       order:
       1. Add a short-format entry model so short output does not build full

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -93,13 +93,15 @@ to `true`.
 
 ### short_format
 
-- Permitted value: `"vertical"`
+- Permitted values: `"vertical"` or `"across"`
 - Default value: unset
 
 Short output uses vertical columns when stdout is a terminal and one entry per
 line when stdout is redirected. Set `short_format = "vertical"` to force the
-vertical grid for redirected output. This setting corresponds to `-C` or
-`--format=vertical` and has no effect on long or tree output.
+vertical grid for redirected output, or set `short_format = "across"` to fill
+rows from left to right. The settings correspond to `-C` /
+`--format=vertical` and `-x` / `--format=across`; either explicit format keeps
+the grid when output is redirected and has no effect on long or tree output.
 
 ### header
 
@@ -310,7 +312,7 @@ show_all = true
 indicator_style = "classify"
 dirs_first = true
 long_format = true
-# short_format = "vertical"
+# short_format = "vertical"  # or "across"
 # header = true
 human_readable = true
 # si = true

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -19,6 +19,7 @@ Currently, only a sub-set of the standard `ls` options are supported. These are:
 - `--no-indicators` - Disable file type indicators
 - `-l` / `--long` - Show long format listing
 - `-C` / `--format=vertical` - Force short output into vertical columns
+- `-x` / `--format=across` - Force short output into columns filled across
 - `--header` - Show a title row in long-format output
 - `--permissions <MODE>` - Select long-format permission display:
   `symbolic`, `octal`, `both`, or `none`
@@ -51,8 +52,9 @@ Use the `--help` option to see the full list of options.
 Short output fills variable-width columns from top to bottom when stdout is a
 terminal. Redirected short output prints one entry per line. Use `-C` or
 `--format=vertical` to keep the vertical grid when redirecting output. The
-grid uses spaces between columns so icons, colors, and Unicode names stay
-aligned across terminals.
+`-x` and `--format=across` options instead fill each row from left to right and
+also keep the grid when redirecting output. Grids use spaces between columns
+so icons, colors, and Unicode names stay aligned across terminals.
 
 When listing multiple directory operands, or a mix of files and directories,
 `lsp` prints file operands first and labels each directory section with a

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -291,7 +291,7 @@ fn across_arg() -> Arg {
     Arg::new(ARG_ACROSS)
         .short('x')
         .action(ArgAction::SetTrue)
-        .help("List entries in columns sorted across")
+        .help("List entries in rows from left to right")
 }
 
 fn format_arg() -> Arg {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,6 +18,7 @@ const ARG_SHOW_ALL: &str = "show_all";
 const ARG_ALMOST_ALL: &str = "almost_all";
 const ARG_LONG: &str = "long";
 const ARG_VERTICAL: &str = "vertical";
+const ARG_ACROSS: &str = "across";
 const ARG_FORMAT: &str = "format";
 const ARG_HEADER: &str = "header";
 const ARG_HUMAN_READABLE: &str = "human_readable";
@@ -191,6 +192,7 @@ fn build_command(mode: CompatMode) -> Command {
         .arg(almost_all_arg())
         .arg(long_arg())
         .arg(vertical_arg())
+        .arg(across_arg())
         .arg(format_arg())
         .arg(header_arg())
         .arg(human_readable_arg())
@@ -285,12 +287,19 @@ fn vertical_arg() -> Arg {
         .help("List entries in columns sorted vertically")
 }
 
+fn across_arg() -> Arg {
+    Arg::new(ARG_ACROSS)
+        .short('x')
+        .action(ArgAction::SetTrue)
+        .help("List entries in columns sorted across")
+}
+
 fn format_arg() -> Arg {
     Arg::new(ARG_FORMAT)
         .long("format")
         .value_name("FORMAT")
         .value_parser(clap::value_parser!(ShortFormat))
-        .help("Select short output format: vertical")
+        .help("Select short output format: vertical or across")
 }
 
 fn header_arg() -> Arg {
@@ -556,6 +565,9 @@ fn flags_from_matches(mode: CompatMode, matches: &ArgMatches) -> Flags {
                 matches
                     .get_flag(ARG_VERTICAL)
                     .then_some(ShortFormat::Vertical)
+            })
+            .or_else(|| {
+                matches.get_flag(ARG_ACROSS).then_some(ShortFormat::Across)
             }),
         header: matches.get_flag(ARG_HEADER),
         human_readable: matches.get_flag(ARG_HUMAN_READABLE),

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -74,6 +74,8 @@ pub enum AttributeDisplay {
 pub enum ShortFormat {
     /// Fill entries down variable-width columns.
     Vertical,
+    /// Fill entries across variable-width rows.
+    Across,
 }
 
 /// Controls when file and directory icons are displayed.

--- a/src/utils/render.rs
+++ b/src/utils/render.rs
@@ -565,10 +565,15 @@ pub(crate) fn display_short_format(
     file_info: &[FileInfo],
     params: &Params,
 ) -> io::Result<()> {
-    if short_output_uses_grid(io::stdout().is_terminal(), params.short_format)
+    if let Some(short_format) =
+        resolve_short_format(io::stdout().is_terminal(), params.short_format)
     {
         let terminal_width = terminal_width_or_default(terminal_size());
-        print_short_grid(&render_short_format(file_info, terminal_width))
+        print_short_grid(&render_short_format(
+            file_info,
+            terminal_width,
+            short_format,
+        ))
     } else {
         print_short_lines(&render_short_single_column_lines(file_info))
     }
@@ -579,8 +584,9 @@ pub(crate) fn display_short_format(
 pub(crate) fn render_short_format_lines(
     file_info: &[FileInfo],
     terminal_width: usize,
+    short_format: ShortFormat,
 ) -> Vec<String> {
-    render_short_format(file_info, terminal_width)
+    render_short_format(file_info, terminal_width, short_format)
         .lines()
         .map(str::to_owned)
         .collect()
@@ -589,11 +595,15 @@ pub(crate) fn render_short_format_lines(
 fn render_short_format(
     file_info: &[FileInfo],
     terminal_width: usize,
+    short_format: ShortFormat,
 ) -> String {
     Grid::new(
         short_render_cells(file_info),
         GridOptions {
-            direction: Direction::TopToBottom,
+            direction: match short_format {
+                ShortFormat::Vertical => Direction::TopToBottom,
+                ShortFormat::Across => Direction::LeftToRight,
+            },
             filling: Filling::Spaces(SHORT_COLUMN_GAP),
             width: terminal_width,
         },
@@ -608,12 +618,12 @@ pub(crate) fn render_short_single_column_lines(
     short_render_cells(file_info)
 }
 
-/// Return whether short output should use a grid for this stdout context.
-pub(crate) fn short_output_uses_grid(
+/// Resolve the short grid format for this stdout context.
+pub(crate) fn resolve_short_format(
     is_terminal: bool,
     short_format: Option<ShortFormat>,
-) -> bool {
-    is_terminal || short_format == Some(ShortFormat::Vertical)
+) -> Option<ShortFormat> {
+    short_format.or(is_terminal.then_some(ShortFormat::Vertical))
 }
 
 fn short_render_cells(file_info: &[FileInfo]) -> Vec<String> {

--- a/tests/crate/cli.rs
+++ b/tests/crate/cli.rs
@@ -292,6 +292,10 @@ fn test_parse_from_mode_keeps_short_format_selector_precedence() {
             try_parse_from_mode(mode, ["lsplus", "-x", "-C"]).unwrap();
         assert_eq!(vertical.short_format, Some(ShortFormat::Vertical));
 
+        let fixed_precedence =
+            try_parse_from_mode(mode, ["lsplus", "-C", "-x"]).unwrap();
+        assert_eq!(fixed_precedence.short_format, Some(ShortFormat::Vertical));
+
         let explicit = try_parse_from_mode(
             mode,
             ["lsplus", "-C", "-x", "--format", "across"],

--- a/tests/crate/cli.rs
+++ b/tests/crate/cli.rs
@@ -274,6 +274,34 @@ fn test_parse_from_mode_accepts_vertical_short_format_options() {
 }
 
 #[test]
+fn test_parse_from_mode_accepts_across_short_format_options() {
+    for mode in [CompatMode::Native, CompatMode::Gnu] {
+        let short = try_parse_from_mode(mode, ["lsplus", "-x"]).unwrap();
+        assert_eq!(short.short_format, Some(ShortFormat::Across));
+
+        let long = try_parse_from_mode(mode, ["lsplus", "--format", "across"])
+            .unwrap();
+        assert_eq!(long.short_format, Some(ShortFormat::Across));
+    }
+}
+
+#[test]
+fn test_parse_from_mode_keeps_short_format_selector_precedence() {
+    for mode in [CompatMode::Native, CompatMode::Gnu] {
+        let vertical =
+            try_parse_from_mode(mode, ["lsplus", "-x", "-C"]).unwrap();
+        assert_eq!(vertical.short_format, Some(ShortFormat::Vertical));
+
+        let explicit = try_parse_from_mode(
+            mode,
+            ["lsplus", "-C", "-x", "--format", "across"],
+        )
+        .unwrap();
+        assert_eq!(explicit.short_format, Some(ShortFormat::Across));
+    }
+}
+
+#[test]
 fn test_parse_from_mode_accepts_icon_display_modes() {
     for mode in [CompatMode::Native, CompatMode::Gnu] {
         for (value, expected) in [

--- a/tests/crate/render.rs
+++ b/tests/crate/render.rs
@@ -8,7 +8,7 @@ use crate::utils::render::{
     SizeCellStyle, build_long_format_table,
     build_long_format_table_with_name_prefixes, directory_header_text,
     render_short_format_lines, render_short_single_column_lines,
-    short_output_uses_grid, size_style_for_color_level,
+    resolve_short_format, size_style_for_color_level,
     terminal_width_or_default,
 };
 use crate::{
@@ -510,8 +510,11 @@ fn test_render_short_format_styles_special_name_types() {
             let mut info = test_file_info(name, None, 0, SystemTime::now());
             info.name_style = name_style;
 
-            let rendered =
-                normalized_lines(render_short_format_lines(&[info], 80));
+            let rendered = normalized_lines(render_short_format_lines(
+                &[info],
+                80,
+                ShortFormat::Vertical,
+            ));
 
             assert!(rendered.contains(expected));
         }
@@ -818,7 +821,11 @@ fn test_render_short_format_lines_uses_single_column_for_narrow_width() {
         test_file_info("beta.txt", None, 0, SystemTime::now()),
     ];
 
-    let rendered = normalized_lines(render_short_format_lines(&files, 8));
+    let rendered = normalized_lines(render_short_format_lines(
+        &files,
+        8,
+        ShortFormat::Vertical,
+    ));
     let rows: Vec<_> = rendered
         .lines()
         .filter(|line| !line.trim().is_empty())
@@ -841,7 +848,11 @@ fn test_render_short_format_lines_groups_multiple_files_when_width_allows_it()
         ),
     ];
 
-    let rendered = normalized_lines(render_short_format_lines(&files, 80));
+    let rendered = normalized_lines(render_short_format_lines(
+        &files,
+        80,
+        ShortFormat::Vertical,
+    ));
     let rows: Vec<_> = rendered
         .lines()
         .filter(|line| !line.trim().is_empty())
@@ -866,7 +877,11 @@ fn test_render_short_format_lines_does_not_pad_short_rows_to_widest_name() {
         ),
     ];
 
-    let rendered = normalized_lines(render_short_format_lines(&files, 20));
+    let rendered = normalized_lines(render_short_format_lines(
+        &files,
+        20,
+        ShortFormat::Vertical,
+    ));
     let short_row = rendered
         .lines()
         .find(|line| line.contains("plain.txt"))
@@ -881,11 +896,26 @@ fn test_render_short_format_lines_uses_gnu_vertical_order_and_column_widths() {
         .map(|name| test_file_info(name, None, 0, SystemTime::now()));
 
     assert_eq!(
-        render_short_format_lines(&files, 20),
+        render_short_format_lines(&files, 20, ShortFormat::Vertical),
         vec![
             String::from("a      dddddddd"),
             String::from("bbbbb  eee"),
             String::from("cc     fffffff"),
+        ]
+    );
+}
+
+#[test]
+fn test_render_short_format_lines_uses_gnu_across_order_and_column_widths() {
+    let files = ["a", "bbbbb", "cc", "dddddddd", "eee", "fffffff"]
+        .map(|name| test_file_info(name, None, 0, SystemTime::now()));
+
+    assert_eq!(
+        render_short_format_lines(&files, 20, ShortFormat::Across),
+        vec![
+            String::from("a    bbbbb"),
+            String::from("cc   dddddddd"),
+            String::from("eee  fffffff"),
         ]
     );
 }
@@ -896,7 +926,7 @@ fn test_render_short_format_lines_handles_incomplete_final_column() {
         .map(|name| test_file_info(name, None, 0, SystemTime::now()));
 
     assert_eq!(
-        render_short_format_lines(&files, 8),
+        render_short_format_lines(&files, 8, ShortFormat::Vertical),
         vec![
             String::from("a  dddd"),
             String::from("b  e"),
@@ -910,8 +940,14 @@ fn test_render_short_format_lines_respects_exact_width_boundary() {
     let files = ["a", "bbb"]
         .map(|name| test_file_info(name, None, 0, SystemTime::now()));
 
-    assert_eq!(render_short_format_lines(&files, 6), vec!["a  bbb"]);
-    assert_eq!(render_short_format_lines(&files, 5), vec!["a", "bbb"]);
+    assert_eq!(
+        render_short_format_lines(&files, 6, ShortFormat::Vertical),
+        vec!["a  bbb"]
+    );
+    assert_eq!(
+        render_short_format_lines(&files, 5, ShortFormat::Vertical),
+        vec!["a", "bbb"]
+    );
 }
 
 #[test]
@@ -919,14 +955,18 @@ fn test_render_short_format_lines_keeps_wide_names_untruncated() {
     let files = [test_file_info("界界界.txt", None, 0, SystemTime::now())];
 
     assert_eq!(
-        render_short_format_lines(&files, 0),
+        render_short_format_lines(&files, 0, ShortFormat::Vertical),
         vec![String::from("界界界.txt")]
     );
 }
 
 #[test]
 fn test_render_short_format_lines_handles_empty_input() {
-    let rendered = normalized_lines(render_short_format_lines(&[], 80));
+    let rendered = normalized_lines(render_short_format_lines(
+        &[],
+        80,
+        ShortFormat::Vertical,
+    ));
 
     assert!(rendered.trim().is_empty());
 }
@@ -938,7 +978,8 @@ fn test_render_short_format_lines_style_directory_when_enabled() {
             test_file_info("alpha/", Some(Icon::Folder), 0, SystemTime::now());
         dir.name_style = NameStyle::Directory;
 
-        let lines = render_short_format_lines(&[dir], 80);
+        let lines =
+            render_short_format_lines(&[dir], 80, ShortFormat::Vertical);
 
         assert_eq!(lines.len(), 1);
         assert_eq!(
@@ -955,7 +996,7 @@ fn test_render_short_format_lines_keep_plain_output_when_color_disabled() {
         test_file_info("alpha/", Some(Icon::Folder), 0, SystemTime::now());
     dir.name_style = NameStyle::Directory;
 
-    let lines = render_short_format_lines(&[dir], 80);
+    let lines = render_short_format_lines(&[dir], 80, ShortFormat::Vertical);
 
     assert_eq!(lines, vec![format!("{} alpha/", Icon::Folder)]);
 }
@@ -967,7 +1008,11 @@ fn test_render_short_format_lines_ignores_ansi_when_measuring_columns() {
         directory.name_style = NameStyle::Directory;
         let plain = test_file_info("x", None, 0, SystemTime::now());
 
-        let lines = render_short_format_lines(&[directory, plain], 7);
+        let lines = render_short_format_lines(
+            &[directory, plain],
+            7,
+            ShortFormat::Vertical,
+        );
 
         assert_eq!(lines.len(), 1);
         assert_eq!(strip_str(&lines[0]), "界/  x");
@@ -987,10 +1032,17 @@ fn test_render_short_single_column_lines_has_no_grid_padding() {
 }
 
 #[test]
-fn test_short_output_uses_grid_for_terminal_or_explicit_vertical_format() {
-    assert!(short_output_uses_grid(true, None));
-    assert!(short_output_uses_grid(false, Some(ShortFormat::Vertical)));
-    assert!(!short_output_uses_grid(false, None));
+fn test_resolve_short_format_uses_explicit_format_or_stdout_default() {
+    for format in [ShortFormat::Vertical, ShortFormat::Across] {
+        assert_eq!(resolve_short_format(true, Some(format)), Some(format));
+        assert_eq!(resolve_short_format(false, Some(format)), Some(format));
+    }
+
+    assert_eq!(
+        resolve_short_format(true, None),
+        Some(ShortFormat::Vertical)
+    );
+    assert_eq!(resolve_short_format(false, None), None);
 }
 
 #[test]

--- a/tests/crate/render_unix.rs
+++ b/tests/crate/render_unix.rs
@@ -10,7 +10,7 @@ use crate::utils::icons::Icon;
 use crate::utils::render::{
     build_long_format_table, render_short_format_lines,
 };
-use crate::{NameStyle, Params, structs::PermissionDisplay};
+use crate::{NameStyle, Params, ShortFormat, structs::PermissionDisplay};
 use colored_text::ColorMode;
 use std::time::{Duration, SystemTime};
 use strip_ansi_escapes::strip_str;
@@ -23,7 +23,11 @@ fn test_render_short_format_lines_preserves_synthetic_dot_names() {
         let mut dotdot = test_file_info("..", None, 0, SystemTime::now());
         dotdot.name_style = NameStyle::Directory;
 
-        let rendered = render_short_format_lines(&[dot, dotdot], 80);
+        let rendered = render_short_format_lines(
+            &[dot, dotdot],
+            80,
+            ShortFormat::Vertical,
+        );
 
         assert_eq!(rendered.len(), 1);
         assert_eq!(strip_str(&rendered[0]), ".  ..");

--- a/tests/crate/render_windows.rs
+++ b/tests/crate/render_windows.rs
@@ -177,7 +177,11 @@ fn test_windows_long_table_colors_native_type_markers() {
 #[test]
 fn test_windows_short_format_colors_junction_name() {
     with_color_environment(None, None, ColorMode::Always, || {
-        let rendered = render_short_format_lines(&[windows_file_info()], 80);
+        let rendered = render_short_format_lines(
+            &[windows_file_info()],
+            80,
+            crate::ShortFormat::Vertical,
+        );
 
         assert_eq!(rendered.len(), 1);
         assert_eq!(

--- a/tests/crate/settings.rs
+++ b/tests/crate/settings.rs
@@ -85,14 +85,14 @@ fn test_load_config_returns_default_when_deserialization_fails() {
 }
 
 #[test]
-fn test_load_config_reads_vertical_short_format() {
+fn test_load_config_reads_across_short_format() {
     let temp_dir = tempdir().unwrap();
     let config_path = temp_dir.path().join("config.toml");
-    fs::write(&config_path, "short_format = \"vertical\"\n").unwrap();
+    fs::write(&config_path, "short_format = \"across\"\n").unwrap();
 
     let params = load_config_from_path(Some(config_path));
 
-    assert_eq!(params.short_format, Some(ShortFormat::Vertical));
+    assert_eq!(params.short_format, Some(ShortFormat::Across));
 }
 
 #[test]

--- a/tests/crate/settings.rs
+++ b/tests/crate/settings.rs
@@ -85,6 +85,17 @@ fn test_load_config_returns_default_when_deserialization_fails() {
 }
 
 #[test]
+fn test_load_config_reads_vertical_short_format() {
+    let temp_dir = tempdir().unwrap();
+    let config_path = temp_dir.path().join("config.toml");
+    fs::write(&config_path, "short_format = \"vertical\"\n").unwrap();
+
+    let params = load_config_from_path(Some(config_path));
+
+    assert_eq!(params.short_format, Some(ShortFormat::Vertical));
+}
+
+#[test]
 fn test_load_config_reads_across_short_format() {
     let temp_dir = tempdir().unwrap();
     let config_path = temp_dir.path().join("config.toml");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -920,6 +920,39 @@ fn test_vertical_short_format_options_force_grid_when_redirected() {
 }
 
 #[test]
+fn test_across_short_format_options_force_grid_when_redirected() {
+    let temp_dir = tempdir().unwrap();
+    write_short_grid_fixture(temp_dir.path());
+
+    let mut short = command_with_home(temp_dir.path());
+    short
+        .arg("-x")
+        .arg("--no-icons")
+        .arg("--no-color")
+        .arg(temp_dir.path());
+    let (short_stdout, _stderr) = run_and_capture(&mut short);
+
+    let mut long = command_with_home(temp_dir.path());
+    long.arg("--format")
+        .arg("across")
+        .arg("--no-icons")
+        .arg("--no-color")
+        .arg(temp_dir.path());
+    let (long_stdout, _stderr) = run_and_capture(&mut long);
+
+    assert_eq!(short_stdout, long_stdout);
+    let lines: Vec<_> = short_stdout.lines().collect();
+    assert_eq!(lines.len(), 2);
+    for name in &SHORT_GRID_NAMES[..3] {
+        assert!(lines[0].contains(name));
+    }
+    for name in &SHORT_GRID_NAMES[3..] {
+        assert!(lines[1].contains(name));
+    }
+    assert!(lines.iter().all(|line| *line == line.trim_end()));
+}
+
+#[test]
 fn test_configured_vertical_short_format_forces_grid_when_redirected() {
     let temp_dir = tempdir().unwrap();
     let config_dir = temp_dir.path().join(".config").join("lsplus");

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -137,16 +137,16 @@ fn test_config_conversion_accepts_attribute_display_modes() {
 }
 
 #[test]
-fn test_config_conversion_accepts_vertical_short_format() {
+fn test_config_conversion_accepts_across_short_format() {
     let config = Config::builder()
-        .set_override("short_format", "vertical")
+        .set_override("short_format", "across")
         .unwrap()
         .build()
         .unwrap();
 
     let params: Params = config.into();
 
-    assert_eq!(params.short_format, Some(ShortFormat::Vertical));
+    assert_eq!(params.short_format, Some(ShortFormat::Across));
 }
 
 #[test]
@@ -214,19 +214,23 @@ fn test_params_merge_no_icons_overrides_configured_icon_display() {
 #[test]
 fn test_params_merge_uses_cli_short_format_over_config() {
     let config = Params {
-        short_format: Some(ShortFormat::Vertical),
+        short_format: Some(ShortFormat::Across),
         ..Params::default()
     };
     let default_flags = Flags::parse_from(["lsplus"]);
     assert_eq!(
         Params::merge(&default_flags, &config).short_format,
-        Some(ShortFormat::Vertical)
+        Some(ShortFormat::Across)
     );
 
-    let cli_flags = Flags::parse_from(["lsplus", "-C"]);
+    let vertical_config = Params {
+        short_format: Some(ShortFormat::Vertical),
+        ..Params::default()
+    };
+    let cli_flags = Flags::parse_from(["lsplus", "-x"]);
     assert_eq!(
-        Params::merge(&cli_flags, &Params::default()).short_format,
-        Some(ShortFormat::Vertical)
+        Params::merge(&cli_flags, &vertical_config).short_format,
+        Some(ShortFormat::Across)
     );
 }
 

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -137,6 +137,19 @@ fn test_config_conversion_accepts_attribute_display_modes() {
 }
 
 #[test]
+fn test_config_conversion_accepts_vertical_short_format() {
+    let config = Config::builder()
+        .set_override("short_format", "vertical")
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let params: Params = config.into();
+
+    assert_eq!(params.short_format, Some(ShortFormat::Vertical));
+}
+
+#[test]
 fn test_config_conversion_accepts_across_short_format() {
     let config = Config::builder()
         .set_override("short_format", "across")


### PR DESCRIPTION
Adds GNU-compatible across short-format output through `-x` and `--format=across`, with matching `short_format = "across"` configuration support.

Across mode fills variable-width columns from left to right and remains a grid when output is redirected. Existing automatic vertical terminal output, redirected single-column output, styling, Unicode width handling, and long/tree
behavior remain unchanged.

Updates CLI, configuration, renderer, integration coverage, and user documentation, and removes stale entries from `BUGS.md`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `-x` / `--format=across` for displaying short-format entries from left to right in rows.
  - Added support for configuring the across layout with `short_format = "across"`.
  - Preserved aligned grid output when redirecting across-format results.

- **Documentation**
  - Updated usage, configuration, and option references to describe the across layout and its behaviour.

- **Bug Fixes**
  - Removed obsolete documentation for resolved path-input and error-handling issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->