### PR TITLE
ci: add cross-platform coverage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -109,6 +109,22 @@ jobs:
           --remap-path-prefix
           --output-path coverage-windows.lcov
 
+      - name: Normalize coverage paths
+        shell: pwsh
+        run: |
+          $coveragePath = (Resolve-Path coverage-windows.lcov).Path
+          $coverageLines = [System.IO.File]::ReadAllLines($coveragePath)
+          for ($index = 0; $index -lt $coverageLines.Length; $index++) {
+            if ($coverageLines[$index].StartsWith('SF:')) {
+              $coverageLines[$index] = $coverageLines[$index].Replace('\', '/')
+            }
+          }
+          [System.IO.File]::WriteAllLines(
+            $coveragePath,
+            $coverageLines,
+            [System.Text.UTF8Encoding]::new($false)
+          )
+
       - name: Validate coverage paths
         shell: pwsh
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -164,28 +164,35 @@ jobs:
     needs: [unix, windows]
 
     steps:
-      - name: Download Unix coverage
+      - name: Download platform coverage
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          name: coverage-linux
-          path: coverage/linux
+          pattern: coverage-*
+          path: coverage
+          merge-multiple: true
 
-      - name: Download Windows coverage
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      - name: Run Codacy coverage reporter
+        env:
+          CODACY_CONFIGURED: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        if: ${{ env.CODACY_CONFIGURED != '' }}
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
+        continue-on-error: true
         with:
-          name: coverage-windows
-          path: coverage/windows
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage/coverage-linux.lcov,coverage/coverage-windows.lcov
 
       - name: Install LCOV
         run: |
           sudo apt-get update
           sudo apt-get install --yes lcov
 
+      # Keep a vendor-neutral combined report for independent inspection;
+      # Codacy ingests the two platform reports directly above.
       - name: Merge coverage
         run: |
           lcov \
-            --add-tracefile coverage/linux/coverage-linux.lcov \
-            --add-tracefile coverage/windows/coverage-windows.lcov \
+            --add-tracefile coverage/coverage-linux.lcov \
+            --add-tracefile coverage/coverage-windows.lcov \
             --output-file coverage.lcov
 
       - name: Validate combined coverage

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -164,6 +164,11 @@ jobs:
     needs: [unix, windows]
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
       - name: Download platform coverage
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-      - name: Generate coverage
+      - name: Run tests and collect coverage
         run: >-
           cargo llvm-cov
           --all-targets
@@ -100,7 +100,7 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-      - name: Generate coverage
+      - name: Run tests and collect coverage
         run: >-
           cargo llvm-cov
           --all-targets
@@ -119,9 +119,10 @@ jobs:
               $coverageLines[$index] = $coverageLines[$index].Replace('\', '/')
             }
           }
-          [System.IO.File]::WriteAllLines(
+          $coverageText = [string]::Join("`n", $coverageLines) + "`n"
+          [System.IO.File]::WriteAllText(
             $coveragePath,
-            $coverageLines,
+            $coverageText,
             [System.Text.UTF8Encoding]::new($false)
           )
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -159,16 +159,11 @@ jobs:
           retention-days: 1
 
   coverage:
-    name: Merge coverage
+    name: Aggregate and publish coverage
     runs-on: ubuntu-latest
     needs: [unix, windows]
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
       - name: Download platform coverage
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,14 +33,47 @@ jobs:
         with:
           components: rustfmt clippy
 
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2
+        with:
+          tool: cargo-llvm-cov
+
       - name: Check formatting
         run: cargo fmt --check
 
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-      - name: Run tests
-        run: cargo test --all-targets --all-features
+      - name: Generate coverage
+        run: >-
+          cargo llvm-cov
+          --all-targets
+          --all-features
+          --lcov
+          --remap-path-prefix
+          --output-path coverage-linux.lcov
+
+      - name: Validate coverage paths
+        shell: bash
+        run: |
+          awk '
+            /^SF:/ {
+              found = 1
+              if ($0 !~ /^SF:src\/[A-Za-z0-9_.\/-]+$/) {
+                print "Invalid LCOV source path: " $0 > "/dev/stderr"
+                invalid = 1
+              }
+            }
+            END { exit !found || invalid }
+          ' coverage-linux.lcov
+
+      - name: Upload Unix coverage
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: coverage-linux
+          path: coverage-linux.lcov
+          if-no-files-found: error
+          retention-days: 1
 
   windows:
     name: Windows tests
@@ -56,14 +89,120 @@ jobs:
         with:
           components: rustfmt clippy
 
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2
+        with:
+          tool: cargo-llvm-cov
+
       - name: Check formatting
         run: cargo fmt --check
 
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-      - name: Run tests
-        run: cargo test --all-targets --all-features
+      - name: Generate coverage
+        run: >-
+          cargo llvm-cov
+          --all-targets
+          --all-features
+          --lcov
+          --remap-path-prefix
+          --output-path coverage-windows.lcov
+
+      - name: Validate coverage paths
+        shell: pwsh
+        run: |
+          $sourcePaths = @(
+            Select-String -Path coverage-windows.lcov -Pattern '^SF:' |
+              ForEach-Object { $_.Line }
+          )
+          if ($sourcePaths.Count -eq 0) {
+            throw "The Windows coverage report contains no source paths."
+          }
+
+          $invalidPaths = @(
+            $sourcePaths |
+              Where-Object {
+                $_ -notmatch '^SF:src/[A-Za-z0-9_./-]+$'
+              }
+          )
+          if ($invalidPaths.Count -gt 0) {
+            $invalidPaths | ForEach-Object {
+              Write-Error "Invalid LCOV source path: $_"
+            }
+            throw "The Windows coverage report has invalid source paths."
+          }
+
+      - name: Upload Windows coverage
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: coverage-windows
+          path: coverage-windows.lcov
+          if-no-files-found: error
+          retention-days: 1
+
+  coverage:
+    name: Merge coverage
+    runs-on: ubuntu-latest
+    needs: [unix, windows]
+
+    steps:
+      - name: Download Unix coverage
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: coverage-linux
+          path: coverage/linux
+
+      - name: Download Windows coverage
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: coverage-windows
+          path: coverage/windows
+
+      - name: Install LCOV
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes lcov
+
+      - name: Merge coverage
+        run: |
+          lcov \
+            --add-tracefile coverage/linux/coverage-linux.lcov \
+            --add-tracefile coverage/windows/coverage-windows.lcov \
+            --output-file coverage.lcov
+
+      - name: Validate combined coverage
+        shell: bash
+        run: |
+          awk '
+            /^SF:/ {
+              found = 1
+              if ($0 !~ /^SF:src\/[A-Za-z0-9_.\/-]+$/) {
+                print "Invalid LCOV source path: " $0 > "/dev/stderr"
+                invalid = 1
+              }
+            }
+            END { exit !found || invalid }
+          ' coverage.lcov
+
+          grep -q '^SF:src/platform/unix.rs$' coverage.lcov
+          grep -q '^SF:src/platform/windows.rs$' coverage.lcov
+
+          shared_count="$(grep -c '^SF:src/app.rs$' coverage.lcov)"
+          if [[ "$shared_count" -ne 1 ]]; then
+            echo "Expected src/app.rs once, found $shared_count." >&2
+            exit 1
+          fi
+
+          lcov --summary coverage.lcov
+
+      - name: Upload combined coverage
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: coverage-combined
+          path: coverage.lcov
+          if-no-files-found: error
+          retention-days: 14
 
   audit:
     name: Dependency audit

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,9 @@
 
 - [ ] migrate docs from `mdbook` to `zensical`
 - [ ] complete code coverage - 83 lines uncovered at last run
+- [ ] replace Windows LCOV `SF:` path normalization with the
+      `LLVM_WINDOWS_PREFER_FORWARD_SLASH` environment override once Rust's
+      bundled LLVM supports it at runtime
 - [ ] add colorization for different file types, folders and symlinks. Make it
       customizable and theme-able. Make it default but allow an option to
       disable it (or vice-versa). Files that have a known extension should all

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -1,6 +1,5 @@
 # An `ls` replacement written in `Rust`
 
-
 LSPlus is a functional Unix `ls` clone written in Rust. I built it as a Rust
 learning project, so some code may still show beginner decisions.
 


### PR DESCRIPTION
Generate native LCOV reports in the Unix and Windows test jobs, with normalized source paths and short-lived workflow artifacts.

Merge both reports after the native suites pass and publish a combined artifact containing portable and platform-specific coverage. The existing local nextest coverage workflow remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved automated testing workflows on Unix and Windows platforms.
  - Added code coverage generation in LCOV format.
  - Added validation to ensure coverage reports reference the expected source files.
  - Coverage reports are now uploaded and combined for easier review.

- **Documentation**
  - Added a task to track future improvements to Windows coverage path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->